### PR TITLE
refactor(docs): テンプレート(feature/cta/greeting/works) setXxxx → set prop

### DIFF
--- a/apps/docs/src/pages/preview/templates/cta/cta001/index.astro
+++ b/apps/docs/src/pages/preview/templates/cta/cta001/index.astro
@@ -12,7 +12,7 @@ import './_style.css';
       <Media isLayer src="https://cdn.lism-css.com/random/img" alt="" width="960" height="640" />
       <Layer style={{ backdropFilter: 'blur(4px)' }} bgc="black:50%" />
     </Frame>
-    <Container isWrapper="s" setGutter py="50" z="1">
+    <Container isWrapper="s" set="gutter" py="50" z="1">
       <Stack ai="center" g="40">
         <Stack ai="center" g="30">
           <Heading level="2" class="u--trim" fz="4xl" fw="bold" ff="mono" lts="l" c="white" ta="center">Contact</Heading>
@@ -29,7 +29,7 @@ import './_style.css';
             bdrs="10"
             py="20"
             fw="bold"
-            setTransition
+            set="transition"
             hov={{ bgc: 'white', c: 'black' }}
           >
             <Icon icon="chat" fz="2em" />
@@ -45,7 +45,7 @@ import './_style.css';
             bdrs="10"
             py="20"
             fw="bold"
-            setTransition
+            set="transition"
             hov={{ bgc: 'accent', c: 'white' }}
           >
             <Icon icon="user" fz="2em" />

--- a/apps/docs/src/pages/preview/templates/cta/cta002/index.astro
+++ b/apps/docs/src/pages/preview/templates/cta/cta002/index.astro
@@ -12,7 +12,7 @@ import './_style.css';
       <Media isLayer src="https://cdn.lism-css.com/random/img" alt="" width="960" height="640" />
       <Layer style={{ backdropFilter: 'blur(4px)' }} bgc="black:30%" />
     </Frame>
-    <Container isWrapper="l" setGutter z="0">
+    <Container isWrapper="l" set="gutter" z="0">
       <Stack g="40">
         <Stack g="30" ai="center">
           <Text class="u--trim" fz="5xl" fw="100" ff="accent" lts="l" c="white" ta="center">Contact</Text>

--- a/apps/docs/src/pages/preview/templates/cta/cta003/index.astro
+++ b/apps/docs/src/pages/preview/templates/cta/cta003/index.astro
@@ -12,7 +12,7 @@ import './_style.css';
       <Media isLayer src="https://cdn.lism-css.com/random/img" alt="" width="960" height="640" />
       <Layer style={{ backdropFilter: 'blur(4px) grayscale(100%)' }} bgc="black:50%" />
     </Frame>
-    <Container isWrapper="l" setGutter py="50" z="1">
+    <Container isWrapper="l" set="gutter" py="50" z="1">
       <Grid gtc={['auto', null, 'auto 1fr']} ai="center" g="40 60" w="stretch">
         <Stack ai="fs" g="40" py={[0, null, '50']}>
           <Stack g="40">
@@ -29,7 +29,7 @@ import './_style.css';
               bdrs="10"
               py="15"
               fw="bold"
-              setTransition
+              set="transition"
               hov={{ bgc: 'white', c: 'black' }}
             >
               <Icon icon="chat" fz="2em" />
@@ -44,7 +44,7 @@ import './_style.css';
               bdrs="10"
               py="15"
               fw="bold"
-              setTransition
+              set="transition"
               hov={{ bgc: 'white', c: 'black' }}
             >
               <Icon icon="user" fz="2em" />

--- a/apps/docs/src/pages/preview/templates/cta/cta004/index.astro
+++ b/apps/docs/src/pages/preview/templates/cta/cta004/index.astro
@@ -12,7 +12,7 @@ import './_style.css';
       <Media isLayer src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
       <Layer style={{ backdropFilter: 'blur(4px) grayscale(100%)' }} bgc="black:30%" />
     </Frame>
-    <Container isWrapper="m" setGutter py="50" z="1">
+    <Container isWrapper="m" set="gutter" py="50" z="1">
       <Stack g="40">
         <Stack ai="center" g="30">
           <Text class="u--trim" fz="5xl" fw="light" lts="l" c="white" ta="center">Contact</Text>
@@ -29,7 +29,7 @@ import './_style.css';
               bdrs="10"
               py="15"
               fw="bold"
-              setTransition
+              set="transition"
               hov={{ bgc: 'white', c: 'black' }}
             >
               <Icon icon="book" fz="2em" />
@@ -44,16 +44,16 @@ import './_style.css';
               bdrs="10"
               py="15"
               fw="bold"
-              setTransition
+              set="transition"
               hov={{ bgc: 'white', c: 'black' }}
             >
               <Icon icon="user" fz="2em" />
               <span>メールで相談する</span>
             </Button>
-            <LinkBox layout="grid" href="#" gc="1 / -1" gtc={['1fr auto', null, '1fr 2fr auto']} ai="center" bgc="white" bdrs="10" ov="h" setHov>
+            <LinkBox layout="grid" href="#" gc="1 / -1" gtc={['1fr auto', null, '1fr 2fr auto']} ai="center" bgc="white" bdrs="10" ov="h" set="hov">
               <Frame as="figure" ar={['16/9', null, 'inherit']} gc={['1 / -1', null, '1']} pos="relative" h="100%" ov="h">
-                <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="540" setTransition hov="to:zoom" />
-                <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+                <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="540" set="transition" hov="to:zoom" />
+                <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                   <Center h="100%" c="white">
                     <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                   </Center>
@@ -65,8 +65,8 @@ import './_style.css';
                   お客様のご都合に合わせて専門スタッフが訪問面談いたします。ご相談方法やご依頼後の流れについてはまずはこちらをご覧ください。
                 </Text>
               </Stack>
-              <Flex ai="center" jc="center" p="15" bd bdrs="99" mx="30" setTransition hov="to:reverse">
-                <Icon icon="arrow-right" fz="120%" setTransition />
+              <Flex ai="center" jc="center" p="15" bd bdrs="99" mx="30" set="transition" hov="to:reverse">
+                <Icon icon="arrow-right" fz="120%" set="transition" />
               </Flex>
             </LinkBox>
           </Grid>

--- a/apps/docs/src/pages/preview/templates/feature/feature001/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature001/index.astro
@@ -6,47 +6,47 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature001">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Stack g="40">
       <Stack ai="center" g="15">
         <h2>新しい挑戦が生まれる</h2>
         <Text fz="s" my-s="15" o="-10">誰もが安心して暮らせる環境づくりに力を入れています。</Text>
       </Stack>
       <Columns cols={['1', null, '3']} g="40">
-        <Grid g="0" as="a" isLinkBox href="#" gtr="subgrid" gr="span 2" bdrs="10" bxsh="20" ov="hidden" setHov setTransition hov="bxsh">
+        <Grid g="0" as="a" isLinkBox href="#" gtr="subgrid" gr="span 2" bdrs="10" bxsh="20" ov="hidden" set={["hov", "transition"]} hov="bxsh">
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
           </Frame>
           <Stack g="30" p="30" className="u--trimChildren">
             <Text fz="m" fw="bold">地域の未来を共に描く</Text>
             <Text fz="s" o="-20"> 住民一人ひとりが主役となり、対話を通じて地域の課題解決を目指すプロジェクトです。 </Text>
-            <Flex ai="center" jc="flex-end" g="15" my-s="auto" setTransition hov="to:solid">
+            <Flex ai="center" jc="flex-end" g="15" my-s="auto" set="transition" hov="to:solid">
               <Inline fz="xs" fs="i">View More</Inline>
               <Icon icon="arrow-right" fz="xs" />
             </Flex>
           </Stack>
         </Grid>
-        <Grid g="0" as="a" isLinkBox href="#" gtr="subgrid" gr="span 2" bdrs="10" bxsh="20" ov="hidden" setHov setTransition hov="bxsh">
+        <Grid g="0" as="a" isLinkBox href="#" gtr="subgrid" gr="span 2" bdrs="10" bxsh="20" ov="hidden" set={["hov", "transition"]} hov="bxsh">
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-2.jpg" alt="" width="960" height="640" />
           </Frame>
           <Stack g="30" p="30" className="u--trimChildren">
             <Text fz="m" fw="bold">伝統文化を次世代へ</Text>
             <Text fz="s" lh="s" o="-20"> 古くから受け継がれてきた祭りを守り、子どもたちが地域の文化に触れる機会を創出します。 </Text>
-            <Flex ai="center" jc="flex-end" g="15" my-s="auto" setTransition hov="to:solid">
+            <Flex ai="center" jc="flex-end" g="15" my-s="auto" set="transition" hov="to:solid">
               <Inline fz="xs" fs="i">View More</Inline>
               <Icon icon="arrow-right" fz="xs" />
             </Flex>
           </Stack>
         </Grid>
-        <Grid g="0" as="a" isLinkBox href="#" gtr="subgrid" gr="span 2" bdrs="10" bxsh="20" ov="hidden" setHov setTransition hov="bxsh">
+        <Grid g="0" as="a" isLinkBox href="#" gtr="subgrid" gr="span 2" bdrs="10" bxsh="20" ov="hidden" set={["hov", "transition"]} hov="bxsh">
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-4.jpg" alt="" width="960" height="640" />
           </Frame>
           <Stack g="30" p="30" className="u--trimChildren">
             <Text fz="m" fw="bold">安心して暮らせる街</Text>
             <Text fz="s" lh="s" o="-20">防犯パトロールや防災訓練を定期的に実施し、協力体制を強化しています。</Text>
-            <Flex ai="center" jc="flex-end" g="15" my-s="auto" setTransition hov="to:solid">
+            <Flex ai="center" jc="flex-end" g="15" my-s="auto" set="transition" hov="to:solid">
               <Inline fz="xs" fs="i">View More</Inline>
               <Icon icon="arrow-right" fz="xs" />
             </Flex>

--- a/apps/docs/src/pages/preview/templates/feature/feature002/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature002/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature002">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Stack g="40">
       <Grid gtc={['1fr', null, 'auto 1fr']} g="inherit">
         <Stack class="u--trimChildren" g="20">
@@ -21,10 +21,10 @@ import './_style.css';
         </Flex>
       </Grid>
       <Columns cols={[2, null, 4]} g={['30', '40']}>
-        <Grid as="a" isLinkBox href="#" g="20" ai="start" setHov>
+        <Grid as="a" isLinkBox href="#" g="20" ai="start" set="hov">
           <Frame as="figure" ar="1/1" bdrs="10" pos="relative">
-            <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" setTransition hov="to:zoom" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" set="transition" hov="to:zoom" />
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -32,13 +32,13 @@ import './_style.css';
           </Frame>
           <Flex ai="center" jc="flex-start" g="15" fz="m" lh="s">
             <Inline>地域の未来を共に描く</Inline>
-            <Icon icon="arrow-right" mx-s="auto" setTransition hov="to:solid" />
+            <Icon icon="arrow-right" mx-s="auto" set="transition" hov="to:solid" />
           </Flex>
         </Grid>
-        <Grid as="a" isLinkBox href="#" g="20" ai="start" setHov>
+        <Grid as="a" isLinkBox href="#" g="20" ai="start" set="hov">
           <Frame as="figure" ar="1/1" bdrs="10" pos="relative">
-            <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" setTransition hov="to:zoom" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" set="transition" hov="to:zoom" />
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -46,13 +46,13 @@ import './_style.css';
           </Frame>
           <Flex ai="center" jc="flex-start" g="15" fz="m" lh="s">
             <Inline>誰もが集える憩いの場</Inline>
-            <Icon icon="arrow-right" mx-s="auto" setTransition hov="to:solid" />
+            <Icon icon="arrow-right" mx-s="auto" set="transition" hov="to:solid" />
           </Flex>
         </Grid>
-        <Grid as="a" isLinkBox href="#" g="20" ai="start" setHov>
+        <Grid as="a" isLinkBox href="#" g="20" ai="start" set="hov">
           <Frame as="figure" ar="1/1" bdrs="10" pos="relative">
-            <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" setTransition hov="to:zoom" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" set="transition" hov="to:zoom" />
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -60,13 +60,13 @@ import './_style.css';
           </Frame>
           <Flex ai="center" jc="flex-start" g="15" fz="m" lh="s">
             <Inline>地元の恵みを食卓へ</Inline>
-            <Icon icon="arrow-right" mx-s="auto" setTransition hov="to:solid" />
+            <Icon icon="arrow-right" mx-s="auto" set="transition" hov="to:solid" />
           </Flex>
         </Grid>
-        <Grid as="a" isLinkBox href="#" g="20" ai="start" setHov>
+        <Grid as="a" isLinkBox href="#" g="20" ai="start" set="hov">
           <Frame as="figure" ar="1/1" bdrs="10" pos="relative">
-            <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" setTransition hov="to:zoom" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" set="transition" hov="to:zoom" />
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -74,7 +74,7 @@ import './_style.css';
           </Frame>
           <Flex ai="center" jc="flex-start" g="15" fz="m" lh="s">
             <Inline>緑豊かな景観づくり</Inline>
-            <Icon icon="arrow-right" mx-s="auto" setTransition hov="to:solid" />
+            <Icon icon="arrow-right" mx-s="auto" set="transition" hov="to:solid" />
           </Flex>
         </Grid>
       </Columns>

--- a/apps/docs/src/pages/preview/templates/feature/feature003/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature003/index.astro
@@ -7,17 +7,17 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature003">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Grid gtc={['1fr', null, 'min(20vw, 20rem) 1fr 1fr']} gtr={['1fr', null, '1fr auto auto 1fr']} g={['40', null, '40 50']}>
       <Stack gr={['1', null, '2']} g="40" class="u--trimChildren">
         <h2>目指す世界の先に</h2>
         <Text fz="s"> この地に受け継がれてきた伝統や祭りを大切に守り、次世代へと繋いでいきます。 地域の魅力を再発見し育む活動を行っています。 </Text>
       </Stack>
       <Columns gr={['2', null, '1 / -1']} gc={['1', null, '2 / -1']} cols={['1', '2']} g="40">
-        <Grid gtr="auto 1fr" isLinkBox as="a" href="#" bdrs="10" bxsh="20" ov="hidden" setHov setTransition hov="bxsh">
+        <Grid gtr="auto 1fr" isLinkBox as="a" href="#" bdrs="10" bxsh="20" ov="hidden" set={["hov", "transition"]} hov="bxsh">
           <Frame as="figure" ar="3/2" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="2xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -28,10 +28,10 @@ import './_style.css';
             <Text fz="s" o="-10">住民が主役となり、対話を通じて地域の課題解決を目指すプロジェクトです。</Text>
           </Stack>
         </Grid>
-        <Grid gtr="auto 1fr" isLinkBox as="a" href="#" bdrs="10" bxsh="20" ov="hidden" setHov setTransition hov="bxsh">
+        <Grid gtr="auto 1fr" isLinkBox as="a" href="#" bdrs="10" bxsh="20" ov="hidden" set={["hov", "transition"]} hov="bxsh">
           <Frame as="figure" ar="3/2" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="2xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>

--- a/apps/docs/src/pages/preview/templates/feature/feature004/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature004/index.astro
@@ -6,13 +6,13 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature004">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Stack g="50">
       <Heading class="u--trim" level="2" fz="2xl" ta="center">未知なる体験</Heading>
       <Columns cols={[1, null, 3]} g="30">
         <Stack g="20">
-          <Frame as="a" isLinkBox href="#" pos="relative" ar={['4/3', null, '3/4']} bdrs="10" bxsh="30" td="none" setHov>
-            <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=1" alt="" width="960" height="640" setTransition hov="to:zoom" />
+          <Frame as="a" isLinkBox href="#" pos="relative" ar={['4/3', null, '3/4']} bdrs="10" bxsh="30" td="none" set="hov">
+            <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=1" alt="" width="960" height="640" set="transition" hov="to:zoom" />
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
@@ -20,7 +20,7 @@ import './_style.css';
                   <Text fz="l" fw="bold" lh="s">革新的な技術力</Text>
                   <Text fz="s" lh="s" o="-10">Advanced Technology</Text>
                 </Stack>
-                <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" c="white" setTransition hov="to:reverse">
+                <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" c="white" set="transition" hov="to:reverse">
                   <Icon icon="arrow-right" fz="s" />
                 </Flex>
               </Grid>
@@ -29,8 +29,8 @@ import './_style.css';
           <Text pb="20">最新のAIとロボット技術を駆使し、高精度なものづくりで未来の産業を支えます。</Text>
         </Stack>
         <Stack g="20">
-          <Frame as="a" isLinkBox href="#" pos="relative" ar={['4/3', null, '3/4']} bdrs="10" bxsh="30" td="none" setHov>
-            <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=2" alt="" width="960" height="640" setTransition hov="to:zoom" />
+          <Frame as="a" isLinkBox href="#" pos="relative" ar={['4/3', null, '3/4']} bdrs="10" bxsh="30" td="none" set="hov">
+            <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=2" alt="" width="960" height="640" set="transition" hov="to:zoom" />
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
@@ -38,7 +38,7 @@ import './_style.css';
                   <Text fz="l" fw="bold" lh="s">徹底した品質管理</Text>
                   <Text fz="s" lh="s" o="-10">Quality First</Text>
                 </Stack>
-                <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" c="white" setTransition hov="to:reverse">
+                <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" c="white" set="transition" hov="to:reverse">
                   <Icon icon="arrow-right" fz="s" />
                 </Flex>
               </Grid>
@@ -47,8 +47,8 @@ import './_style.css';
           <Text pb="20">ミクロン単位の精度を追求し、すべての製品においてお客様に安心と信頼をお届けします。</Text>
         </Stack>
         <Stack g="20">
-          <Frame as="a" isLinkBox href="#" pos="relative" ar={['4/3', null, '3/4']} bdrs="10" bxsh="30" td="none" setHov>
-            <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=3" alt="" width="960" height="640" setTransition hov="to:zoom" />
+          <Frame as="a" isLinkBox href="#" pos="relative" ar={['4/3', null, '3/4']} bdrs="10" bxsh="30" td="none" set="hov">
+            <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=3" alt="" width="960" height="640" set="transition" hov="to:zoom" />
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
@@ -56,7 +56,7 @@ import './_style.css';
                   <Text fz="l" fw="bold" lh="s">グローバル供給体制</Text>
                   <Text fz="s" lh="s" o="-10">Global Network</Text>
                 </Stack>
-                <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" c="white" setTransition hov="to:reverse">
+                <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" c="white" set="transition" hov="to:reverse">
                   <Icon icon="arrow-right" fz="s" />
                 </Flex>
               </Grid>

--- a/apps/docs/src/pages/preview/templates/feature/feature005/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature005/index.astro
@@ -6,13 +6,13 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature005">
-  <Container isWrapper="m" bgc="base" py="50" setGutter>
+  <Container isWrapper="m" bgc="base" py="50" set="gutter">
     <Heading level="2" ta="center" mb="40">製品について</Heading>
     <Columns cols={[1, null, 2]} g={['30', null, '40']}>
-      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" setTransition setHov hov="bxsh">
+      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" set={["transition", "hov"]} hov="bxsh">
         <Frame as="figure" pos="relative">
           <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
-          <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+          <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
             <Center h="100%" c="white">
               <Inline fz="s" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
             </Center>
@@ -23,10 +23,10 @@ import './_style.css';
           <Text class="u--trim" fz="s" o="-10">繊維の奥の汚れを落とし、衣類の傷みを抑えながら、ふんわりと優しく洗い上げます。</Text>
         </Stack>
       </Grid>
-      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" setTransition setHov hov="bxsh">
+      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" set={["transition", "hov"]} hov="bxsh">
         <Frame as="figure" pos="relative">
           <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" />
-          <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+          <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
             <Center h="100%" c="white">
               <Inline fz="s" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
             </Center>
@@ -37,10 +37,10 @@ import './_style.css';
           <Text class="u--trim" fz="s" o="-10">快適な室温はもちろん、空気清浄機能でウイルスや花粉の活動を抑制します。</Text>
         </Stack>
       </Grid>
-      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" setTransition setHov hov="bxsh">
+      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" set={["transition", "hov"]} hov="bxsh">
         <Frame as="figure" pos="relative">
           <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" />
-          <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+          <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
             <Center h="100%" c="white">
               <Inline fz="s" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
             </Center>
@@ -51,10 +51,10 @@ import './_style.css';
           <Text class="u--trim" fz="s" o="-10">過熱水蒸気の力で、本格的なオーブン料理が誰でも簡単においしく作れます。</Text>
         </Stack>
       </Grid>
-      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" setTransition setHov hov="bxsh">
+      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" set={["transition", "hov"]} hov="bxsh">
         <Frame as="figure" pos="relative">
           <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" />
-          <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+          <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
             <Center h="100%" c="white">
               <Inline fz="s" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
             </Center>

--- a/apps/docs/src/pages/preview/templates/feature/feature006/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature006/index.astro
@@ -6,13 +6,13 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature006">
-  <Container isWrapper="m" bgc="base" py="50" setGutter>
+  <Container isWrapper="m" bgc="base" py="50" set="gutter">
     <Heading level="2" ta="center">ここに特徴が並びます</Heading>
     <Grid gt="repeat" cols={['1', null, '2']} rows={['1', null, '3']} my-s="40" g={['30', '40']}>
-      <Grid as="a" isLinkBox href="#" gr="1 / span 3" gtr="1fr auto" bxsh="20" setTransition setHov hov="bxsh">
+      <Grid as="a" isLinkBox href="#" gr="1 / span 3" gtr="1fr auto" bxsh="20" set={["transition", "hov"]} hov="bxsh">
         <Frame as="figure" pos="relative">
-          <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" setTransition hov="to:zoom" />
-          <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+          <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" set="transition" hov="to:zoom" />
+          <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
             <Center h="100%" c="white">
               <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
             </Center>
@@ -23,10 +23,10 @@ import './_style.css';
           <Text class="u--trim" fz="m" o="-10">繊維の奥の汚れを落とし、衣類の傷みを抑えながら、ふんわりと優しく洗い上げます。</Text>
         </Stack>
       </Grid>
-      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" setTransition setHov hov="bxsh">
+      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" set={["transition", "hov"]} hov="bxsh">
         <Frame as="figure" pos="relative">
-          <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" setTransition hov="to:zoom" />
-          <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+          <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" set="transition" hov="to:zoom" />
+          <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
             <Center h="100%" c="white">
               <Inline fz="s" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
             </Center>
@@ -37,10 +37,10 @@ import './_style.css';
           <Text class="u--trim" fz="s" o="-10">快適な室温はもちろん、空気清浄機能でウイルスや花粉の活動を抑制します。</Text>
         </Stack>
       </Grid>
-      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" setTransition setHov hov="bxsh">
+      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" set={["transition", "hov"]} hov="bxsh">
         <Frame as="figure" pos="relative">
-          <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" setTransition hov="to:zoom" />
-          <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+          <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" set="transition" hov="to:zoom" />
+          <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
             <Center h="100%" c="white">
               <Inline fz="s" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
             </Center>
@@ -51,10 +51,10 @@ import './_style.css';
           <Text class="u--trim" fz="s" o="-10">過熱水蒸気の力で、本格的なオーブン料理が誰でも簡単においしく作れます。</Text>
         </Stack>
       </Grid>
-      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" setTransition setHov hov="bxsh">
+      <Grid as="a" isLinkBox href="#" gtc="1fr 2fr" bxsh="20" set={["transition", "hov"]} hov="bxsh">
         <Frame as="figure" pos="relative">
-          <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" setTransition hov="to:zoom" />
-          <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+          <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" set="transition" hov="to:zoom" />
+          <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
             <Center h="100%" c="white">
               <Inline fz="s" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
             </Center>

--- a/apps/docs/src/pages/preview/templates/feature/feature007/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature007/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature007">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Grid gt="repeat" cols={['2', '3', '4']} rows={['4', '3']} g="20">
       <LinkBox
         href="#"
@@ -16,11 +16,10 @@ import './_style.css';
         ov="hidden"
         bdrs="30"
         bxsh="20"
-        setTransition
-        setHov
+        set={["transition", "hov"]}
       >
         <Frame isLayer>
-          <Media src="https://cdn.lism-css.com/random/img?category=v&r=1" alt="" width="960" height="640" setTransition hov="to:zoom" />
+          <Media src="https://cdn.lism-css.com/random/img?category=v&r=1" alt="" width="960" height="640" set="transition" hov="to:zoom" />
         </Frame>
         <Layer bgc="black:20%" />
         <Grid gtr="auto auto" gtc="auto" p="30" h="100%" pos="relative">
@@ -30,7 +29,7 @@ import './_style.css';
           </Stack>
           <Flex ai="center" jc="flex-end" c="white" my-s="auto" g="20">
             <Inline fs="i">View More</Inline>
-            <Stack p="15" bd bdrs="99" setTransition hov="to:reverse">
+            <Stack p="15" bd bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="arrow-right" fz="m" />
             </Stack>
           </Flex>
@@ -44,11 +43,10 @@ import './_style.css';
         ov="hidden"
         bdrs="30"
         bxsh="20"
-        setTransition
-        setHov
+        set={["transition", "hov"]}
       >
         <Frame isLayer>
-          <Media src="https://cdn.lism-css.com/random/img?category=v&r=2" alt="" width="960" height="640" setTransition hov="to:zoom" />
+          <Media src="https://cdn.lism-css.com/random/img?category=v&r=2" alt="" width="960" height="640" set="transition" hov="to:zoom" />
         </Frame>
         <Layer bgc="black:20%" />
         <Grid gtr="auto auto" gtc="auto" p="30" h="100%" pos="relative">
@@ -58,15 +56,15 @@ import './_style.css';
           </Stack>
           <Flex ai="center" jc="flex-end" c="white" my-s="auto" g="20">
             <Inline fs="i">View More</Inline>
-            <Stack p="15" bd bdrs="99" setTransition hov="to:reverse">
+            <Stack p="15" bd bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="arrow-right" fz="m" />
             </Stack>
           </Flex>
         </Grid>
       </LinkBox>
-      <LinkBox href="#" gr={['4', '3', '1 / span 1']} gc={['1', null, '4']} pos="relative" ov="hidden" bdrs="30" bxsh="20" setTransition setHov>
+      <LinkBox href="#" gr={['4', '3', '1 / span 1']} gc={['1', null, '4']} pos="relative" ov="hidden" bdrs="30" bxsh="20" set={["transition", "hov"]}>
         <Frame isLayer>
-          <Media src="https://cdn.lism-css.com/random/img?category=v&r=3" alt="" width="960" height="640" setTransition hov="to:zoom" />
+          <Media src="https://cdn.lism-css.com/random/img?category=v&r=3" alt="" width="960" height="640" set="transition" hov="to:zoom" />
         </Frame>
         <Layer bgc="black:20%" />
         <Grid gtr="auto auto" gtc="auto" p="30" h="100%" pos="relative">
@@ -76,7 +74,7 @@ import './_style.css';
           </Stack>
           <Flex ai="center" jc="flex-end" c="white" my-s="auto" g="20">
             <Inline fs="i">View More</Inline>
-            <Stack p="15" bd bdrs="99" setTransition hov="to:reverse">
+            <Stack p="15" bd bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="arrow-right" fz="m" />
             </Stack>
           </Flex>
@@ -90,11 +88,10 @@ import './_style.css';
         ov="hidden"
         bdrs="30"
         bxsh="20"
-        setTransition
-        setHov
+        set={["transition", "hov"]}
       >
         <Frame isLayer>
-          <Media src="https://cdn.lism-css.com/random/img?category=v&r=4" alt="" width="960" height="640" setTransition hov="to:zoom" />
+          <Media src="https://cdn.lism-css.com/random/img?category=v&r=4" alt="" width="960" height="640" set="transition" hov="to:zoom" />
         </Frame>
         <Layer bgc="black:20%" />
         <Grid gtr="auto auto" gtc="auto" p="30" h="100%" pos="relative">
@@ -104,7 +101,7 @@ import './_style.css';
           </Stack>
           <Flex ai="center" jc="flex-end" c="white" my-s="auto" g="20">
             <Inline fs="i">View More</Inline>
-            <Stack p="15" bd bdrs="99" setTransition hov="to:reverse">
+            <Stack p="15" bd bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="arrow-right" fz="m" />
             </Stack>
           </Flex>

--- a/apps/docs/src/pages/preview/templates/feature/feature008/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature008/index.astro
@@ -7,14 +7,14 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature008">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Grid gtr={['auto 1fr auto', null, 'auto 1fr']} gtc={['1fr', null, '1fr auto']} g="40">
       <h2 class="u--trim">この季節だからこそ</h2>
       <Columns cols={['1', '2', '3']} gc="1 / -1" g="40">
-        <Stack as="a" isLinkBox href="#" g="30" setHov>
+        <Stack as="a" isLinkBox href="#" g="30" set="hov">
           <Frame as="figure" ar="16/9" bdrs="10" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -25,10 +25,10 @@ import './_style.css';
             <Text class="u--trim" fz="s" o="-20">Summer recommended products</Text>
           </Stack>
         </Stack>
-        <Stack as="a" isLinkBox href="#" g="30" setHov>
+        <Stack as="a" isLinkBox href="#" g="30" set="hov">
           <Frame as="figure" ar="16/9" bdrs="10" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -39,10 +39,10 @@ import './_style.css';
             <Text class="u--trim" fz="s" o="-20">Mountain special goods</Text>
           </Stack>
         </Stack>
-        <Stack as="a" isLinkBox href="#" g="30" setHov>
+        <Stack as="a" isLinkBox href="#" g="30" set="hov">
           <Frame as="figure" ar="16/9" bdrs="10" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -53,10 +53,10 @@ import './_style.css';
             <Text class="u--trim" fz="s" o="-20">Feeling the signs of autumn</Text>
           </Stack>
         </Stack>
-        <Stack as="a" isLinkBox href="#" g="30" setHov>
+        <Stack as="a" isLinkBox href="#" g="30" set="hov">
           <Frame as="figure" ar="16/9" bdrs="10" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -67,10 +67,10 @@ import './_style.css';
             <Text class="u--trim" fz="s" o="-20">A season that makes you want to travel</Text>
           </Stack>
         </Stack>
-        <Stack as="a" isLinkBox href="#" g="30" setHov>
+        <Stack as="a" isLinkBox href="#" g="30" set="hov">
           <Frame as="figure" ar="16/9" bdrs="10" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=5" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -81,10 +81,10 @@ import './_style.css';
             <Text class="u--trim" fz="s" o="-20">Enjoy the mild weather</Text>
           </Stack>
         </Stack>
-        <Stack as="a" isLinkBox href="#" g="30" setHov>
+        <Stack as="a" isLinkBox href="#" g="30" set="hov">
           <Frame as="figure" ar="16/9" bdrs="10" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=6" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>

--- a/apps/docs/src/pages/preview/templates/feature/feature009/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature009/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature009">
-  <Container isWrapper="m" py="50" setGutter>
+  <Container isWrapper="m" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">私たちの取り組み</Heading>
       <FluidCols cols="300px" gtr="auto auto auto" g="40">

--- a/apps/docs/src/pages/preview/templates/feature/feature010/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature010/index.astro
@@ -6,13 +6,13 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature010">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" fz="2xl" fw="bold" ta="center">厳選された商品</Heading>
       <Columns cols={['1', '2', '4']} gtr="auto auto auto" g="40">
-        <Grid gtr="subgrid" gr="span 3" g="30" as="a" isLinkBox href="#" setHov>
+        <Grid gtr="subgrid" gr="span 3" g="30" as="a" isLinkBox href="#" set="hov">
           <Frame as="figure" ar="1/1" bdrs="10">
-            <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" setTransition hov="to:zoom" />
+            <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           </Frame>
           <Stack g="inherit">
             <Text class="u--trim" fz="l" fw="bold">ストームシールド</Text>
@@ -20,14 +20,14 @@ import './_style.css';
               突然の雨風にも耐える高い耐久性。初心者でも簡単に設営できる、オールシーズン対応テント。
             </Text>
           </Stack>
-          <Flex g="20" ai="center" bd-b px="15" pb="10" setTransition hov="to:cAccent">
+          <Flex g="20" ai="center" bd-b px="15" pb="10" set="transition" hov="to:cAccent">
             <Text fz="m" fx="1" fs="i">View Detail</Text>
             <Icon icon="arrow-right" fz="m" />
           </Flex>
         </Grid>
-        <Grid gtr="subgrid" gr="span 3" g="30" as="a" isLinkBox href="#" setHov>
+        <Grid gtr="subgrid" gr="span 3" g="30" as="a" isLinkBox href="#" set="hov">
           <Frame as="figure" ar="1/1" bdrs="10">
-            <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" setTransition hov="to:zoom" />
+            <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           </Frame>
           <Stack g="inherit">
             <Text class="u--trim" fz="l" fw="bold">リッジウォーカー</Text>
@@ -35,27 +35,27 @@ import './_style.css';
               背中の蒸れを軽減する背面システムを採用。日帰りから小屋泊まで幅広く対応する人気モデル。
             </Text>
           </Stack>
-          <Flex g="20" ai="center" bd-b px="15" pb="10" setTransition hov="to:cAccent">
+          <Flex g="20" ai="center" bd-b px="15" pb="10" set="transition" hov="to:cAccent">
             <Text fz="m" fx="1" fs="i">View Detail</Text>
             <Icon icon="arrow-right" fz="m" />
           </Flex>
         </Grid>
-        <Grid gtr="subgrid" gr="span 3" g="30" as="a" isLinkBox href="#" setHov>
+        <Grid gtr="subgrid" gr="span 3" g="30" as="a" isLinkBox href="#" set="hov">
           <Frame as="figure" ar="1/1" bdrs="10">
-            <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" setTransition hov="to:zoom" />
+            <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           </Frame>
           <Stack g="inherit">
             <Text class="u--trim" fz="l" fw="bold">オーロラダウン</Text>
             <Text class="u--trim" fz="m" lh="s" o="-20"> 高品質な750フィルパワーのダウンを使用。-5℃まで対応し、秋冬キャンプでも快適な眠りを。 </Text>
           </Stack>
-          <Flex g="20" ai="center" bd-b px="15" pb="10" setTransition hov="to:cAccent">
+          <Flex g="20" ai="center" bd-b px="15" pb="10" set="transition" hov="to:cAccent">
             <Text fz="m" fx="1" fs="i">View Detail</Text>
             <Icon icon="arrow-right" fz="m" />
           </Flex>
         </Grid>
-        <Grid gtr="subgrid" gr="span 3" g="30" as="a" isLinkBox href="#" setHov>
+        <Grid gtr="subgrid" gr="span 3" g="30" as="a" isLinkBox href="#" set="hov">
           <Frame as="figure" ar="1/1" bdrs="10">
-            <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" setTransition hov="to:zoom" />
+            <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           </Frame>
           <Stack g="inherit">
             <Text class="u--trim" fz="l" fw="bold">フィールドリラックスチェア</Text>
@@ -63,7 +63,7 @@ import './_style.css';
               体を包み込むような快適な座り心地。軽量コンパクト設計で持ち運びも簡単。設営もあっという間です。
             </Text>
           </Stack>
-          <Flex g="20" ai="center" bd-b px="15" pb="10" setTransition hov="to:cAccent">
+          <Flex g="20" ai="center" bd-b px="15" pb="10" set="transition" hov="to:cAccent">
             <Text fz="m" fx="1" fs="i">View Detail</Text>
             <Icon icon="arrow-right" fz="m" />
           </Flex>

--- a/apps/docs/src/pages/preview/templates/feature/feature011/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature011/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature011">
-  <Container isWrapper="m" bgc="base-2" py="50" setGutter>
+  <Container isWrapper="m" bgc="base-2" py="50" set="gutter">
     <Grid
       gt={[
         '"title" "body" "link" / 1fr',
@@ -31,8 +31,7 @@ import './_style.css';
           bgc="base"
           p={['20', '30']}
           bdrs="10"
-          setTransition
-          setHov
+          set={["transition", "hov"]}
           ai="center"
           hov="bxsh"
         >
@@ -45,7 +44,7 @@ import './_style.css';
               <Text>目標金額を設定して貯蓄ができる「目的別預金」が登場。楽しみながら計画的な資産形成が行えます。</Text>
             </Flex>
           </Grid>
-          <Center w="fit" bd p="15" bdrs="99" setTransition hov="to:reverse">
+          <Center w="fit" bd p="15" bdrs="99" set="transition" hov="to:reverse">
             <Icon icon="arrow-right" fz="s" />
           </Center>
         </Grid>
@@ -59,8 +58,7 @@ import './_style.css';
           bgc="base"
           p={['20', '30']}
           bdrs="10"
-          setTransition
-          setHov
+          set={["transition", "hov"]}
           ai="center"
           hov="bxsh"
         >
@@ -73,7 +71,7 @@ import './_style.css';
               <Text>通信の暗号化や二段階認証を導入。お客様の大切な資産と個人情報を厳重に保護します。</Text>
             </Flex>
           </Grid>
-          <Center w="fit" bd p="15" bdrs="99" setTransition hov="to:reverse">
+          <Center w="fit" bd p="15" bdrs="99" set="transition" hov="to:reverse">
             <Icon icon="arrow-right" fz="s" />
           </Center>
         </Grid>
@@ -87,8 +85,7 @@ import './_style.css';
           bgc="base"
           p={['20', '30']}
           bdrs="10"
-          setTransition
-          setHov
+          set={["transition", "hov"]}
           ai="center"
           hov="bxsh"
         >
@@ -101,7 +98,7 @@ import './_style.css';
               <Text>口座開設から運用状況の確認までスマホアプリで完結。いつでも手軽に資産をチェックできます。</Text>
             </Flex>
           </Grid>
-          <Center w="fit" bd p="15" bdrs="99" setTransition hov="to:reverse">
+          <Center w="fit" bd p="15" bdrs="99" set="transition" hov="to:reverse">
             <Icon icon="arrow-right" fz="s" />
           </Center>
         </Grid>

--- a/apps/docs/src/pages/preview/templates/feature/feature012/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature012/index.astro
@@ -6,17 +6,17 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature012">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Stack g="40">
       <Flex ai="baseline" g="0 30" fxw="wrap">
         <h2>カテゴリーから探す</h2>
         <Inline fz="m" fw="bold" o="-20">Categories</Inline>
       </Flex>
       <Columns cols={[1, 2, 3]} g="40" cg="40">
-        <Grid g="30" as="a" isLinkBox href="#" setHov>
+        <Grid g="30" as="a" isLinkBox href="#" set="hov">
           <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -30,10 +30,10 @@ import './_style.css';
             <Text class="u--trim" fz="s">毎日の料理を心躍る体験に。キッチンを美しく彩る、ミニマルなデザインの調理家電。</Text>
           </Stack>
         </Grid>
-        <Grid g="30" as="a" isLinkBox href="#" setHov>
+        <Grid g="30" as="a" isLinkBox href="#" set="hov">
           <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -47,10 +47,10 @@ import './_style.css';
             <Text class="u--trim" fz="s">空間に溶け込み、心地よい空気と時間を作り出す。日々の暮らしの質を高めるアイテム。</Text>
           </Stack>
         </Grid>
-        <Grid g="30" as="a" isLinkBox href="#" setHov>
+        <Grid g="30" as="a" isLinkBox href="#" set="hov">
           <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -64,10 +64,10 @@ import './_style.css';
             <Text class="u--trim" fz="s">掃除さえも、美しい時間に変える。パワフルな吸引力と、オブジェのような佇まい。</Text>
           </Stack>
         </Grid>
-        <Grid g="30" as="a" isLinkBox href="#" setHov>
+        <Grid g="30" as="a" isLinkBox href="#" set="hov">
           <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -81,10 +81,10 @@ import './_style.css';
             <Text class="u--trim" fz="s">大切な衣類を、優しく、美しく。静かでクリーンなデザインが、空間を洗練させます。</Text>
           </Stack>
         </Grid>
-        <Grid g="30" as="a" isLinkBox href="#" setHov>
+        <Grid g="30" as="a" isLinkBox href="#" set="hov">
           <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=5" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -98,10 +98,10 @@ import './_style.css';
             <Text class="u--trim" fz="s">心を揺さぶる、クリアで立体的なサウンド。音楽をアートのように空間に飾るオーディオ。</Text>
           </Stack>
         </Grid>
-        <Grid g="30" as="a" isLinkBox href="#" setHov>
+        <Grid g="30" as="a" isLinkBox href="#" set="hov">
           <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
             <Media src="https://cdn.lism-css.com/random/img?r=6" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>

--- a/apps/docs/src/pages/preview/templates/feature/feature013/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature013/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature013">
-  <Container isWrapper="l" bgc="base-2" py="50" setGutter>
+  <Container isWrapper="l" bgc="base-2" py="50" set="gutter">
     <Stack g="40">
       <Stack ai="center" g="5">
         <Heading level="2" fz="2xl" fw="bold">厳選された商品</Heading>
@@ -17,45 +17,44 @@ import './_style.css';
           href="#"
           layout="grid"
           class="set--innerRs"
-          setHov
+          set={["hov", "transition"]}
           gc="1 / -1"
           gt="repeat"
           cols={['1', null, '2']}
           bgc="white"
           ov="hidden"
           bdrs="20"
-          setTransition
           hov="bxsh"
         >
           <Frame pos="relative" min-h="100%">
-            <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" setTransition hov="to:zoom" />
+            <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           </Frame>
           <Stack g="30" jc="center" p="40">
             <Text class="u--trim" fz="l" fw="bold">期間限定コラボモデル</Text>
             <Text class="u--trim" fz="s">
               ここでしか出会えない特別な一品を。アーティストとのコラボなど、数量限定のモデル。自分を慈しむ時間を、もっと豊かに。毎日のセルフケアを、心地よい体験へと変える。
             </Text>
-            <Flex bdrs="inner" jc="center" bd p="10" setTransition hov="to:reverse">
+            <Flex bdrs="inner" jc="center" bd p="10" set="transition" hov="to:reverse">
               <Text fz="m">View Detail</Text>
             </Flex>
           </Stack>
         </LinkBox>
         <Columns cols={['1', '2', '4']} g="40">
-          <LinkBox layout="grid" gtr="subgrid" gr="span 3" setHov g="30" href="#">
+          <LinkBox layout="grid" gtr="subgrid" gr="span 3" set="hov" g="30" href="#">
             <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
-              <Media src="/img/img-1.jpg" alt="" width="960" height="640" setTransition hov="to:zoom" />
+              <Media src="/img/img-1.jpg" alt="" width="960" height="640" set="transition" hov="to:zoom" />
             </Frame>
             <Stack g="20">
               <Text class="u--trim" fz="m" fw="bold">空調・生活家電</Text>
               <Text class="u--trim" fz="s" o="-10">空間に溶け込み、心地よい空気と時間を作り出す。日々の暮らしの質を高めるアイテム。</Text>
             </Stack>
-            <Flex my-s="auto" jc="center" bd bdc="line" p="10" bdrs="20" setTransition hov="to:reverse">
+            <Flex my-s="auto" jc="center" bd bdc="line" p="10" bdrs="20" set="transition" hov="to:reverse">
               <Text fz="s">View Detail</Text>
             </Flex>
           </LinkBox>
-          <LinkBox layout="grid" gtr="subgrid" gr="span 3" setHov g="30" href="#">
+          <LinkBox layout="grid" gtr="subgrid" gr="span 3" set="hov" g="30" href="#">
             <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
-              <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" setTransition hov="to:zoom" />
+              <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" set="transition" hov="to:zoom" />
             </Frame>
             <Stack g="20">
               <Text class="u--trim" fz="m" fw="bold">スマートホーム</Text>
@@ -63,31 +62,31 @@ import './_style.css';
                 家電たちが静かに連携し、暮らしをサポート。テクノロジーを意識させない、未来の日常をつくります。
               </Text>
             </Stack>
-            <Flex my-s="auto" jc="center" bd bdc="line" p="10" bdrs="20" setTransition hov="to:reverse">
+            <Flex my-s="auto" jc="center" bd bdc="line" p="10" bdrs="20" set="transition" hov="to:reverse">
               <Text fz="s">View Detail</Text>
             </Flex>
           </LinkBox>
-          <LinkBox layout="grid" gtr="subgrid" gr="span 3" setHov g="30" href="#">
+          <LinkBox layout="grid" gtr="subgrid" gr="span 3" set="hov" g="30" href="#">
             <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
-              <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" setTransition hov="to:zoom" />
+              <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" set="transition" hov="to:zoom" />
             </Frame>
             <Stack g="20">
               <Text class="u--trim" fz="m" fw="bold">アクセサリ</Text>
               <Text class="u--trim" fz="s" o="-10">製品体験をさらに豊かにする専用アクセサリ。細部にまで、ブランドの美意識を宿します。</Text>
             </Stack>
-            <Flex my-s="auto" jc="center" bd bdc="line" p="10" bdrs="20" setTransition hov="to:reverse">
+            <Flex my-s="auto" jc="center" bd bdc="line" p="10" bdrs="20" set="transition" hov="to:reverse">
               <Text fz="s">View Detail</Text>
             </Flex>
           </LinkBox>
-          <LinkBox layout="grid" gtr="subgrid" gr="span 3" setHov g="30" href="#">
+          <LinkBox layout="grid" gtr="subgrid" gr="span 3" set="hov" g="30" href="#">
             <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
-              <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" setTransition hov="to:zoom" />
+              <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" set="transition" hov="to:zoom" />
             </Frame>
             <Stack g="20">
               <Text class="u--trim" fz="m" fw="bold">美容健康</Text>
               <Text class="u--trim" fz="s" o="-10">自分を慈しむ時間を、もっと豊かに。毎日のセルフケアを、心地よい体験へと変える。</Text>
             </Stack>
-            <Flex my-s="auto" jc="center" bd bdc="line" p="10" bdrs="20" setTransition hov="to:reverse">
+            <Flex my-s="auto" jc="center" bd bdc="line" p="10" bdrs="20" set="transition" hov="to:reverse">
               <Text fz="s">View Detail</Text>
             </Flex>
           </LinkBox>

--- a/apps/docs/src/pages/preview/templates/feature/feature014/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature014/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature014">
-  <Container isWrapper="l" bgc="base-2" py="50" setGutter>
+  <Container isWrapper="l" bgc="base-2" py="50" set="gutter">
     <Stack g="50">
       <Stack ai="center" g="30">
         <Text class="u--trim" fz="4xl" fw="light" lts="l">Feature</Text>
@@ -16,7 +16,7 @@ import './_style.css';
       <Grid gt="repeat" cols={['1', null, '3']}>
         <Grid gtr="subgrid" gr="span 3" ji="c" g="30" p={['40', null, '0 40']}>
           <Frame as="figure" ar="1/1" w="10rem" bdrs="99">
-            <Media src="https://cdn.lism-css.com/random/img?category=v&r=1" alt="" width="960" height="640" setTransition hov="to:zoom" />
+            <Media src="https://cdn.lism-css.com/random/img?category=v&r=1" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           </Frame>
           <Stack g="30">
             <Text class="u--trim" fz="l" fw="bold" ta="center">アクアマリン</Text>
@@ -35,7 +35,7 @@ import './_style.css';
               w="stretch"
               p="20 30"
               bdrs="99"
-              setTransition
+              set="transition"
               hov="reverse"
             >
               <Inline gc="2">View More</Inline>
@@ -45,7 +45,7 @@ import './_style.css';
         </Grid>
         <Grid gtr="subgrid" gr="span 3" ji="c" g="30" p={['40', null, '0 40']} bd bdw={['1px 0 0 0', null, '0 0 0 1px']} bdc="white">
           <Frame as="figure" ar="1/1" w="10rem" bdrs="99">
-            <Media src="https://cdn.lism-css.com/random/img?category=v&r=2" alt="" width="960" height="640" setTransition hov="to:zoom" />
+            <Media src="https://cdn.lism-css.com/random/img?category=v&r=2" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           </Frame>
           <Stack g="30">
             <Text class="u--trim" fz="l" fw="bold" ta="center">ローズクォーツ</Text>
@@ -64,7 +64,7 @@ import './_style.css';
               w="stretch"
               p="20 30"
               bdrs="99"
-              setTransition
+              set="transition"
               hov="reverse"
             >
               <Inline gc="2">View More</Inline>
@@ -74,7 +74,7 @@ import './_style.css';
         </Grid>
         <Grid gtr="subgrid" gr="span 3" ji="c" g="30" p={['40', null, '0 40']} bd bdw={['1px 0 0 0', null, '0 0 0 1px']} bdc="white">
           <Frame as="figure" ar="1/1" w="10rem" bdrs="99">
-            <Media src="https://cdn.lism-css.com/random/img?category=v&r=3" alt="" width="960" height="640" setTransition hov="to:zoom" />
+            <Media src="https://cdn.lism-css.com/random/img?category=v&r=3" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           </Frame>
           <Stack g="30">
             <Text class="u--trim" fz="l" fw="bold" ta="center">ムーンストーン</Text>
@@ -93,7 +93,7 @@ import './_style.css';
               w="stretch"
               p="20 30"
               bdrs="99"
-              setTransition
+              set="transition"
               hov="reverse"
             >
               <Inline gc="2">View More</Inline>

--- a/apps/docs/src/pages/preview/templates/feature/feature015/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature015/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature015">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Stack g="20" ai="center" mb="40">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold">こだわりの品質</Heading>
       <Text class="u--trim" fz="s" ta="center" o="-20">Product Features</Text>

--- a/apps/docs/src/pages/preview/templates/feature/feature016/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature016/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Feature016">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Grid gtc={['auto', null, 'minmax(20rem, 1fr) 2fr']} g={['40', '50']} bgc="base-2" p={['50 40', '50']} bdrs="20">
       <Stack gr="1" g="40">
         <Stack g="30">

--- a/apps/docs/src/pages/preview/templates/greeting/greeting001/index.astro
+++ b/apps/docs/src/pages/preview/templates/greeting/greeting001/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Greeting001">
-  <Container isWrapper="m" py="50" bgc="base" setGutter>
+  <Container isWrapper="m" py="50" bgc="base" set="gutter">
     <Stack g="50">
       <Heading level="2" fz="3xl" fw="bold" ff="accent" ta="center">代表からご挨拶</Heading>
       <Grid gtc={['auto', null, '1fr 1fr']} g="50">

--- a/apps/docs/src/pages/preview/templates/greeting/greeting002/index.astro
+++ b/apps/docs/src/pages/preview/templates/greeting/greeting002/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Greeting002">
-  <Wrapper contentSize="l" py="50" bgc="base" setGutter>
+  <Wrapper contentSize="l" py="50" bgc="base" set="gutter">
     <Stack g="50">
       <Stack class="u--trimChildren" g="40">
         <Inline fz="min(22vw, 10rem)" fw="bold" ff="accent" mx-s="-.5rem" c="gray" o="-30" whspace="nowrap">Greeting</Inline>

--- a/apps/docs/src/pages/preview/templates/greeting/greeting003/index.astro
+++ b/apps/docs/src/pages/preview/templates/greeting/greeting003/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Greeting003">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Grid gtc={['auto', null, 'auto 1fr']} g="50 60">
       <Frame ar="5/2" gc="1 / -1" pos="relative">
         <Media src="https://cdn.lism-css.com/random/img" alt="" width="960" height="640" />

--- a/apps/docs/src/pages/preview/templates/greeting/greeting004/index.astro
+++ b/apps/docs/src/pages/preview/templates/greeting/greeting004/index.astro
@@ -15,7 +15,7 @@ import './_style.css';
         </Center>
       </Layer>
     </Frame>
-    <Wrapper contentSize="m" py="50" my-s="-8rem" pos="relative" setGutter>
+    <Wrapper contentSize="m" py="50" my-s="-8rem" pos="relative" set="gutter">
       <Grid gtc="auto" g="40" bgc="white" p={['40', '50']}>
         <Stack g="30">
           <Heading level="2" class="u--trim" fz="3xl" fw="bold" ff="accent">地球と共生する、日常を未来へ</Heading>

--- a/apps/docs/src/pages/preview/templates/works/works001/index.astro
+++ b/apps/docs/src/pages/preview/templates/works/works001/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Works001">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Stack g="40">
       <Stack g="20">
         <Heading level="2" class="u--trim" fz="3xl" fw="bold">制作実績</Heading>
@@ -23,10 +23,10 @@ import './_style.css';
       </Cluster>
       <FluidCols cols="20rem" g="40" ac="start">
         <Grid gtr="subgrid" gr="span 2" g="30" ai="start">
-          <Stack as="a" isLinkBox href="#" g="30" setHov>
+          <Stack as="a" isLinkBox href="#" g="30" set="hov">
             <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
               <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -41,10 +41,10 @@ import './_style.css';
           </Cluster>
         </Grid>
         <Grid gtr="subgrid" gr="span 2" g="30" ai="start" ai="start">
-          <Stack as="a" isLinkBox href="#" g="30" setHov>
+          <Stack as="a" isLinkBox href="#" g="30" set="hov">
             <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
               <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -58,10 +58,10 @@ import './_style.css';
           </Cluster>
         </Grid>
         <Grid gtr="subgrid" gr="span 2" g="30" ai="start">
-          <Stack as="a" isLinkBox href="#" g="30" setHov>
+          <Stack as="a" isLinkBox href="#" g="30" set="hov">
             <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
               <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -76,10 +76,10 @@ import './_style.css';
           </Cluster>
         </Grid>
         <Grid gtr="subgrid" gr="span 2" g="30" ai="start">
-          <Stack as="a" isLinkBox href="#" g="30" setHov>
+          <Stack as="a" isLinkBox href="#" g="30" set="hov">
             <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
               <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -94,10 +94,10 @@ import './_style.css';
           </Cluster>
         </Grid>
         <Grid gtr="subgrid" gr="span 2" g="30" ai="start">
-          <Stack as="a" isLinkBox href="#" g="30" setHov>
+          <Stack as="a" isLinkBox href="#" g="30" set="hov">
             <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
               <Media src="https://cdn.lism-css.com/random/img?r=5" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -111,10 +111,10 @@ import './_style.css';
           </Cluster>
         </Grid>
         <Grid gtr="subgrid" gr="span 2" g="30" ai="start">
-          <Stack as="a" isLinkBox href="#" g="30" setHov>
+          <Stack as="a" isLinkBox href="#" g="30" set="hov">
             <Frame as="figure" ar="16/9" bdrs="20" pos="relative">
               <Media src="https://cdn.lism-css.com/random/img?r=6" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>

--- a/apps/docs/src/pages/preview/templates/works/works002/index.astro
+++ b/apps/docs/src/pages/preview/templates/works/works002/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Works002">
-  <Container isWrapper="l" py="50" bgc="base-2" setGutter>
+  <Container isWrapper="l" py="50" bgc="base-2" set="gutter">
     <Stack g="40">
       <Stack ai="center" g="30">
         <Heading level="2" class="u--trim" fz="4xl" fw="light" lts="l">Works</Heading>
@@ -22,11 +22,11 @@ import './_style.css';
         <Button href="####" bgc="base" c="text" px="20" py="10" bdrs="99">音楽</Button>
       </Cluster>
       <FluidCols cols="20rem" g="30">
-        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" setTransition hov="bxsh">
-          <Stack as="a" isLinkBox href="#" g="30" setHov p="20">
+        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" set="transition" hov="bxsh">
+          <Stack as="a" isLinkBox href="#" g="30" set="hov" p="20">
             <Frame as="figure" ar="16/9" pos="relative" bdrs="inner">
               <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -46,11 +46,11 @@ import './_style.css';
             <Button href="####" bgc="base-2" c="text" fz="s" px="15" py="5" bdrs="99">動画</Button>
           </Cluster>
         </Grid>
-        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" setTransition hov="bxsh">
-          <Stack as="a" isLinkBox href="#" g="30" setHov p="20">
+        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" set="transition" hov="bxsh">
+          <Stack as="a" isLinkBox href="#" g="30" set="hov" p="20">
             <Frame as="figure" ar="16/9" pos="relative" bdrs="inner">
               <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -69,11 +69,11 @@ import './_style.css';
             <Button href="####" bgc="base-2" c="text" fz="s" px="15" py="5" bdrs="99">動画</Button>
           </Cluster>
         </Grid>
-        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" setTransition hov="bxsh">
-          <Stack as="a" isLinkBox href="#" g="30" setHov p="20">
+        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" set="transition" hov="bxsh">
+          <Stack as="a" isLinkBox href="#" g="30" set="hov" p="20">
             <Frame as="figure" ar="16/9" pos="relative" bdrs="inner">
               <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -93,11 +93,11 @@ import './_style.css';
             <Button href="####" bgc="base-2" c="text" fz="s" px="15" py="5" bdrs="99">音楽</Button>
           </Cluster>
         </Grid>
-        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" setTransition hov="bxsh">
-          <Stack as="a" isLinkBox href="#" g="30" setHov p="20">
+        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" set="transition" hov="bxsh">
+          <Stack as="a" isLinkBox href="#" g="30" set="hov" p="20">
             <Frame as="figure" ar="16/9" pos="relative" bdrs="inner">
               <Media src="https://cdn.lism-css.com/random/img?r=4" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -117,11 +117,11 @@ import './_style.css';
             <Button href="####" bgc="base-2" c="text" fz="s" px="15" py="5" bdrs="99">音楽</Button>
           </Cluster>
         </Grid>
-        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" setTransition hov="bxsh">
-          <Stack as="a" isLinkBox href="#" g="30" setHov p="20">
+        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" set="transition" hov="bxsh">
+          <Stack as="a" isLinkBox href="#" g="30" set="hov" p="20">
             <Frame as="figure" ar="16/9" pos="relative" bdrs="inner">
               <Media src="https://cdn.lism-css.com/random/img?r=5" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -140,11 +140,11 @@ import './_style.css';
             <Button href="####" bgc="base-2" c="text" fz="s" px="15" py="5" bdrs="99">ブランディング</Button>
           </Cluster>
         </Grid>
-        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" setTransition hov="bxsh">
-          <Stack as="a" isLinkBox href="#" g="30" setHov p="20">
+        <Grid class="set--innerRs" gtr="subgrid" gr="span 2" g="20" bgc="base" bdrs="20" ai="start" set="transition" hov="bxsh">
+          <Stack as="a" isLinkBox href="#" g="30" set="hov" p="20">
             <Frame as="figure" ar="16/9" pos="relative" bdrs="inner">
               <Media src="https://cdn.lism-css.com/random/img?r=6" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>


### PR DESCRIPTION
## Summary
- `apps/docs/src/pages/preview/templates/` 配下の feature/cta/greeting/works テンプレート（26ファイル）で `setXxxx` props を `set` prop に変換
- 単一の `setXxxx` は `set="value"` (文字列)、複数の `setXxxx` は `set={["value1", "value2"]}` (配列) に統一
- 対象: `setGutter`, `setHov`, `setTransition`, `setShadow`, `setPlain`, `setInnerRs`, `setBp` (実際に使用されていたのは `setGutter`, `setHov`, `setTransition`)

Closes #191 (前半グループ)

## Test plan
- [x] `rg 'set(Gutter|Shadow|Hov|Transition|Plain|InnerRs|Bp|Mask)'` で対象ディレクトリ内にヒットなしを確認
- [x] `isXxxx` props は変更なし
- [x] `hov` prop は変更なし
- [x] `class="set--innerRs"` 等の CSS クラスは変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)