### PR TITLE
feat: d (display) に flex, grid, inline-grid を追加

### DIFF
--- a/packages/lism-css/config/defaults/props.ts
+++ b/packages/lism-css/config/defaults/props.ts
@@ -52,7 +52,7 @@ export default {
 
   d: {
     prop: 'display',
-    presets: ['none', 'block', 'inline-flex'],
+    presets: ['none', 'block', 'flex', 'inline-flex', 'grid', 'inline-grid'],
     bp: 1,
   },
   o: { prop: 'opacity', presets: ['0'], token: 'o', tokenClass: 1 },

--- a/packages/lism-css/src/lib/types/PropValueTypes.spec-d.ts
+++ b/packages/lism-css/src/lib/types/PropValueTypes.spec-d.ts
@@ -40,7 +40,7 @@ describe('PropValueTypes', () => {
   it('d には presets と utils の値を設定できる（レスポンシブ対応）', () => {
     // bp: 1 なので Responsive でラップされる
     expectTypeOf<PropValueTypes['d']>().toEqualTypeOf<
-      Responsive<'none' | 'block' | 'inline-flex' | (string & {}) | number | boolean | null | undefined>
+      Responsive<'none' | 'block' | 'flex' | 'inline-flex' | 'grid' | 'inline-grid' | (string & {}) | number | boolean | null | undefined>
     >();
   });
 
@@ -159,7 +159,9 @@ describe('ResponsivePropValueTypes', () => {
     type Props = ResponsivePropValueTypes;
     type DProp = Props['d'];
 
-    expectTypeOf<DProp>().toEqualTypeOf<'none' | 'block' | 'inline-flex' | (string & {}) | number | boolean | null | undefined>();
+    expectTypeOf<DProp>().toEqualTypeOf<
+      'none' | 'block' | 'flex' | 'inline-flex' | 'grid' | 'inline-grid' | (string & {}) | number | boolean | null | undefined
+    >();
   });
 });
 

--- a/packages/lism-css/src/scss/_prop-config.scss
+++ b/packages/lism-css/src/scss/_prop-config.scss
@@ -101,7 +101,10 @@ $props: (
     utilities: (
       'none': 'none',
       'block': 'block',
+      'flex': 'flex',
       'inline-flex': 'inline-flex',
+      'grid': 'grid',
+      'inline-grid': 'inline-grid',
     ),
     bp: 1,
   ),


### PR DESCRIPTION
## Summary
- `d` (display) の Prop Class プリセットに `flex`, `grid`, `inline-grid` を追加
- 型テスト (spec-d.ts) も合わせて更新

Closes #180

## 変更ファイル
- `packages/lism-css/config/defaults/props.ts` — presets に追加
- `packages/lism-css/src/scss/_prop-config.scss` — utilities に追加
- `packages/lism-css/src/lib/types/PropValueTypes.spec-d.ts` — 型テスト更新

## Test plan
- [x] `pnpm build` 成功
- [x] `pnpm typecheck` 成功
- [x] 生成CSSに `.-d\:flex`, `.-d\:grid`, `.-d\:inline-grid` クラスが含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)