### PR TITLE
refactor(docs): テンプレート後半(section/nav/news等) setXxxx → set prop (#191)

### DIFF
--- a/apps/docs/src/pages/preview/templates/history/history001/index.astro
+++ b/apps/docs/src/pages/preview/templates/history/history001/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="History001">
-  <Container isWrapper="m" bgc="base" py="50" setGutter>
+  <Container isWrapper="m" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="3xl" fw="bold" ff="accent" ta="center">私たちの歩み</Heading>
       <Stack bd-l g="40">

--- a/apps/docs/src/pages/preview/templates/history/history002/index.astro
+++ b/apps/docs/src/pages/preview/templates/history/history002/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="History002">
-  <Container isWrapper="m" bgc="base" py="50" setGutter>
+  <Container isWrapper="m" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="3xl" fw="bold" ff="accent" ta="center">ここに歴史を記す</Heading>
       <Stack bd-y-s>

--- a/apps/docs/src/pages/preview/templates/information/information001/index.astro
+++ b/apps/docs/src/pages/preview/templates/information/information001/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Information001">
-  <Wrapper bgc="base" py="50" setGutter>
+  <Wrapper bgc="base" py="50" set="gutter">
     <Stack g="40">
       <Stack g="20" ai="center">
         <h2 class="u--trim">会社情報</h2>

--- a/apps/docs/src/pages/preview/templates/information/information002/index.astro
+++ b/apps/docs/src/pages/preview/templates/information/information002/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Information002">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Stack g="20" ai="center" mb="40">
       <h2 class="u--trim">会社情報</h2>
       <Text class="u--trim" fz="s" ta="center" o="-30">Company Information</Text>

--- a/apps/docs/src/pages/preview/templates/information/information003/index.astro
+++ b/apps/docs/src/pages/preview/templates/information/information003/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Information003">
-  <Container isWrapper="m" bgc="base" py="50" setGutter>
+  <Container isWrapper="m" bgc="base" py="50" set="gutter">
     <Stack g="20" ai="center" mb="40">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold">店舗一覧</Heading>
       <Text class="u--trim" fz="s" ta="center" o="-20">Shop List</Text>

--- a/apps/docs/src/pages/preview/templates/information/information004/index.astro
+++ b/apps/docs/src/pages/preview/templates/information/information004/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Information004">
-  <Container isWrapper="m" bgc="base" py="50" setGutter>
+  <Container isWrapper="m" bgc="base" py="50" set="gutter">
     <Stack g="20" ai="center" mb="40">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold">オフィス</Heading>
       <Text class="u--trim" fz="s" ta="center" o="-20">All Offices</Text>

--- a/apps/docs/src/pages/preview/templates/member/member001/index.astro
+++ b/apps/docs/src/pages/preview/templates/member/member001/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Member001">
-  <Container isWrapper="m" bgc="base" py="50" setGutter>
+  <Container isWrapper="m" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">スタッフ</Heading>
       <FluidCols cols="10rem" g={['40', '50']}>

--- a/apps/docs/src/pages/preview/templates/member/member002/index.astro
+++ b/apps/docs/src/pages/preview/templates/member/member002/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Member002">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">社員一覧</Heading>
       <FluidCols cols="14rem" g="40">

--- a/apps/docs/src/pages/preview/templates/member/member003/index.astro
+++ b/apps/docs/src/pages/preview/templates/member/member003/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Member003">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="4xl" fw="500" ff="accent" lts="l" ta="center">Member</Heading>
       <Grid gtc="repeat(auto-fit, minmax(10rem, 1fr))" g="40">

--- a/apps/docs/src/pages/preview/templates/member/member004/index.astro
+++ b/apps/docs/src/pages/preview/templates/member/member004/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Member004">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="3xl" fw="normal" ta="center" lts="l">Staff Introduction</Heading>
       <Grid gtc="repeat(auto-fit, minmax(14rem, 1fr))" g="40">

--- a/apps/docs/src/pages/preview/templates/member/member005/index.astro
+++ b/apps/docs/src/pages/preview/templates/member/member005/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Member005">
-  <Container isWrapper="l" bgc="base-2" py="50" setGutter>
+  <Container isWrapper="l" bgc="base-2" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="5xl" fw="bold" ff="accent" fs="i" c="gray" ta="center" lts="l">Fellow</Heading>
       <Grid gtc="repeat(auto-fit, minmax(14rem, 1fr))" g="40">

--- a/apps/docs/src/pages/preview/templates/member/member006/index.astro
+++ b/apps/docs/src/pages/preview/templates/member/member006/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Member006">
-  <Container isWrapper="l" bgc="base-2" py="50" setGutter>
+  <Container isWrapper="l" bgc="base-2" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="4xl" fw="500" c="gray" ta="center" lts="l">Team</Heading>
       <Grid gt="repeat" cols={['1', null, '2']} g="40">

--- a/apps/docs/src/pages/preview/templates/navigation/navigation001/index.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation001/index.astro
@@ -6,54 +6,54 @@ import './_style.css';
 ---
 
 <DemoLayout title="Navigation001">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">製品カテゴリー</Heading>
       <Grid gtc="repeat(auto-fit, minmax(250px, 1fr))" g-x="40" pt="1px">
-        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y setHov>
-          <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">キッチン家電</Text>
+        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y set="hov">
+          <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">キッチン家電</Text>
           <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
             <Icon icon="caret-right" fz="xs" c="white" />
           </Flex>
         </LinkBox>
-        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y setHov>
-          <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">オーディオ</Text>
+        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y set="hov">
+          <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">オーディオ</Text>
           <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
             <Icon icon="caret-right" fz="xs" c="white" />
           </Flex>
         </LinkBox>
-        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y setHov>
-          <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">生活家電</Text>
+        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y set="hov">
+          <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">生活家電</Text>
           <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
             <Icon icon="caret-right" fz="xs" c="white" />
           </Flex>
         </LinkBox>
-        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y setHov>
-          <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">冷蔵庫</Text>
+        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y set="hov">
+          <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">冷蔵庫</Text>
           <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
             <Icon icon="caret-right" fz="xs" c="white" />
           </Flex>
         </LinkBox>
-        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y setHov>
-          <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">洗濯機・衣類ケア</Text>
+        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y set="hov">
+          <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">洗濯機・衣類ケア</Text>
           <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
             <Icon icon="caret-right" fz="xs" c="white" />
           </Flex>
         </LinkBox>
-        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y setHov>
-          <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">美容</Text>
+        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y set="hov">
+          <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">美容</Text>
           <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
             <Icon icon="caret-right" fz="xs" c="white" />
           </Flex>
         </LinkBox>
-        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y setHov>
-          <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">照明器具</Text>
+        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y set="hov">
+          <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">照明器具</Text>
           <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
             <Icon icon="caret-right" fz="xs" c="white" />
           </Flex>
         </LinkBox>
-        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y setHov>
-          <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">パソコン・周辺機器</Text>
+        <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" py="30" px="10" mt="-1px" bd-y set="hov">
+          <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">パソコン・周辺機器</Text>
           <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
             <Icon icon="caret-right" fz="xs" c="white" />
           </Flex>

--- a/apps/docs/src/pages/preview/templates/navigation/navigation002/index.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation002/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Navigation002">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Grid gtc={['auto', null, 'auto 1fr']} g="50 60">
       <Stack ai="flex-s" g="30">
         <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">製品カテゴリー</Heading>
@@ -14,57 +14,57 @@ import './_style.css';
       </Stack>
       <Stack g="40">
         <FluidCols cols="16rem" g="0 40" pt="1px">
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y setHov>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">キッチン家電</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y set="hov">
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">キッチン家電</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
               <Icon icon="caret-right" fz="xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y setHov>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">オーディオ</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y set="hov">
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">オーディオ</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
               <Icon icon="caret-right" fz="xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y setHov>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">生活家電</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y set="hov">
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">生活家電</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
               <Icon icon="caret-right" fz="xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y setHov>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">冷蔵庫</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y set="hov">
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">冷蔵庫</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
               <Icon icon="caret-right" fz="xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y setHov>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">洗濯機・衣類ケア</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y set="hov">
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">洗濯機・衣類ケア</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
               <Icon icon="caret-right" fz="xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y setHov>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">美容</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y set="hov">
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">美容</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
               <Icon icon="caret-right" fz="xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y setHov>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">照明器具</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y set="hov">
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">照明器具</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
               <Icon icon="caret-right" fz="xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y setHov>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">パソコン・周辺機器</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="40 10" mt="-1px" bd-y set="hov">
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">パソコン・周辺機器</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="5">
               <Icon icon="caret-right" fz="xs" c="white" />
             </Flex>
           </LinkBox>
         </FluidCols>
         <Flex jc="flex-e">
-          <LinkBox href="#" layout="flex" ai="center" g="10" setTransition hov={{ c: 'link' }}>
+          <LinkBox href="#" layout="flex" ai="center" g="10" set="transition" hov={{ c: 'link' }}>
             <Text class="u--trim">全てのカテゴリーを見る</Text>
             <Icon icon="arrow-right" />
           </LinkBox>

--- a/apps/docs/src/pages/preview/templates/navigation/navigation003/index.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation003/index.astro
@@ -6,62 +6,62 @@ import './_style.css';
 ---
 
 <DemoLayout title="Navigation003">
-  <Container isWrapper="l" bgc="base-2" py="50" setGutter>
+  <Container isWrapper="l" bgc="base-2" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">製品カテゴリー</Heading>
       <Stack g="50">
         <FluidCols cols="18rem" g="30">
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">キッチン家電</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">キッチン家電</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
               <Icon icon="arrow-right" fz="2xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">オーディオ</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">オーディオ</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
               <Icon icon="arrow-right" fz="2xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">生活家電</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">生活家電</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
               <Icon icon="arrow-right" fz="2xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">冷蔵庫</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">冷蔵庫</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
               <Icon icon="arrow-right" fz="2xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">洗濯機・衣類ケア</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">洗濯機・衣類ケア</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
               <Icon icon="arrow-right" fz="2xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">美容</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">美容</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
               <Icon icon="arrow-right" fz="2xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">照明器具</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">照明器具</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
               <Icon icon="arrow-right" fz="2xs" c="white" />
             </Flex>
           </LinkBox>
-          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
-            <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">パソコン・周辺機器</Text>
+          <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="30" bd bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
+            <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">パソコン・周辺機器</Text>
             <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
               <Icon icon="arrow-right" fz="2xs" c="white" />
             </Flex>
           </LinkBox>
         </FluidCols>
         <Flex jc="flex-e">
-          <LinkBox href="#" layout="flex" ai="center" g="10" setTransition hov={{ c: 'link' }}>
+          <LinkBox href="#" layout="flex" ai="center" g="10" set="transition" hov={{ c: 'link' }}>
             <Text class="u--trim">全てのカテゴリーを見る</Text>
             <Icon icon="arrow-right" />
           </LinkBox>

--- a/apps/docs/src/pages/preview/templates/navigation/navigation004/index.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation004/index.astro
@@ -13,7 +13,7 @@ import './_style.css';
         <Layer bgc="black:30%" />
       </Frame>
     </Layer>
-    <Container isWrapper="l" gr="1" gc="1" py="50" setGutter pos="rel">
+    <Container isWrapper="l" gr="1" gc="1" py="50" set="gutter" pos="rel">
       <Stack g="40">
         <Stack g="30" ai="flex-s" c="white">
           <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">製品カテゴリー</Heading>
@@ -24,72 +24,72 @@ import './_style.css';
         </Stack>
         <Stack g="50">
           <Grid gtc="repeat(auto-fit, minmax(250px, 1fr))" g="30">
-            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
+            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
               <Stack jc="center" g="15">
-                <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">洗濯機・衣類ケア</Text>
+                <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">洗濯機・衣類ケア</Text>
                 <Text class="u--trim" fz="xs" o="-20">LAUNDRY</Text>
               </Stack>
               <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
                 <Icon icon="caret-right" fz="2xs" c="white" />
               </Flex>
             </LinkBox>
-            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
+            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
               <Stack jc="center" g="15">
-                <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">掃除機</Text>
+                <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">掃除機</Text>
                 <Text class="u--trim" fz="xs" o="-20">CLEANING</Text>
               </Stack>
               <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
                 <Icon icon="caret-right" fz="2xs" c="white" />
               </Flex>
             </LinkBox>
-            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
+            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
               <Stack jc="center" g="15">
-                <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">オーディオ</Text>
+                <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">オーディオ</Text>
                 <Text class="u--trim" fz="xs" o="-20">AUDIO</Text>
               </Stack>
               <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
                 <Icon icon="caret-right" fz="2xs" c="white" />
               </Flex>
             </LinkBox>
-            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
+            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
               <Stack jc="center" g="15">
-                <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">美容・健康家電</Text>
+                <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">美容・健康家電</Text>
                 <Text class="u--trim" fz="xs" o="-20">BEAUTY & HEALTH</Text>
               </Stack>
               <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
                 <Icon icon="caret-right" fz="2xs" c="white" />
               </Flex>
             </LinkBox>
-            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
+            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
               <Stack jc="center" g="15">
-                <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">照明</Text>
+                <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">照明</Text>
                 <Text class="u--trim" fz="xs" o="-20">LIGHTING</Text>
               </Stack>
               <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
                 <Icon icon="caret-right" fz="2xs" c="white" />
               </Flex>
             </LinkBox>
-            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
+            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
               <Stack jc="center" g="15">
-                <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">スマートホーム</Text>
+                <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">スマートホーム</Text>
                 <Text class="u--trim" fz="xs" o="-20">SMART HOME</Text>
               </Stack>
               <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
                 <Icon icon="caret-right" fz="2xs" c="white" />
               </Flex>
             </LinkBox>
-            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
+            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
               <Stack jc="center" g="15">
-                <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">キッチン</Text>
+                <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">キッチン</Text>
                 <Text class="u--trim" fz="xs" o="-20">KITCHEN</Text>
               </Stack>
               <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">
                 <Icon icon="caret-right" fz="2xs" c="white" />
               </Flex>
             </LinkBox>
-            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" setTransition setHov hov={{ bxsh: '20' }}>
+            <LinkBox href="#" layout="flex" g="30" ai="center" jc="between" p="20" bgc="white" bdrs="10" set={["transition", "hov"]} hov={{ bxsh: '20' }}>
               <Stack jc="center" g="15">
-                <Text class="u--trim" fz="m" fw="bold" setTransition hov="to:cLink">空調・生活家電</Text>
+                <Text class="u--trim" fz="m" fw="bold" set="transition" hov="to:cLink">空調・生活家電</Text>
                 <Text class="u--trim" fz="xs" o="-20">LIVING & AIR</Text>
               </Stack>
               <Flex ai="center" jc="center" bgc="black" bdrs="99" p="10">

--- a/apps/docs/src/pages/preview/templates/navigation/navigation005/index.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation005/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Navigation005">
-  <Container isWrapper="l" bgc="base-2" py="50" setGutter>
+  <Container isWrapper="l" bgc="base-2" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="5xl" fw="bold" ff="accent" c="gray">Navigation</Heading>
       <Stack g="40">

--- a/apps/docs/src/pages/preview/templates/navigation/navigation006/index.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation006/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Navigation006">
-  <Container isWrapper="l" bgc="base-2" py="50" setGutter>
+  <Container isWrapper="l" bgc="base-2" py="50" set="gutter">
     <Grid gtr={['auto 1fr auto', null, '1fr auto auto 1fr']} gtc={['auto', null, 'minmax(14rem, auto) 1fr']} ai="center" g="40">
       <Stack gr={['1', null, '2']} gc="1" g="20">
         <Text class="u--trim" fz="3xl" fw="bold" ff="accent" c="gray">Navigation</Text>
@@ -96,7 +96,7 @@ import './_style.css';
         </LinkBox>
       </FluidCols>
       <Flex gr={['3', null, '3']} gc={['1', null, '1']} g="15">
-        <Button g="15" variant="outline" href="#" w={['stretch', null, 'auto']} bdrs="10" setTransition hov={{ bgc: 'black', c: 'white' }}>
+        <Button g="15" variant="outline" href="#" w={['stretch', null, 'auto']} bdrs="10" set="transition" hov={{ bgc: 'black', c: 'white' }}>
           <Inline gc="1" fz="s">View More</Inline>
           <Icon icon="arrow-right" gc="2" fz="80%" />
         </Button>

--- a/apps/docs/src/pages/preview/templates/navigation/navigation007/index.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation007/index.astro
@@ -8,13 +8,13 @@ import './_style.css';
 <DemoLayout title="Navigation007">
   <Container isWrapper="l" py="50">
     <Stack g="40">
-      <Stack ai="center" g="20" setGutter>
+      <Stack ai="center" g="20" set="gutter">
         <Heading level="2" class="u--trim" fz="2xl" fw="bold">素敵な旅がここに</Heading>
         <Inline class="u--trim" fz="s" o="-20">Good experience</Inline>
       </Stack>
       <FluidCols cols="22rem">
-        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" setHov>
-          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=1" alt="" width="960" height="640" setTransition hov="to:zoom" />
+        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" set="hov">
+          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=1" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           <Layer bgc="rgb(0 0 0 / 35%)" />
           <Stack pos="rel" h="100%" jc="fe" c="white" p="30" g="20" my-s="auto">
             <Grid gtc="1fr auto" ai="end" g="30">
@@ -22,14 +22,14 @@ import './_style.css';
                 <Text class="u--trim" fz="l" fw="bold" lh="s">こだわりの贅沢</Text>
                 <Text class="u--trim" fz="s" lh="s" o="-10">LUXURY TRAVEL</Text>
               </Stack>
-              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" setTransition hov="to:reverse">
+              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" set="transition" hov="to:reverse">
                 <Icon icon="arrow-right" fz="s" />
               </Flex>
             </Grid>
           </Stack>
         </LinkBox>
-        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" setHov>
-          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=2" alt="" width="960" height="640" setTransition hov="to:zoom" />
+        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" set="hov">
+          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=2" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           <Layer bgc="rgb(0 0 0 / 35%)" />
           <Stack pos="rel" h="100%" jc="fe" c="white" p="30" g="20" my-s="auto">
             <Grid gtc="1fr auto" ai="end" g="30">
@@ -37,14 +37,14 @@ import './_style.css';
                 <Text class="u--trim" fz="l" fw="bold" lh="s">自然と遊ぶ冒険</Text>
                 <Text class="u--trim" fz="s" lh="s" o="-10">ADVENTURE TRAVEL</Text>
               </Stack>
-              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" setTransition hov="to:reverse">
+              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" set="transition" hov="to:reverse">
                 <Icon icon="arrow-right" fz="s" />
               </Flex>
             </Grid>
           </Stack>
         </LinkBox>
-        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" setHov>
-          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=3" alt="" width="960" height="640" setTransition hov="to:zoom" />
+        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" set="hov">
+          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=3" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           <Layer bgc="rgb(0 0 0 / 35%)" />
           <Stack pos="rel" h="100%" jc="fe" c="white" p="30" g="20" my-s="auto">
             <Grid gtc="1fr auto" ai="end" g="30">
@@ -52,14 +52,14 @@ import './_style.css';
                 <Text class="u--trim" fz="l" fw="bold" lh="s">文化に触れる</Text>
                 <Text class="u--trim" fz="s" lh="s" o="-10">CULTURAL TOURS</Text>
               </Stack>
-              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" setTransition hov="to:reverse">
+              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" set="transition" hov="to:reverse">
                 <Icon icon="arrow-right" fz="s" />
               </Flex>
             </Grid>
           </Stack>
         </LinkBox>
-        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" setHov>
-          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=4" alt="" width="960" height="640" setTransition hov="to:zoom" />
+        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" set="hov">
+          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=4" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           <Layer bgc="rgb(0 0 0 / 35%)" />
           <Stack pos="rel" h="100%" jc="fe" c="white" p="30" g="20" my-s="auto">
             <Grid gtc="1fr auto" ai="end" g="30">
@@ -67,14 +67,14 @@ import './_style.css';
                 <Text class="u--trim" fz="l" fw="bold" lh="s">家族で楽しむ</Text>
                 <Text class="u--trim" fz="s" lh="s" o="-10">FAMILY TRIPS</Text>
               </Stack>
-              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" setTransition hov="to:reverse">
+              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" set="transition" hov="to:reverse">
                 <Icon icon="arrow-right" fz="s" />
               </Flex>
             </Grid>
           </Stack>
         </LinkBox>
-        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" setHov>
-          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=5" alt="" width="960" height="640" setTransition hov="to:zoom" />
+        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" set="hov">
+          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=5" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           <Layer bgc="rgb(0 0 0 / 35%)" />
           <Stack pos="rel" h="100%" jc="fe" c="white" p="30" g="20" my-s="auto">
             <Grid gtc="1fr auto" ai="end" g="30">
@@ -82,14 +82,14 @@ import './_style.css';
                 <Text class="u--trim" fz="l" fw="bold" lh="s">気ままにひとりで</Text>
                 <Text class="u--trim" fz="s" lh="s" o="-10">SOLO TRAVEL</Text>
               </Stack>
-              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" setTransition hov="to:reverse">
+              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" set="transition" hov="to:reverse">
                 <Icon icon="arrow-right" fz="s" />
               </Flex>
             </Grid>
           </Stack>
         </LinkBox>
-        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" setHov>
-          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=6" alt="" width="960" height="640" setTransition hov="to:zoom" />
+        <LinkBox layout="frame" href="#" pos="rel" ar="4/3" bxsh="30" set="hov">
+          <Media isLayer src="https://cdn.lism-css.com/random/img?category=v&r=6" alt="" width="960" height="640" set="transition" hov="to:zoom" />
           <Layer bgc="rgb(0 0 0 / 35%)" />
           <Stack pos="rel" h="100%" jc="fe" c="white" p="30" g="20" my-s="auto">
             <Grid gtc="1fr auto" ai="end" g="30">
@@ -97,7 +97,7 @@ import './_style.css';
                 <Text class="u--trim" fz="l" fw="bold" lh="s">心ととのえる</Text>
                 <Text class="u--trim" fz="s" lh="s" o="-10">WELLNESS RETREATS</Text>
               </Stack>
-              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" setTransition hov="to:reverse">
+              <Flex ai="center" jc="center" bd bdc="white" p="15" bdrs="99" set="transition" hov="to:reverse">
                 <Icon icon="arrow-right" fz="s" />
               </Flex>
             </Grid>

--- a/apps/docs/src/pages/preview/templates/navigation/navigation008/index.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation008/index.astro
@@ -8,7 +8,7 @@ import './_style.css';
 
 <DemoLayout title="Navigation008">
   <Grid gtr="auto" gtc={['auto', null, 'auto 1fr']} pos="rel">
-    <Container isWrapper="l" gr="1" gc="1" py="50" setGutter pos="rel" z="1">
+    <Container isWrapper="l" gr="1" gc="1" py="50" set="gutter" pos="rel" z="1">
       <Stack g="40">
         <Stack g="30" ai="fs" c="white">
           <Heading level="2" class="u--trim" fz="3xl" fw="bold" ta="center">募集職種</Heading>

--- a/apps/docs/src/pages/preview/templates/news/news001/index.astro
+++ b/apps/docs/src/pages/preview/templates/news/news001/index.astro
@@ -7,14 +7,14 @@ import './_style.css';
 ---
 
 <DemoLayout title="News001">
-  <Container isWrapper="m" py="50" setGutter>
+  <Container isWrapper="m" py="50" set="gutter">
     <Grid gtc={['1fr', 'auto 1fr']} g="40">
       <Box gr={['1', '1 / 2']} gc={['1', '1 / 2']}>
         <h2 class="u--trim">お知らせ</h2>
       </Box>
       <Box gr={['2', '2']} gc={['1', '1 / 3']}>
         <Grid gtc={['auto', 'auto 1fr']} className="u--collapseGrid" ov="clip" p="0" bd-y>
-          <Grid as="a" isLinkBox href="#" gtc="subgrid" gc="1 / -1" g={['20', '30']} py="30" setHov>
+          <Grid as="a" isLinkBox href="#" gtc="subgrid" gc="1 / -1" g={['20', '30']} py="30" set="hov">
             <Grid gtc={['auto auto', 'auto 1fr']} g="30" jc="start" ai="center">
               <Inline fz="s">2025.07.13</Inline>
               <Text d="in-flex" jc="center" fz="xs" lh="xs" c="text" bgc="white" bd p="10 20" bdrs="99">新サービス</Text>
@@ -24,7 +24,7 @@ import './_style.css';
               <Icon icon="arrow-right" fz="s" c="text" mx-s="auto" />
             </Flex>
           </Grid>
-          <Grid as="a" isLinkBox href="#" gtc="subgrid" gc="1 / -1" g={['20', '30']} py="30" setHov>
+          <Grid as="a" isLinkBox href="#" gtc="subgrid" gc="1 / -1" g={['20', '30']} py="30" set="hov">
             <Grid gtc={['auto auto', 'auto 1fr']} g="30" jc="start" ai="center">
               <Inline fz="s">2025.07.13</Inline>
               <Text d="in-flex" jc="center" fz="xs" lh="xs" c="white" bgc="text" p="10 20" bdrs="99">セキュリティ</Text>
@@ -34,7 +34,7 @@ import './_style.css';
               <Icon icon="arrow-right" fz="s" c="text" mx-s="auto" />
             </Flex>
           </Grid>
-          <Grid as="a" isLinkBox href="#" gtc="subgrid" gc="1 / -1" g={['20', '30']} py="30" setHov>
+          <Grid as="a" isLinkBox href="#" gtc="subgrid" gc="1 / -1" g={['20', '30']} py="30" set="hov">
             <Grid gtc={['auto auto', 'auto 1fr']} g="30" jc="start" ai="center">
               <Inline fz="s">2025.07.13</Inline>
               <Text d="in-flex" jc="center" bd bdc="accent" fz="xs" lh="xs" c="white" bgc="accent" p="10 20" bdrs="99">重要なお知らせ</Text>

--- a/apps/docs/src/pages/preview/templates/news/news002/index.astro
+++ b/apps/docs/src/pages/preview/templates/news/news002/index.astro
@@ -7,17 +7,17 @@ import './_style.css';
 ---
 
 <DemoLayout title="News002">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Grid gtc={['1fr', 'auto 1fr']} g="40">
       <Flex gr={['1', '1 / 2']} gc={['1', '1 / 2']} ai="flex-e" jc="flex-s">
         <h2>お知らせ</h2>
       </Flex>
       <Box gr="2" , gc={['1', '1 / 3']}>
         <Grid gtc={['1fr', 'repeat(auto-fit, minmax(300px, 1fr))']} gtr="auto auto" g="40">
-          <Grid as="a" gtr="subgrid" gr="span 2" g="0" isLinkBox href="#" bdrs="10" bxsh="20" ov="hidden" setHov setTransition hov="bxsh">
+          <Grid as="a" gtr="subgrid" gr="span 2" g="0" isLinkBox href="#" bdrs="10" bxsh="20" ov="hidden" set={["hov", "transition"]} hov="bxsh">
             <Frame as="figure" ar="og" pos="rel">
               <Media src="/img/img-5.jpg" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -34,10 +34,10 @@ import './_style.css';
               <Text className="u--trim" fz="m" o="-10">不正送金対策の強化に伴うワンタイムパスワードの仕様変更のお知らせ</Text>
             </Stack>
           </Grid>
-          <Grid as="a" gtr="subgrid" gr="span 2" g="0" isLinkBox href="#" bdrs="10" bxsh="20" ov="hidden" setHov setTransition hov="bxsh">
+          <Grid as="a" gtr="subgrid" gr="span 2" g="0" isLinkBox href="#" bdrs="10" bxsh="20" ov="hidden" set={["hov", "transition"]} hov="bxsh">
             <Frame as="figure" ar="og" pos="rel">
               <Media src="/img/img-4.jpg" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>
@@ -53,10 +53,10 @@ import './_style.css';
               <Text className="u--trim" fz="m" o="-10">2025年9月1日よりインターネットバンキングのサービス提供時間を24時間に拡大いたします</Text>
             </Stack>
           </Grid>
-          <Grid as="a" gtr="subgrid" gr="span 2" g="0" isLinkBox href="#" bdrs="10" bxsh="20" ov="hidden" setHov setTransition hov="bxsh">
+          <Grid as="a" gtr="subgrid" gr="span 2" g="0" isLinkBox href="#" bdrs="10" bxsh="20" ov="hidden" set={["hov", "transition"]} hov="bxsh">
             <Frame as="figure" ar="og" pos="rel">
               <Media src="/img/img-2.jpg" alt="" width="960" height="640" />
-              <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+              <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
                 <Center h="100%" c="white">
                   <Inline fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">View More</Inline>
                 </Center>

--- a/apps/docs/src/pages/preview/templates/news/news003/index.astro
+++ b/apps/docs/src/pages/preview/templates/news/news003/index.astro
@@ -7,39 +7,39 @@ import './_style.css';
 ---
 
 <DemoLayout title="News003">
-  <Container isWrapper="m" py="50" setGutter>
+  <Container isWrapper="m" py="50" set="gutter">
     <Grid gtr={['auto', null, 'auto auto 1fr']} gtc={['auto', null, 'auto 1fr']} g="30">
       <Stack gr="1" gc="1" g="20" min-w={['auto', null, '12rem']}>
         <Text class="u--trim" fz="3xl" fw="light" lts="l">News</Text>
         <Heading level="2" class="u--trim" fz="s" fw="normal" o="-20">お知らせ</Heading>
       </Stack>
       <Grid gr={['2', null, '1 / -1']} gc={['1', null, '2']} gtc={['auto', 'auto 1fr']} bd-y-s>
-        <Grid isLinkBox gtc="subgrid" gc="1 / -1" g={['20', '30']} bd-y-e py="30" setHov>
+        <Grid isLinkBox gtc="subgrid" gc="1 / -1" g={['20', '30']} bd-y-e py="30" set="hov">
           <Grid gtc={['auto auto', 'auto 1fr']} g="30" jc="start" ai="center">
             <Text fz="m">2025.07.13</Text>
             <Text d="if" jc="center" fz="xs" lh="xs" c="text" bgc="white" bd p="10 20" bdrs="99" ta="center">新サービス</Text>
           </Grid>
-          <Flex as="a" href="#" setPlain ai="center" td="n" g="30" hov="to:cLink">
+          <Flex as="a" href="#" set="plain" ai="center" td="n" g="30" hov="to:cLink">
             <Text>目標金額を設定して貯蓄ができる「目的別預金」が登場。楽しみながら計画的な資産形成が行えます。</Text>
             <Icon icon="caret-right" fz="s" c="text" mx-s="auto" />
           </Flex>
         </Grid>
-        <Grid isLinkBox gtc="subgrid" gc="1 / -1" g={['20', '30']} bd-y-e py="30" setHov>
+        <Grid isLinkBox gtc="subgrid" gc="1 / -1" g={['20', '30']} bd-y-e py="30" set="hov">
           <Grid gtc={['auto auto', 'auto 1fr']} g="30" jc="start" ai="center">
             <Text fz="m">2025.07.13</Text>
             <Text d="if" jc="center" fz="xs" lh="xs" c="text" bgc="white" bd p="10 20" bdrs="99" ta="center">セキュリティ</Text>
           </Grid>
-          <Flex as="a" href="#" setPlain ai="center" td="n" g="30" hov="to:cLink">
+          <Flex as="a" href="#" set="plain" ai="center" td="n" g="30" hov="to:cLink">
             <Text>当行を装った不審なメール（フィッシング詐欺）にご注意ください</Text>
             <Icon icon="caret-right" fz="s" c="text" mx-s="auto" />
           </Flex>
         </Grid>
-        <Grid isLinkBox gtc="subgrid" gc="1 / -1" g={['20', '30']} bd-y-e py="30" setHov>
+        <Grid isLinkBox gtc="subgrid" gc="1 / -1" g={['20', '30']} bd-y-e py="30" set="hov">
           <Grid gtc={['auto auto', 'auto 1fr']} g="30" jc="start" ai="center">
             <Text fz="m">2025.07.13</Text>
             <Text d="if" jc="center" fz="xs" lh="xs" c="text" bgc="white" bd p="10 20" bdrs="99" ta="center">重要なお知らせ</Text>
           </Grid>
-          <Flex as="a" href="#" setPlain ai="center" td="n" g="30" hov="to:cLink">
+          <Flex as="a" href="#" set="plain" ai="center" td="n" g="30" hov="to:cLink">
             <Text>インターネットバンキングサービス利用規定の一部改定について</Text>
             <Icon icon="caret-right" fz="s" c="text" mx-s="auto" />
           </Flex>

--- a/apps/docs/src/pages/preview/templates/news/news004/index.astro
+++ b/apps/docs/src/pages/preview/templates/news/news004/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="News004">
-  <Container isWrapper="m" bgc="base-2" py="50" setGutter>
+  <Container isWrapper="m" bgc="base-2" py="50" set="gutter">
     <Grid gtr={['auto', null, 'auto auto 1fr']} gtc={['auto', null, 'auto 1fr']} g="30">
       <Stack gr="1" gc="1" g="20" min-w={['auto', null, '12rem']}>
         <Text class="u--trim" fz="3xl" fw="light" lts="l">News</Text>
@@ -24,9 +24,7 @@ import './_style.css';
           bgc="white"
           p="30"
           bdrs="20"
-          setTransition
-          setHov
-          setTransition
+          set={["transition", "hov"]}
           hov="bxsh"
         >
           <Grid gtc={['auto auto', 'auto 1fr']} g="30" jc="start" ai="center">
@@ -34,8 +32,8 @@ import './_style.css';
             <Text d="if" jc="center" fz="xs" lh="xs" c="text" bd p="10 20" bdrs="99" ta="center">新サービス</Text>
           </Grid>
           <Flex ai="center" c="text" td="n" g="30">
-            <Text setTransition hov="to:cLink">目標金額を設定して貯蓄ができる「目的別預金」が登場。楽しみながら計画的な資産形成が行えます。</Text>
-            <Flex ai="center" jc="center" p="15" bd bdc="text" bdrs="99" setTransition hov="to:reverse">
+            <Text set="transition" hov="to:cLink">目標金額を設定して貯蓄ができる「目的別預金」が登場。楽しみながら計画的な資産形成が行えます。</Text>
+            <Flex ai="center" jc="center" p="15" bd bdc="text" bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="caret-right" fz="xs" mx-s="auto" />
             </Flex>
           </Flex>
@@ -50,9 +48,7 @@ import './_style.css';
           bgc="white"
           p="30"
           bdrs="20"
-          setTransition
-          setHov
-          setTransition
+          set={["transition", "hov"]}
           hov="bxsh"
         >
           <Grid gtc={['auto auto', 'auto 1fr']} g="30" jc="start" ai="center">
@@ -60,8 +56,8 @@ import './_style.css';
             <Text d="if" jc="center" fz="xs" lh="xs" c="text" bd p="10 20" bdrs="99" ta="center">セキュリティ</Text>
           </Grid>
           <Flex ai="center" c="text" td="n" g="30">
-            <Text setTransition hov="to:cLink">当行を装った不審なメール（フィッシング詐欺）にご注意ください。</Text>
-            <Flex ai="center" jc="center" p="15" bd bdc="text" bdrs="99" setTransition hov="to:reverse">
+            <Text set="transition" hov="to:cLink">当行を装った不審なメール（フィッシング詐欺）にご注意ください。</Text>
+            <Flex ai="center" jc="center" p="15" bd bdc="text" bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="caret-right" fz="xs" mx-s="auto" />
             </Flex>
           </Flex>
@@ -76,9 +72,7 @@ import './_style.css';
           bgc="white"
           p="30"
           bdrs="20"
-          setTransition
-          setHov
-          setTransition
+          set={["transition", "hov"]}
           hov="bxsh"
         >
           <Grid gtc={['auto auto', 'auto 1fr']} g="30" jc="start" ai="center">
@@ -86,8 +80,8 @@ import './_style.css';
             <Text d="if" jc="center" fz="xs" lh="xs" c="text" bd p="10 20" bdrs="99" ta="center">重要なお知らせ</Text>
           </Grid>
           <Flex ai="center" c="text" td="n" g="30">
-            <Text setTransition hov="to:cLink">インターネットバンキングサービス利用規定の一部改定について</Text>
-            <Flex ai="center" jc="center" p="15" bd bdc="text" bdrs="99" setTransition hov="to:reverse">
+            <Text set="transition" hov="to:cLink">インターネットバンキングサービス利用規定の一部改定について</Text>
+            <Flex ai="center" jc="center" p="15" bd bdc="text" bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="caret-right" fz="xs" mx-s="auto" />
             </Flex>
           </Flex>

--- a/apps/docs/src/pages/preview/templates/news/news005/index.astro
+++ b/apps/docs/src/pages/preview/templates/news/news005/index.astro
@@ -7,16 +7,16 @@ import './_style.css';
 ---
 
 <DemoLayout title="News005">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Grid gtc={['1fr', 'auto 1fr']} g="40">
       <Flex gr={['1', '1 / 2']} gc={['1', '1 / 2']} ai="fe" jc="fs">
         <Heading level="2" fz="2xl" fw="bold">ニュース</Heading>
       </Flex>
       <Columns cols={['1', '2', '4']} gr="2" gc={['1', '1 / 3']} g="30">
-        <Grid as="a" gtr="subgrid" gr="span 2" g="5" isLinkBox href="#" ov="h" setHov>
+        <Grid as="a" gtr="subgrid" gr="span 2" g="5" isLinkBox href="#" ov="h" set="hov">
           <Frame as="figure" ar="og" pos="rel" bdrs="10">
             <Media src="https://cdn.lism-css.com/random/img?category=working&r=1" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="l" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -32,10 +32,10 @@ import './_style.css';
             <Text className="u--trimHL" fz="m">年末年始休業のお知らせ（2025/12/28〜2026/1/4）</Text>
           </Stack>
         </Grid>
-        <Grid as="a" gtr="subgrid" gr="span 2" g="5" isLinkBox href="#" ov="h" setHov>
+        <Grid as="a" gtr="subgrid" gr="span 2" g="5" isLinkBox href="#" ov="h" set="hov">
           <Frame as="figure" ar="og" pos="rel" bdrs="10">
             <Media src="https://cdn.lism-css.com/random/img?category=working&r=2" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="l" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -51,10 +51,10 @@ import './_style.css';
             <Text className="u--trimHL" fz="m">当社制作の「〇〇」が、国際的デザインアワード「ABC Design Award」を受賞しました</Text>
           </Stack>
         </Grid>
-        <Grid as="a" gtr="subgrid" gr="span 2" g="5" isLinkBox href="#" ov="h" setHov>
+        <Grid as="a" gtr="subgrid" gr="span 2" g="5" isLinkBox href="#" ov="h" set="hov">
           <Frame as="figure" ar="og" pos="rel" bdrs="10">
             <Media src="https://cdn.lism-css.com/random/img?category=working&r=3" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="l" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>
@@ -70,10 +70,10 @@ import './_style.css';
             <Text className="u--trimHL" fz="m">デザイン専門誌「Design Today」11月号に、弊社代表のインタビューが掲載されました</Text>
           </Stack>
         </Grid>
-        <Grid as="a" gtr="subgrid" gr="span 2" g="5" isLinkBox href="#" ov="h" setHov>
+        <Grid as="a" gtr="subgrid" gr="span 2" g="5" isLinkBox href="#" ov="h" set="hov">
           <Frame as="figure" ar="og" pos="rel" bdrs="10">
             <Media src="https://cdn.lism-css.com/random/img?category=working&r=4" alt="" width="960" height="640" />
-            <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
+            <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 30%)" style={{ backdropFilter: 'blur(4px)' }}>
               <Center h="100%" c="white">
                 <Inline fz="l" fs="i" fw="light" lts="l" px="20" py="10">View More</Inline>
               </Center>

--- a/apps/docs/src/pages/preview/templates/news/news006/index.astro
+++ b/apps/docs/src/pages/preview/templates/news/news006/index.astro
@@ -7,79 +7,79 @@ import './_style.css';
 ---
 
 <DemoLayout title="News006">
-  <Container isWrapper="l" bgc="base-2" py="50" setGutter>
+  <Container isWrapper="l" bgc="base-2" py="50" set="gutter">
     <Grid gtr={['auto', null, 'auto auto 1fr']} gtc={['auto', null, 'auto 1fr']} g="30">
       <Stack gr="1" gc="1" g="20" min-w={['auto', null, '12rem']}>
         <Text class="u--trim" fz="2xl" fw="light" lts="l">News</Text>
         <Heading level="2" class="u--trim" fz="xs" o="-20">お知らせ</Heading>
       </Stack>
       <FluidCols cols="22rem" gr={['2', null, '1 / -1']} gc={['1', null, '2']} g="30">
-        <Grid gtr="subgrid" gr="span 2" g="30" isLinkBox as="a" href="#" bgc="white" p="30" bdrs="20" setTransition setHov hov="bxsh">
+        <Grid gtr="subgrid" gr="span 2" g="30" isLinkBox as="a" href="#" bgc="white" p="30" bdrs="20" set={["transition", "hov"]} hov="bxsh">
           <Grid gtc="1fr auto" g="20" jc="start" ai="center">
             <Text fz="s">2025.10.30</Text>
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">COLUMN</Text>
           </Grid>
           <Flex c="text" g="30">
             <Stack class="u--trimChildren" g="30">
-              <Text setTransition hov="to:cLink">デザインコラム更新「UIデザインにおけるアクセシビリティの重要性」</Text>
+              <Text set="transition" hov="to:cLink">デザインコラム更新「UIデザインにおけるアクセシビリティの重要性」</Text>
               <Text fz="s" o="-20"
                 >デザインコラムを更新しました。「Webアクセシビリティ」の基本的な考え方と、 今日から実践できるポイントについて解説します。</Text
               >
             </Stack>
-            <Flex ai="center" jc="center" aslf="e" p="15" bd bdc="black" bdrs="99" setTransition hov="to:reverse">
+            <Flex ai="center" jc="center" aslf="e" p="15" bd bdc="black" bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="caret-right" fz="xs" mx-s="auto" />
             </Flex>
           </Flex>
         </Grid>
-        <Grid gtr="subgrid" gr="span 2" g="30" isLinkBox as="a" href="#" bgc="white" p="30" bdrs="20" setTransition setHov hov="bxsh">
+        <Grid gtr="subgrid" gr="span 2" g="30" isLinkBox as="a" href="#" bgc="white" p="30" bdrs="20" set={["transition", "hov"]} hov="bxsh">
           <Grid gtc="1fr auto" g="20" jc="start" ai="center">
             <Text fz="s">2025.10.30</Text>
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">EVENT</Text>
           </Grid>
           <Flex c="text" g="30">
             <Stack class="u--trimChildren" g="30">
-              <Text setTransition hov="to:cLink">「LOOS DESIGN CONFERENCE 2025」登壇のお知らせ</Text>
+              <Text set="transition" hov="to:cLink">「LOOS DESIGN CONFERENCE 2025」登壇のお知らせ</Text>
               <Text fz="s" o="-20"
                 >2025年12月5日（金）に開催される国内最大級のデザインカンファレンスに、弊社アートディレクターの〇〇が登壇。「デザインがビジネスにもたらす価値」についてお話しします。</Text
               >
             </Stack>
-            <Flex ai="center" jc="center" aslf="e" p="15" bd bdc="black" bdrs="99" setTransition hov="to:reverse">
+            <Flex ai="center" jc="center" aslf="e" p="15" bd bdc="black" bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="caret-right" fz="xs" mx-s="auto" />
             </Flex>
           </Flex>
         </Grid>
-        <Grid gtr="subgrid" gr="span 2" g="30" isLinkBox as="a" href="#" bgc="white" p="30" bdrs="20" setTransition setHov hov="bxsh">
+        <Grid gtr="subgrid" gr="span 2" g="30" isLinkBox as="a" href="#" bgc="white" p="30" bdrs="20" set={["transition", "hov"]} hov="bxsh">
           <Grid gtc="1fr auto" g="20" jc="start" ai="center">
             <Text fz="s">2025.10.30</Text>
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">RELEASE</Text>
           </Grid>
           <Flex c="text" g="30">
             <Stack class="u--trimChildren" g="30">
-              <Text setTransition hov="to:cLink">新サービス「スタートアップ向けブランディング支援パッケージ」提供開始</Text>
+              <Text set="transition" hov="to:cLink">新サービス「スタートアップ向けブランディング支援パッケージ」提供開始</Text>
               <Text fz="s" o="-20"
                 >スタートアップ企業様を対象としたスピーディーかつ高品質なブランディング支援パッケージの提供を開始しました。
                 ロゴ、Webサイト、名刺までをワンストップでご提供します。</Text
               >
             </Stack>
-            <Flex ai="center" jc="center" aslf="e" p="15" bd bdc="black" bdrs="99" setTransition hov="to:reverse">
+            <Flex ai="center" jc="center" aslf="e" p="15" bd bdc="black" bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="caret-right" fz="xs" mx-s="auto" />
             </Flex>
           </Flex>
         </Grid>
-        <Grid gtr="subgrid" gr="span 2" g="30" isLinkBox as="a" href="#" bgc="white" p="30" bdrs="20" setTransition setHov hov="bxsh">
+        <Grid gtr="subgrid" gr="span 2" g="30" isLinkBox as="a" href="#" bgc="white" p="30" bdrs="20" set={["transition", "hov"]} hov="bxsh">
           <Grid gtc="1fr auto" g="20" jc="start" ai="center">
             <Text fz="s">2025.10.30</Text>
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">NEWS</Text>
           </Grid>
           <Flex c="text" g="30">
             <Stack class="u--trimChildren" g="30">
-              <Text setTransition hov="to:cLink">オフィス移転および電話番号変更のお知らせ</Text>
+              <Text set="transition" hov="to:cLink">オフィス移転および電話番号変更のお知らせ</Text>
               <Text fz="s" o="-20"
                 >業務拡大に伴いオフィスを下記住所へ移転いたしました。
                 社員一同より一層の努力を重ねてまいります。今後とも変わらぬご愛顧を賜りますようお願い申し上げます。</Text
               >
             </Stack>
-            <Flex ai="center" jc="center" aslf="e" p="15" bd bdc="black" bdrs="99" setTransition hov="to:reverse">
+            <Flex ai="center" jc="center" aslf="e" p="15" bd bdc="black" bdrs="99" set="transition" hov="to:reverse">
               <Icon icon="caret-right" fz="xs" mx-s="auto" />
             </Flex>
           </Flex>

--- a/apps/docs/src/pages/preview/templates/pricetable/pricetable001/index.astro
+++ b/apps/docs/src/pages/preview/templates/pricetable/pricetable001/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="PriceTable001">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">料金プラン</Heading>
       <Grid gtc="repeat(auto-fit, minmax(18rem, 1fr))" g="40">

--- a/apps/docs/src/pages/preview/templates/pricetable/pricetable002/index.astro
+++ b/apps/docs/src/pages/preview/templates/pricetable/pricetable002/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="PriceTable002">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">料金プラン</Heading>
       <Columns cols={['1', null, '2']} g="40" ai="center">

--- a/apps/docs/src/pages/preview/templates/pricetable/pricetable003/index.astro
+++ b/apps/docs/src/pages/preview/templates/pricetable/pricetable003/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="PriceTable003">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">料金プラン</Heading>
       <Columns cols={['1', null, '2']} g={['40', null, '0']} ai="center">

--- a/apps/docs/src/pages/preview/templates/pricetable/pricetable004/index.astro
+++ b/apps/docs/src/pages/preview/templates/pricetable/pricetable004/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="PriceTable004">
-  <Container isWrapper="l" bgc="base" py="50" setGutter>
+  <Container isWrapper="l" bgc="base" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">料金プラン</Heading>
       <Columns cols={['1', null, '3']} g="30">

--- a/apps/docs/src/pages/preview/templates/section/section001/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section001/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Section001">
-  <Wrapper contentSize="s" py="50" bgc="base" setGutter>
+  <Wrapper contentSize="s" py="50" bgc="base" set="gutter">
     <Stack ai="center" g="40">
       <h2 class="u--trim">人と緑が共に育つ街</h2>
       <Frame as="figure" class="set--innerRs" as="figure" ar="16/9" pos="rel" bdrs="20" bxsh="20" bgc="white" p="10">

--- a/apps/docs/src/pages/preview/templates/section/section002-2/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section002-2/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Section002-2">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Grid gtc={['auto', null, 'minmax(20rem, 1fr) 1fr']} gtr={['1fr', null, '1fr auto auto 1fr']} g="40 60" }>
       <Stack gr={['1', null, '2']} g="40">
         <h2 class="u--trim">暮らしを、もっと豊かに</h2>

--- a/apps/docs/src/pages/preview/templates/section/section002/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section002/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Section002">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Grid gtc={['auto', null, '1fr minmax(20rem, 1fr)']} gtr={['1fr', null, '1fr auto auto 1fr']} g="40 60">
       <Stack gr={[' 1', null, '2']} g="40">
         <h2 class="u--trim">暮らしを、もっと豊かに</h2>

--- a/apps/docs/src/pages/preview/templates/section/section007/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section007/index.astro
@@ -23,7 +23,7 @@ import './_style.css';
       </Frame>
     </Grid>
     <Layer style={{ backdropFilter: 'blur(8px)' }} bgc="black:30%" z="0" />
-    <Wrapper contentSize="s" setGutter py="60" c="white" pos="rel">
+    <Wrapper contentSize="s" set="gutter" py="60" c="white" pos="rel">
       <Stack g="40">
         <Stack g="30" ai="center">
           <Text class="u--trim" fz="5xl" fw="100" lts="l">Feature</Text>

--- a/apps/docs/src/pages/preview/templates/section/section008/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section008/index.astro
@@ -8,7 +8,7 @@ import './_style.css';
 <DemoLayout title="Section008">
   <Container bgc="base" py="50">
     <Stack g={['40', null, '50']}>
-      <Stack ai="center" g="30" ff="accent" setGutter>
+      <Stack ai="center" g="30" ff="accent" set="gutter">
         <Heading level="2" fz="clamp(1.5rem, 4.5vw, 2rem)" fw="bold" ta="center">大地の恵みを、あなたの毎日へ</Heading>
         <Text>自然由来の環境負荷を抑えた製法で、一つひとつ丁寧に手作りしています。</Text>
       </Stack>

--- a/apps/docs/src/pages/preview/templates/section/section009-2/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section009-2/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Section009-2">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Stack g="50">
       <Grid gtc={['auto', null, '1fr 1fr']}>
         <Stack g="50" jc="center" p={['40', null, '50']}>
@@ -20,7 +20,7 @@ import './_style.css';
             透明性の高い情報発信を行い、信頼関係の構築に努めています。 これからも、持続可能な発展と社会貢献を両立させるための取り組みを続けてまいります。
           </Text>
           <Flex jc="flex-e">
-            <Flex as="a" isLinkBox href="#" ai="center" g="15" setTransition hov="c">
+            <Flex as="a" isLinkBox href="#" ai="center" g="15" set="transition" hov="c">
               <Inline fz="l" fs="i">View More</Inline>
               <Icon icon="arrow-right" />
             </Flex>

--- a/apps/docs/src/pages/preview/templates/section/section009/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section009/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Section009">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Stack g="50">
       <Grid gtc={['auto', null, '1fr 1fr']}>
         <Stack g="50" jc="center" p={['40', null, '50']}>
@@ -20,7 +20,7 @@ import './_style.css';
             透明性の高い情報発信を行い、信頼関係の構築に努めています。 これからも、持続可能な発展と社会貢献を両立させるための取り組みを続けてまいります。
           </Text>
           <Flex jc="flex-e">
-            <Flex as="a" isLinkBox href="#" ai="center" g="15" setTransition hov="c">
+            <Flex as="a" isLinkBox href="#" ai="center" g="15" set="transition" hov="c">
               <Inline fz="l" fs="i">View More</Inline>
               <Icon icon="arrow-right" />
             </Flex>

--- a/apps/docs/src/pages/preview/templates/section/section010/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section010/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Section010">
-  <Container isWrapper="m" py="50" setGutter>
+  <Container isWrapper="m" py="50" set="gutter">
     <Stack g="30">
       <Frame as="figure" ar="16/9" pos="rel">
         <Media src="https://cdn.lism-css.com/random/img" alt="" width="960" height="640" />

--- a/apps/docs/src/pages/preview/templates/section/section011/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section011/index.astro
@@ -11,7 +11,7 @@ import './_style.css';
       <Frame as="figure" ar="16/9" pos="rel" max-h="32rem">
         <Media src="https://cdn.lism-css.com/random/img" alt="" width="960" height="640" />
         <Layer>
-          <Container isWrapper="m" py="40" h="100%" setGutter>
+          <Container isWrapper="m" py="40" h="100%" set="gutter">
             <Stack jc="flex-e" g="30" min-h="100%" c="white">
               <Heading level="2" class="u--trim" fz="min(5vw, 2rem)" fw="bold">まだ見ぬ世界をあなたに</Heading>
               <Text class="u--trim" fz="min(2.5vw, 1rem)">A world you've never seen before</Text>
@@ -19,7 +19,7 @@ import './_style.css';
           </Container>
         </Layer>
       </Frame>
-      <Container isWrapper="m" py="40" setGutter>
+      <Container isWrapper="m" py="40" set="gutter">
         <Stack g="30">
           <Heading level="3" fz="xl" fw="bold">未知の世界を体感</Heading>
           <Text>

--- a/apps/docs/src/pages/preview/templates/section/section012/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section012/index.astro
@@ -13,7 +13,7 @@ import './_style.css';
         <Layer bgc="black:30%" />
       </Frame>
     </Layer>
-    <Container isWrapper="m" gr="1" gc="1" setGutter pos="rel" z="1">
+    <Container isWrapper="m" gr="1" gc="1" set="gutter" pos="rel" z="1">
       <Grid gtc={['auto', null, 'auto 1fr']} c="white" g="50" py="50">
         <Heading level="2" class="u--trim" fz="3xl" fw="bold" hl="l">自然素材が生み出す<br />癒やしのひととき</Heading>
         <Stack class="u--trimChildren" g="40">

--- a/apps/docs/src/pages/preview/templates/section/section013/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section013/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Section013">
-  <Container isWrapper="l" bgc="gray" py="50" setGutter>
+  <Container isWrapper="l" bgc="gray" py="50" set="gutter">
     <Columns cols={[1, null, 3]} g={['30', null, '40']} c="white">
       <Stack g="30">
         <Heading level="2" class="u--trim" fz="5xl" ff="accent" fs="italic" fw="900" lts="l">Feature</Heading>

--- a/apps/docs/src/pages/preview/templates/section/section014/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section014/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Section014">
-  <Container isWrapper="l" py="50" setGutter>
+  <Container isWrapper="l" py="50" set="gutter">
     <Grid gtc={['auto', null, 'auto 1fr']} g="40 50">
       <Box>
         <Heading level="2" class="u--trim" fz="3xl" fw="bold" hl="l">最高のユーザー体験を<br />提供する未来のために</Heading>

--- a/apps/docs/src/pages/preview/templates/section/section016/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section016/index.astro
@@ -7,7 +7,7 @@ import './_style.css';
 
 <DemoLayout title="Section016">
   <Container py="50">
-    <Container isWrapper="m" setGutter>
+    <Container isWrapper="m" set="gutter">
       <Grid gtc={['auto', null, 'auto 1fr']} g="50 60">
         <Stack g="30" min-w="16rem" ff="accent" fs="i" c="gray">
           <Heading level="2" class="u--trim" fz="5xl" fw="bold">Relaxing</Heading>

--- a/apps/docs/src/pages/preview/templates/testimonials/testimonials001/index.astro
+++ b/apps/docs/src/pages/preview/templates/testimonials/testimonials001/index.astro
@@ -6,7 +6,7 @@ import './_style.css';
 ---
 
 <DemoLayout title="Testimonials001">
-  <Container isWrapper="l" bgc="gray:5%" py="50" setGutter>
+  <Container isWrapper="l" bgc="gray:5%" py="50" set="gutter">
     <Stack g="50">
       <Heading level="2" class="u--trim" fz="2xl" fw="bold" ta="center">お客様の声</Heading>
       <FluidCols cols="20rem" g="30">


### PR DESCRIPTION
## Summary
- section, navigation, news, member, pricetable, history, information, testimonials の44テンプレートファイルで setXxxx → set prop 変換
- `setGutter` → `set="gutter"`, `setHov setTransition` → `set={["hov", "transition"]}` 等
- news004 の重複 `setTransition` を正しく配列形式に統合

Closes partially #191