### PR TITLE
fix(react): resolve hook import errors and preserve "use client" directive in build

### DIFF
--- a/packages/lism-ui/package.json
+++ b/packages/lism-ui/package.json
@@ -57,6 +57,7 @@
 		"@vitejs/plugin-react-swc": "^3.11.0",
 		"glob": "^13.0.6",
 		"rollup": "^4.59.0",
+		"rollup-plugin-preserve-directives": "^0.4.0",
 		"typescript": "~5.8.3",
 		"unplugin-dts": "1.0.0-beta.6",
 		"vite": "^6.4.1"

--- a/packages/lism-ui/src/components/Accordion/react/Accordion.jsx
+++ b/packages/lism-ui/src/components/Accordion/react/Accordion.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+'use client';
+import { createContext, useRef, useId, useEffect, useContext } from 'react';
 import getLismProps from 'lism-css/lib/getLismProps';
 import { Lism, Stack } from 'lism-css/react';
 import { getRootProps, getItemProps, getHeadingProps, getPanelProps, defaultProps } from '../getProps';
@@ -9,7 +10,7 @@ import '../_style.css';
 
 // Context: 純粋なReact環境で AccordionItem → Button / Panel へ accID を共有
 // Astro 環境では Context が使えないため null がフォールバック
-const AccordionContext = React.createContext(null);
+const AccordionContext = createContext(null);
 
 /**
  * 複数の AccordionItem をラップするルート要素
@@ -23,13 +24,13 @@ export function AccordionRoot({ children, ...props }) {
  * 個別のアコーディオンアイテム（<div> ベース、setEvent で開閉イベントを登録）
  */
 export function AccordionItem({ children, ...props }) {
-	const ref = React.useRef(null);
+	const ref = useRef(null);
 
 	// コンポーネント単位でユニークIDを生成
-	const accID = React.useId();
+	const accID = useId();
 
 	// マウント時に開閉イベントを登録（アンマウント時にクリーンアップ）
-	React.useEffect(() => {
+	useEffect(() => {
 		if (!ref.current) return;
 		return setEvent(ref.current);
 	}, []);
@@ -58,7 +59,7 @@ export function Heading({ children, ...props }) {
  * accID: Context から取得できればそれを優先、なければ props / プレースホルダー
  */
 export function Button({ children, accID: _accID = '__LISM_ACC_ID__', ...props }) {
-	const ctx = React.useContext(AccordionContext);
+	const ctx = useContext(AccordionContext);
 	const accID = ctx?.accID || _accID;
 
 	return (
@@ -73,7 +74,7 @@ export function Button({ children, accID: _accID = '__LISM_ACC_ID__', ...props }
  * パネル
  */
 export function Panel({ children, ...props }) {
-	const ctx = React.useContext(AccordionContext);
+	const ctx = useContext(AccordionContext);
 	const { panelProps, contentProps } = getPanelProps({ _contextID: ctx?.accID, ...props });
 
 	return (

--- a/packages/lism-ui/src/components/Modal/react/Modal.jsx
+++ b/packages/lism-ui/src/components/Modal/react/Modal.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+'use client';
+import { useRef, useEffect } from 'react';
 import { Lism } from 'lism-css/react';
 import { setEvent } from '../setModal';
 import { getProps } from '../getProps';
@@ -7,8 +8,8 @@ import '../_style.css';
 
 // duration: [s]
 const Modal = ({ children, ...props }) => {
-	const ref = React.useRef(null);
-	React.useEffect(() => {
+	const ref = useRef(null);
+	useEffect(() => {
 		if (!ref?.current) return;
 		return setEvent(ref?.current);
 	}, [ref]);

--- a/packages/lism-ui/src/components/Tabs/react/Tabs.jsx
+++ b/packages/lism-ui/src/components/Tabs/react/Tabs.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+'use client';
+import { useState, useId, Children, isValidElement } from 'react';
 import { Lism } from 'lism-css/react';
 import Tab from './Tab';
 import TabItem from './TabItem';
@@ -10,19 +11,19 @@ import getTabsProps from '../getProps';
 import '../_style.css';
 
 export default function Tabs({ tabId = '', defaultIndex = 1, listProps = {}, children, ...props }) {
-	const [activeIndex, setActiveIndex] = React.useState(defaultIndex);
-	const theTabId = tabId || React.useId();
+	const [activeIndex, setActiveIndex] = useState(defaultIndex);
+	const theTabId = tabId || useId();
 	const btns = [];
 	const panels = [];
 
 	// Tabs.Item の処理
-	React.Children.forEach(children, (child, index) => {
+	Children.forEach(children, (child, index) => {
 		const tabIndex = index + 1; // 1 はじまり
-		// console.log('child.type', React.isValidElement(child), child.type);
+		// console.log('child.type', isValidElement(child), child.type);
 
-		if (React.isValidElement(child) && child.type === TabItem) {
-			React.Children.forEach(child.props.children, (nestedChild) => {
-				if (React.isValidElement(nestedChild)) {
+		if (isValidElement(child) && child.type === TabItem) {
+			Children.forEach(child.props.children, (nestedChild) => {
+				if (isValidElement(nestedChild)) {
 					if (nestedChild.type === Tab) {
 						const tabProps = nestedChild.props;
 						btns.push(

--- a/packages/lism-ui/vite.config.js
+++ b/packages/lism-ui/vite.config.js
@@ -2,6 +2,7 @@
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import dts from 'unplugin-dts/vite';
+import preserveDirectives from 'rollup-plugin-preserve-directives';
 // import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 // import {useRef} from 'react'; とかした時に、React is not defined 言われないように
@@ -71,7 +72,7 @@ export default defineConfig({
 			// },
 		},
 		rollupOptions: {
-			plugins: [],
+			plugins: [preserveDirectives()],
 			external: ['react', 'react-dom', 'react/jsx-runtime', 'lism-css/config.js'],
 			output: {
 				dir: 'dist',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,6 +427,9 @@ importers:
             rollup:
                 specifier: ^4.59.0
                 version: 4.59.0
+            rollup-plugin-preserve-directives:
+                specifier: ^0.4.0
+                version: 0.4.0(rollup@4.59.0)
             typescript:
                 specifier: ~5.8.3
                 version: 5.8.3
@@ -10117,6 +10120,16 @@ packages:
 
     /rfdc@1.4.1:
         resolution: { integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA== }
+        dev: true
+
+    /rollup-plugin-preserve-directives@0.4.0(rollup@4.59.0):
+        resolution: { integrity: sha512-gx4nBxYm5BysmEQS+e2tAMrtFxrGvk+Pe5ppafRibQi0zlW7VYAbEGk6IKDw9sJGPdFWgVTE0o4BU4cdG0Fylg== }
+        peerDependencies:
+            rollup: 2.x || 3.x || 4.x
+        dependencies:
+            '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
+            magic-string: 0.30.21
+            rollup: 4.59.0
         dev: true
 
     /rollup@4.59.0:


### PR DESCRIPTION
## 概要
Next.js (App Router / Turbopack) 等の厳格な ESM 解決および Server Components (RSC) 環境において，@lism-css/ui/react
のコンポーネント（Accordion, Modal, Tabs 等）を利用した際に発生する useRef is not a function 等のエラーを解決します．

Fixes #96 

## 原因
1. 名前解決の問題: `import React from 'react';` というデフォルトインポートが，ビルド後の Next.js
  実行環境において正しく解決されていなかった．
2. Client Component としての認識: フック（状態・参照管理）を使用するコンポーネントに `"use client"`
  が付与されておらず，Server Component として評価されていた．また，Rollup の仕様により，ソースコードに記述した "use
  client" がビルド成果物（dist）から削除されていた．

## 修正内容
1. ソースコードの修正:
    - `packages/lism-ui/src/components/{Accordion,Modal,Tabs}/react/*.jsx` の先頭に `"use client";` を追加．
    - `import React from 'react';` から，`import { useRef, useEffect, ... } from 'react';`
	  のような名前付きインポートに変更．
2. ビルド設定の修正:
    - `packages/lism-ui/ に rollup-plugin-preserve-directives` をインストール．
    - `packages/lism-ui/vite.config.js の rollupOptions.plugins` にプラグインを追加し，ビルド時に `"use client"` ディレクティブが保持されるように構成．

## 確認事項
- [x] @lism-css/ui の `pnpm build` を実行し，`dist/components/Accordion/react/Accordion.js` などの生成物の先頭に `"use client"; `が存在することを確認した．
- [x] Next.js 16 (Turbopack) の npm run build において，`useRef is not a function`
 のエラーが解消し，正常にビルド・動作することを確認した．