### PR TITLE
feat: ネガティブマージンをspaceトークンで指定可能にする

### DIFF
--- a/packages/lism-css/src/lib/getMaybeCssVar.test.ts
+++ b/packages/lism-css/src/lib/getMaybeCssVar.test.ts
@@ -74,9 +74,9 @@ describe('getMaybeSpaceVar', () => {
 			expect(getMaybeSpaceVar(100)).toBe('var(--s100)');
 		});
 
-		test('負の数値も変換される', () => {
-			expect(getMaybeSpaceVar(-10)).toBe('var(--s-10)');
-			expect(getMaybeSpaceVar(-20)).toBe('var(--s-20)');
+		test('負の数値は calc(-1 * var(--s{abs})) に変換される', () => {
+			expect(getMaybeSpaceVar(-10)).toBe('calc(-1 * var(--s10))');
+			expect(getMaybeSpaceVar(-20)).toBe('calc(-1 * var(--s20))');
 		});
 	});
 
@@ -87,9 +87,9 @@ describe('getMaybeSpaceVar', () => {
 			expect(getMaybeSpaceVar('100')).toBe('var(--s100)');
 		});
 
-		test('負の数値文字列も変換される', () => {
-			expect(getMaybeSpaceVar('-10')).toBe('var(--s-10)');
-			expect(getMaybeSpaceVar('-20')).toBe('var(--s-20)');
+		test('負の数値文字列も calc(-1 * var(--s{abs})) に変換される', () => {
+			expect(getMaybeSpaceVar('-10')).toBe('calc(-1 * var(--s10))');
+			expect(getMaybeSpaceVar('-20')).toBe('calc(-1 * var(--s20))');
 		});
 	});
 
@@ -98,6 +98,11 @@ describe('getMaybeSpaceVar', () => {
 			expect(getMaybeSpaceVar('10 20')).toBe('var(--s10) var(--s20)');
 			expect(getMaybeSpaceVar('10 20 30')).toBe('var(--s10) var(--s20) var(--s30)');
 			expect(getMaybeSpaceVar('0 10 20 30')).toBe('0 var(--s10) var(--s20) var(--s30)');
+		});
+
+		test('スペース区切りに負の値が混在する場合も処理される', () => {
+			expect(getMaybeSpaceVar('-20 30')).toBe('calc(-1 * var(--s20)) var(--s30)');
+			expect(getMaybeSpaceVar('10 -20')).toBe('var(--s10) calc(-1 * var(--s20))');
 		});
 
 		test('スペース区切りに数値以外が混在する場合も処理される', () => {

--- a/packages/lism-css/src/lib/getMaybeCssVar.ts
+++ b/packages/lism-css/src/lib/getMaybeCssVar.ts
@@ -28,6 +28,13 @@ export function getMaybeSpaceVar(value: CssValue): string {
 
 	// spaceが 整数 or 整数を示す文字列 の場合
 	if (typeof value === 'number' || isNumStr(value)) {
+		const numValue = typeof value === 'number' ? value : Number(value);
+
+		// 負の値: calc(-1 * var(--s{absValue})) に変換
+		if (numValue < 0) {
+			return `calc(-1 * var(--s${Math.abs(numValue)}))`;
+		}
+
 		return `var(--s${value})`;
 	}
 


### PR DESCRIPTION
## Summary
- `m="-20"` のように負の値を指定すると `calc(-1 * var(--s20))` としてstyle出力されるように変更
- ネガティブマージン用のユーティリティクラスは追加しない（既存のspaceトークンを `calc()` で反転して利用）
- スペース区切りの一括指定（例: `m="-20 30"`）でも負の値が正しく処理される

### 変更ファイル
- `packages/lism-css/src/lib/getMaybeCssVar.ts` — `getMaybeSpaceVar()` に負の値の処理を追加
- `packages/lism-css/src/lib/getMaybeCssVar.test.ts` — テストケースの更新・追加

### 使用例
```jsx
<Box mt="-20" />
// → class: -mt, style: --mt: calc(-1 * var(--s20))

<Box m="-20 30" />
// → class: -m, style: --m: calc(-1 * var(--s20)) var(--s30)
```

Closes #7

## Test plan
- [x] 既存テスト37件すべて通過
- [x] ドキュメントサイトでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)