### PR TITLE
ESLint設定のパーサーオプションを修正

### DIFF
--- a/apps/playgrounds/with-vite/eslint.config.js
+++ b/apps/playgrounds/with-vite/eslint.config.js
@@ -12,6 +12,10 @@ export default tseslint.config(
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     plugins: {
       'react-hooks': reactHooks,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ import tseslint from 'typescript-eslint';
 
 export default defineConfig(
 	{
-		ignores: ['**/dist/**', '**/node_modules/**', '**/.turbo/**', 'apps/playgrounds/**'],
+		ignores: ['**/dist/**', '**/node_modules/**', '**/.turbo/**', 'apps/playgrounds/**', 'eslint.config.mjs'],
 	},
 	eslintConfigPrettier,
 	eslint.configs.recommended,
@@ -22,6 +22,10 @@ export default defineConfig(
 
 			ecmaVersion: 'latest',
 			sourceType: 'module',
+			parserOptions: {
+				projectService: true,
+				tsconfigRootDir: import.meta.dirname,
+			},
 		},
 	},
 	// TypeScriptファイルには型チェック付きのrecommendedを適用


### PR DESCRIPTION
parserOptions 未設定に起因するエラーが、.ts では修整ましたが .js 等では発生するので、それらを修整しました。