### PR TITLE
fix(build): resolve module not found error for react export

### DIFF
--- a/packages/lism-ui/package.json
+++ b/packages/lism-ui/package.json
@@ -26,7 +26,7 @@
 	"main": "./dist/index.js",
 	"exports": {
 		"./react": {
-			"import": "./src/components/react.js",
+			"import": "./dist/components/react.js",
 			"types": "./dist/components/index.d.ts"
 		},
 		"./astro": {

--- a/packages/lism-ui/vite.config.js
+++ b/packages/lism-ui/vite.config.js
@@ -31,6 +31,7 @@ function deleteDuplicateDir(filePath) {
 // ファイルパスは大文字・小文字まで一致しないと Vercel でこけるので注意。
 const entries = {
 	// 'components/index': resolve(__dirname, 'src/components/index.ts'),
+	'components/react': resolve(__dirname, 'src/components/react.ts'),
 
 	// ↓ scripts.jsのビルドと、setEvent.js もこれでビルドされる.
 	'scripts/tabs': resolve(__dirname, 'src/components/Tabs/script.js'),


### PR DESCRIPTION
## 概要
`@lism-css/lism-ui` パッケージにおいて，~`import { ... } from '@lism-css/lism-ui/react';`~ (修正) `import { ... } from '@lism-css/ui';` 等のインポートを実行した際，厳格なESM解決環境 (Next.js / Turbopack 等) で `Module not found` エラーが発生する不具合を修正します．

Fixes https://github.com/lism-css/lism-css/issues/94

## 原因
1. `package.json` の `exports` フィールドにおいて，`./react`
の解決先がビルド済みのファイルではなく，誤ってソースコード (`src/components/react.js`) に指定されていました．
2. また，`vite.config.js` のビルド設定において `react.ts` が独立したエントリーポイントとして指定されておらず，npm
パッケージ内に必要な `dist/components/react.js` が生成されていませんでした．

## 修正内容
1. **`packages/lism-ui/vite.config.js` の修正:** `entries` に `components/react` を追加し，ビルド時に
`dist/components/react.js` が出力されるよう構成を変更しました．
2. **`packages/lism-ui/package.json` の修正:** `exports["./react"]`
フィールドの参照先パスを，コンパイル前のソースディレクトリ (`src`) から，正しいビルド成果物の出力先 (`dist`)
へ修正しました．

## 確認事項
- [x] `pnpm build` を実行し，`dist/components/react.js` が正しく生成されることを確認しました．
- [x] Next.js (App Router) 等の環境において，`@lism-css/lism-ui/react` の**モジュール解決エラー (Module not found) が解消されること**を確認しました．