### PR TITLE
fix: 英語版 /en/ui/ と /en/templates/ の404を修正

### DIFF
--- a/apps/docs/src/pages/[lang]/templates/[category]/[id].astro
+++ b/apps/docs/src/pages/[lang]/templates/[category]/[id].astro
@@ -1,0 +1,101 @@
+---
+/**
+ * テンプレート詳細ページ（非root言語用）
+ *
+ * URL: /{lang}/templates/{category}/{id}
+ * 例: /en/templates/cta/cta001
+ */
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import { Stack, Flow, Text, Group } from 'lism-css/astro';
+import { PreviewFrame, PreviewTitle } from '@/components/Preview';
+import SrcCode from '@/components/mdx/SrcCode.astro';
+import { templates, type TemplateCategoryId } from '@/config/templates';
+import { getAllTemplatePaths, getTemplate } from '@/lib/templates';
+import { siteConfig } from '@/config/site';
+import { isRootLang, isValidLang, type LangCode } from '@/lib/i18n';
+
+// 静的パス生成
+export function getStaticPaths() {
+  const langCodes = Object.keys(siteConfig.langs) as LangCode[];
+  const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
+  const templatePaths = getAllTemplatePaths();
+
+  const paths = [];
+  for (const lang of nonRootLangs) {
+    for (const { category, id } of templatePaths) {
+      paths.push({
+        params: { lang, category, id },
+        props: { lang },
+      });
+    }
+  }
+  return paths;
+}
+
+interface Props {
+  lang: LangCode;
+}
+
+const { lang } = Astro.props;
+const { category, id } = Astro.params;
+
+if (!isValidLang(lang)) {
+  return Astro.redirect('/404');
+}
+
+const template = getTemplate(category!, id!);
+
+// テンプレートが見つからない場合は404
+if (!template) {
+  return Astro.redirect('/404');
+}
+
+// カテゴリ情報
+const categoryData = templates[category as TemplateCategoryId];
+
+// プレビューURLとコード埋め込み用のパス
+const previewUrl = `/preview/templates/${category}/${id}/`;
+const templatePath = `src/pages/preview/templates/${category}/${id}`;
+---
+
+<BaseLayout title={`${template.title} - Templates`} description={template.description} excludeFromSearch>
+  <Flow g="30" class="templatePage">
+    <Stack as="header" g="10">
+      <Text fz="xs" c="text-2" tt="uppercase" lts="l">
+        {categoryData.label}
+      </Text>
+      <h1 class="-fz:3xl -fw:bold">{template.title}</h1>
+      <Text c="text-2">{template.description}</Text>
+    </Stack>
+    {
+      template.draft && (
+        <Group class="draftBadge" fz="xs" w="fit" bgc="red" c="base" bdrs="10" px="10">
+          DRAFT
+        </Group>
+      )
+    }
+    {/* プレビュー */}
+    <Group layout="flow" my-s="50">
+      <!-- <PreviewTitle>Preview</PreviewTitle> -->
+      <PreviewFrame url={previewUrl} hasSizeSwitch />
+    </Group>
+
+    {/* ソースコード */}
+    <Stack g="15">
+      <PreviewTitle>Code</PreviewTitle>
+      <SrcCode dir="docs" path={templatePath + '/index.astro'} title="index.astro" />
+      <SrcCode dir="docs" path={templatePath + '/_style.css'} title="style.css" />
+    </Stack>
+  </Flow>
+</BaseLayout>
+
+<style>
+  .templatePage {
+    /* 詳細ページ固有のスタイル */
+  }
+
+  .code-embed {
+    border-radius: var(--bdrs--15);
+    overflow: hidden;
+  }
+</style>

--- a/apps/docs/src/pages/[lang]/templates/index.astro
+++ b/apps/docs/src/pages/[lang]/templates/index.astro
@@ -1,0 +1,101 @@
+---
+/**
+ * テンプレート一覧ページ（非root言語用）
+ * カテゴリ別にテンプレートを一覧表示
+ */
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import { Stack, FluidCols, Frame, LinkBox, Box, Lism, Text, Inline, Heading } from 'lism-css/astro';
+import { templates, categoryIds, type TemplateCategoryId } from '@/config/templates';
+import { filterDraftItems } from '@/lib/templates';
+import { siteConfig } from '@/config/site';
+import { isRootLang, isValidLang, type LangCode } from '@/lib/i18n';
+
+export async function getStaticPaths() {
+  const langCodes = Object.keys(siteConfig.langs) as LangCode[];
+  const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
+  return nonRootLangs.map((lang) => ({
+    params: { lang },
+    props: { lang },
+  }));
+}
+
+interface Props {
+  lang: LangCode;
+}
+
+const { lang } = Astro.props;
+
+if (!isValidLang(lang)) {
+  return Astro.redirect('/404');
+}
+---
+
+<BaseLayout title="Templates" description="Web site templates built with Lism CSS" excludeFromSearch>
+  <Stack g="40" class="templates">
+    <Stack as="header" g="20">
+      <h1>Web Templates</h1>
+      <Text c="text-2">A collection of copy-and-paste ready web site templates built with Lism CSS.</Text>
+    </Stack>
+
+    <Stack g="40">
+      {
+        categoryIds.map((categoryId: TemplateCategoryId) => {
+          const category = templates[categoryId];
+          const items = filterDraftItems(category.items);
+          return (
+            <Box as="section">
+              <Heading level="2" layout="flex" ai="center" g="10" fz="xl" bd-b py="10" px="5">
+                <span>{category.label}</span>
+                <Inline fz="xs" c="text-2" fw="normal">
+                  ({items.length})
+                </Inline>
+              </Heading>
+
+              <FluidCols autoFill cols="24rem" g="20" my-s="20" class="templateList">
+                {items.map((item) => (
+                  <LinkBox class="templateList_link" layout="stack" href={`/${lang}/templates/${categoryId}/${item.id}`} p="10" g="20" setHov>
+                    <Frame ar="3/2" bd bdrs="20" ov="hidden">
+                      <img
+                        src={`/screenshots/templates/${categoryId}/${item.id}.png`}
+                        alt={item.title}
+                        loading="lazy"
+                        decoding="async"
+                        class="templateList_thumb"
+                      />
+                    </Frame>
+                    <Lism layout="cluster" g="10" class="u--trim -ff:mono -fz:s">
+                      {item.title}
+                    </Lism>
+                  </LinkBox>
+                ))}
+              </FluidCols>
+            </Box>
+          );
+        })
+      }
+    </Stack>
+  </Stack>
+</BaseLayout>
+
+<style>
+  /* サムネイルカードのスタイル */
+  .templateList_link > .l--frame {
+    --bdw: 2px;
+    transition: box-shadow 0.2s;
+    box-shadow: var(--_isHov, var(--bxsh--30)) var(--_notHov, var(--bxsh--10));
+  }
+
+  /* サムネイル画像のスタイル */
+  .templateList_thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: top;
+    transition: transform 0.3s ease;
+  }
+
+  /* ホバー時のズーム効果 */
+  .templateList_link:hover .templateList_thumb {
+    transform: scale(1.02);
+  }
+</style>

--- a/apps/docs/src/pages/[lang]/ui/[...slug].astro
+++ b/apps/docs/src/pages/[lang]/ui/[...slug].astro
@@ -1,0 +1,100 @@
+---
+/**
+ * UIコンポーネント詳細ページ（非root言語用）
+ * - 翻訳がない場合はroot言語にフォールバック（未翻訳の注意書き付き）
+ * - URL例: /en/ui/Accordion, /en/ui/examples/Card
+ */
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import { generateToc } from '@/lib/generateToc';
+import { Icon, Lism, Flow, Heading } from 'lism-css/astro';
+import PostNavigation from '@parts/PostNavigation.astro';
+import TranslationNotice from '@/components/TranslationNotice.astro';
+import { siteConfig } from '@/config/site';
+import { isRootLang, isValidLang, getRootLang, type LangCode } from '@/lib/i18n';
+import { getPostsByLang, getPostWithFallback } from '@/lib/content';
+import { render } from 'astro:content';
+
+// MDXでグローバルに使用するコンポーネント
+import * as mdxComponents from '@/components/mdx';
+
+export async function getStaticPaths() {
+  const langCodes = Object.keys(siteConfig.langs) as LangCode[];
+  const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
+  const rootLang = getRootLang();
+  const allPosts = await getPostsByLang(rootLang);
+
+  // ui/ で始まるIDのみフィルタリング
+  const uiPosts = allPosts.filter((post) => post.id.startsWith('ui/'));
+
+  const paths = [];
+  for (const lang of nonRootLangs) {
+    for (const post of uiPosts) {
+      paths.push({
+        // slug から ui/ プレフィックスを除去（URLに ui/ は含まれないため）
+        params: { lang, slug: post.id.replace(/^ui\//, '') },
+        props: { lang, slug: post.id },
+      });
+    }
+  }
+  return paths;
+}
+
+interface Props {
+  lang: LangCode;
+  slug: string;
+}
+
+const { lang, slug } = Astro.props;
+
+if (!isValidLang(lang)) {
+  return Astro.redirect('/404');
+}
+
+// 記事を取得（なければroot言語にフォールバック）
+const { entry, isFallback } = await getPostWithFallback(lang, slug);
+
+if (!entry) {
+  return Astro.redirect('/404');
+}
+
+const { Content, headings } = await render(entry);
+const toc = generateToc(headings);
+
+// OG画像のパス
+const ogImage = `/ui/og/${slug.replace(/^ui\//, '')}.png`;
+---
+
+<BaseLayout
+  title={entry.data.title}
+  description={entry.data.description}
+  ogImage={ogImage}
+  toc={toc}
+  lang={lang}
+  schemaType="TechArticle"
+  date={entry.data.date}
+>
+  {/* フォールバック（未翻訳）ページは検索対象から除外 */}
+  <Lism as="article" class="z--article set--cqUnit" {...!isFallback && { 'data-pagefind-body': true }}>
+    {/* 未翻訳の注意書き */}
+    {isFallback && <TranslationNotice lang={lang} />}
+
+    {/* 記事タイトル */}
+    <Heading level="1" class="articleTitle">{entry.data.title}</Heading>
+
+    <Lism class="u--cbox" keycolor="yellow" p="20" my="40" bdrs="10" bd>
+      <Lism layout="flex" ai="center" g="10" fw="bold">
+        <Icon icon="warning" fz="l" c="keycolor" />
+        This page is currently under construction
+      </Lism>
+      <Lism fz="s" my-s="5">Lism UI (@lism-css/ui) is still in preparation.</Lism>
+    </Lism>
+
+    {/* 記事本文 */}
+    <Flow class="articleContent" my-s="40">
+      <Content components={mdxComponents} />
+    </Flow>
+
+    {/* 前後記事ナビゲーション */}
+    <PostNavigation currentSlug={slug} lang={lang} />
+  </Lism>
+</BaseLayout>

--- a/apps/docs/src/pages/[lang]/ui/index.astro
+++ b/apps/docs/src/pages/[lang]/ui/index.astro
@@ -1,0 +1,120 @@
+---
+/**
+ * UIコンポーネント一覧ページ（非root言語用）
+ * content/{lang}/ui/ 配下のMDXを一覧表示
+ */
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import { Stack, FluidCols, LinkBox, Frame, Lism, Media } from 'lism-css/astro';
+import { getPostsByLang } from '@/lib/content';
+import { siteConfig } from '@/config/site';
+import { isRootLang, isValidLang, type LangCode } from '@/lib/i18n';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export async function getStaticPaths() {
+  const langCodes = Object.keys(siteConfig.langs) as LangCode[];
+  const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
+  return nonRootLangs.map((lang) => ({
+    params: { lang },
+    props: { lang },
+  }));
+}
+
+interface Props {
+  lang: LangCode;
+}
+
+const { lang } = Astro.props;
+
+if (!isValidLang(lang)) {
+  return Astro.redirect('/404');
+}
+
+// 現在の言語の記事を取得
+const allPosts = await getPostsByLang(lang);
+
+// ui/ 配下の記事のみフィルタリング（examples配下は除く）
+const uiPosts = allPosts
+  .filter((post) => post.id.startsWith('ui/') && !post.id.startsWith('ui/examples/'))
+  .sort((a, b) => {
+    const orderA = a.data.order ?? 999;
+    const orderB = b.data.order ?? 999;
+    return orderA - orderB;
+  });
+
+// ui/examples/ 配下の記事を別途フィルタリング
+const examplePosts = allPosts
+  .filter((post) => post.id.startsWith('ui/examples/'))
+  .sort((a, b) => {
+    const orderA = a.data.order ?? 999;
+    const orderB = b.data.order ?? 999;
+    return orderA - orderB;
+  });
+
+// サムネイル画像が存在するかチェック
+function getThumbPath(title: string): string {
+  const thumbPath = `/thumb/components/${title}.png`;
+  const fullPath = path.join(process.cwd(), 'public', thumbPath);
+  if (fs.existsSync(fullPath)) {
+    return thumbPath;
+  }
+  return '/thumb/components/Empty.png';
+}
+---
+
+<BaseLayout title="Lism UI" description="UI components based on Lism CSS — @lism-css/ui" excludeFromSearch>
+  <Lism class="uiComponents">
+    <Stack as="header" g="20">
+      <h1>Lism UI</h1>
+      <p class="-c:text-2">
+        A collection of UI components from <code>@lism-css/ui</code>, built on Lism CSS, with implementation examples and samples.
+      </p>
+    </Stack>
+    <Lism as="section" my-s="50">
+      <Stack as="header" g="20">
+        <h2>Components</h2>
+        <p class="-c:text-2">Components available from <code>@lism-css/ui</code>.</p>
+      </Stack>
+      <FluidCols cols="240px" g="30" my-s="40">
+        {
+          uiPosts.map((post) => {
+            const postUrl = `/${lang}/ui/${post.id.replace('ui/', '')}/`;
+            const thumbPath = getThumbPath(post.data.title);
+            return (
+              <LinkBox layout="stack" href={postUrl} p="5" g="5" bdrs="20" hov="neutral" class={post.data.draft ? '_draft' : ''}>
+                <Frame ar="3/2" bd bdrs="20" bgc="base">
+                  <Media src={thumbPath} alt={post.data.title} width="360" height="240" loading="lazy" />
+                </Frame>
+                <Lism class="u--trim -ff:mono -fz:s -p:10">{post.data.title}</Lism>
+              </LinkBox>
+            );
+          })
+        }
+      </FluidCols>
+    </Lism>
+    {
+      examplePosts.length > 0 && (
+        <Lism my-s="50">
+          <Stack as="header" g="20">
+            <h2>Examples</h2>
+            <p class="-c:text-2">Additional implementation examples and samples using Lism CSS and Lism UI.</p>
+          </Stack>
+          <FluidCols cols="240px" g="30" my-s="40">
+            {examplePosts.map((post) => {
+              const postUrl = `/${lang}/ui/${post.id.replace('ui/', '')}/`;
+              const thumbPath = getThumbPath(post.data.title);
+              return (
+                <LinkBox layout="stack" href={postUrl} p="5" g="5" bdrs="20" hov="neutral" class={post.data.draft ? '_draft' : ''}>
+                  <Frame ar="3/2" bd bdrs="20" bgc="base">
+                    <Media src={thumbPath} alt={post.data.title} width="360" height="240" loading="lazy" />
+                  </Frame>
+                  <Lism class="u--trim -ff:mono -fz:s -p:10">{post.data.title}</Lism>
+                </LinkBox>
+              );
+            })}
+          </FluidCols>
+        </Lism>
+      )
+    }
+  </Lism>
+</BaseLayout>


### PR DESCRIPTION
## Summary

- `/en/ui/` と `/en/templates/` が 404 を返す問題を修正
- 非root言語用のページルート4ファイルを追加
  - `[lang]/ui/index.astro` — UI一覧ページ
  - `[lang]/ui/[...slug].astro` — UI詳細ページ（未翻訳時はroot言語にフォールバック）
  - `[lang]/templates/index.astro` — テンプレート一覧ページ
  - `[lang]/templates/[category]/[id].astro` — テンプレート詳細ページ

Closes #163

## Test plan

- [ ] `http://localhost:4000/en/ui/` が正常に表示される
- [ ] `http://localhost:4000/en/ui/Accordion/` 等の個別ページが表示される
- [ ] `http://localhost:4000/en/templates/` が正常に表示される
- [ ] `http://localhost:4000/en/templates/cta/cta001` 等の個別ページが表示される
- [ ] 日本語版の `/ui/` `/templates/` が引き続き正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)