### PR TITLE
refactor(lism-ui): setPlain を set="plain" に移行

### DIFF
--- a/packages/lism-ui/src/components/Accordion/getProps.js
+++ b/packages/lism-ui/src/components/Accordion/getProps.js
@@ -16,7 +16,7 @@ export function getHeadingProps(props) {
   const defaultProps = {
     lismClass: 'c--accordion_heading',
     as: 'div',
-    setPlain: 1,
+    set: 'plain',
   };
 
   const returnProps = { ...defaultProps, ...props };
@@ -60,7 +60,7 @@ export const defaultProps = {
     lismClass: 'c--accordion_button',
     as: 'button',
     layout: 'flex',
-    setPlain: 1,
+    set: 'plain',
     g: '10',
     w: '100%',
     ai: 'center',

--- a/packages/lism-ui/src/components/Details/getProps.js
+++ b/packages/lism-ui/src/components/Details/getProps.js
@@ -16,7 +16,7 @@ export function getDetailsProps({ lismClass, ...props }) {
  */
 export const defaultProps = {
   summary: { lismClass: 'c--details_summary', layout: 'flex', g: '10', ai: 'center' },
-  title: { lismClass: 'c--details_title', as: 'span', fx: '1', setPlain: 1 },
+  title: { lismClass: 'c--details_title', as: 'span', fx: '1', set: 'plain' },
   icon: { lismClass: 'c--details_icon a--icon', as: 'span', 'aria-hidden': 'true' },
   body: { lismClass: 'c--details_body' },
   content: { lismClass: 'c--details_content', layout: 'flow', flow: 's' },

--- a/packages/lism-ui/src/components/Modal/getProps.js
+++ b/packages/lism-ui/src/components/Modal/getProps.js
@@ -3,7 +3,7 @@ import atts from 'lism-css/lib/helper/atts';
 export function getProps({ lismClass = '', duration, style = {}, ...props }) {
   const theProps = {
     lismClass: atts(lismClass, 'c--modal'),
-    setPlain: true,
+    set: 'plain',
   };
   if (duration) {
     style['--duration'] = duration;
@@ -25,6 +25,6 @@ export function getInnerProps({ lismClass = '', offset, style = {}, ...props }) 
 
 export const defaultProps = {
   body: { lismClass: 'c--modal_body' },
-  closeBtn: { as: 'button', setPlain: true, hov: 'o', d: 'in-flex' },
-  openBtn: { as: 'button', setPlain: true, hov: 'o', d: 'in-flex' },
+  closeBtn: { as: 'button', set: 'plain', hov: 'o', d: 'in-flex' },
+  openBtn: { as: 'button', set: 'plain', hov: 'o', d: 'in-flex' },
 };

--- a/packages/lism-ui/src/components/Tabs/astro/Tab.astro
+++ b/packages/lism-ui/src/components/Tabs/astro/Tab.astro
@@ -12,6 +12,6 @@ const { tabId = 'tab', index = 0, isActive, ...props } = Astro.props;
 const controlId = `${tabId}-${index}`;
 ---
 
-<Lism as="button" lismClass="c--tabs_tab" setPlain role="tab" aria-controls={controlId} aria-selected={isActive ? 'true' : 'false'} {...props}>
+<Lism as="button" lismClass="c--tabs_tab" set="plain" role="tab" aria-controls={controlId} aria-selected={isActive ? 'true' : 'false'} {...props}>
   <slot />
 </Lism>

--- a/packages/lism-ui/src/components/Tabs/react/Tab.jsx
+++ b/packages/lism-ui/src/components/Tabs/react/Tab.jsx
@@ -5,6 +5,6 @@ export default function Tab({ tabId = 'tab', index = 0, isActive = false, ...pro
   const controlId = `${tabId}-${index}`;
 
   return (
-    <Lism as="button" lismClass="c--tabs_tab" setPlain role="tab" aria-controls={controlId} aria-selected={isActive ? 'true' : 'false'} {...props} />
+    <Lism as="button" lismClass="c--tabs_tab" set="plain" role="tab" aria-controls={controlId} aria-selected={isActive ? 'true' : 'false'} {...props} />
   );
 }


### PR DESCRIPTION
## Summary
- `packages/lism-ui/` 内の全 `setPlain` props を新しい `set="plain"` に移行
- 対象: Modal, Accordion, Details, Tabs (React/Astro) の計5ファイル
- Closes #191

## 変更内容
| Before | After |
|--------|-------|
| `setPlain: true` | `set: 'plain'` |
| `setPlain: 1` | `set: 'plain'` |
| `setPlain` (JSX boolean) | `set="plain"` |

## Test plan
- [x] `rg 'setPlain\|setGutter\|setShadow\|setHov\|setTransition\|setInnerRs\|setBp\|setMask' packages/lism-ui/` でヒットなし確認
- [x] `pnpm test` 全タスク成功（5/5、エラー0件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)