### PR TITLE
fix: Icon に viewBox 指定時 size が width/height に反映されない問題を修正

### DIFF
--- a/packages/lism-css/src/components/atomic/Icon/getProps.ts
+++ b/packages/lism-css/src/components/atomic/Icon/getProps.ts
@@ -91,11 +91,13 @@ export default function getProps({ lismClass, as, icon, label, exProps = {}, ...
   // viewBoxがあれば、svg描画として扱う
   if (_rest.viewBox) {
     Component = 'svg';
+    const _size = _rest.size as string | undefined;
+    if (_size) delete _rest.size;
     if (!_rest.width) {
-      exProps.width = '1em';
+      exProps.width = _size || '1em';
     }
     if (!_rest.height) {
-      exProps.height = '1em';
+      exProps.height = _size || '1em';
     }
   } else if (_rest.src) {
     Component = 'img';


### PR DESCRIPTION
## Summary
- `<Icon viewBox="...">` で直接 SVG 描画する際、`size` プロップが `width`/`height` 属性に変換されず無視されていたバグを修正
- `_rest.size` を取り出し、`width`/`height` のデフォルト値として使用するように変更

## 原因
`getProps.ts` の `viewBox` 分岐で `Component = 'svg'`（生の SVG 要素）を設定する際、`size` が考慮されていなかった。`size` は `_rest` に残ったまま `getLismProps()` を経由し、SVG 要素には無効な `size` HTML 属性として出力されていた。

## 変更ファイル
- `packages/lism-css/src/components/atomic/Icon/getProps.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)