### PR TITLE
docs(en): Prop Class → Property Class リネーム・setXxxx → set prop 記法更新

### DIFF
--- a/apps/docs/src/content/en/base-styles.mdx
+++ b/apps/docs/src/content/en/base-styles.mdx
@@ -193,7 +193,7 @@ hr {
 }
 ```
 
-While the Reset CSS removes list styles from elements with a class, this rule restores the browser default list style for lists with no class, or with only a Prop Class (a class starting with `-`).
+While the Reset CSS removes list styles from elements with a class, this rule restores the browser default list style for lists with no class, or with only a Property Class (a class starting with `-`).
 
 
 ### Definition lists (dl)

--- a/apps/docs/src/content/en/changelog.mdx
+++ b/apps/docs/src/content/en/changelog.mdx
@@ -151,7 +151,7 @@ They are now provided by the `@lism-css/ui` package instead.
 - Spacing scale has been overhauled.
 - Color tokens have been globally adjusted.
 
-### Prop Class changes
+### Property Class changes
 
 | Before | After | Notes |
 | ------ | ------ | ---- |
@@ -160,7 +160,7 @@ They are now provided by the `@lism-css/ui` package instead.
 | `-td:under` | Removed | |
 | - | `-tt:upper`, `-tt:lower` | Newly added |
 
-- `translate`, `scale`, and `rotate` have been removed from Prop Classes.
+- `translate`, `scale`, and `rotate` have been removed from Property Classes.
 
 
 

--- a/apps/docs/src/content/en/core-components/Lism.mdx
+++ b/apps/docs/src/content/en/core-components/Lism.mdx
@@ -68,7 +68,7 @@ The props specific to Lism CSS that `<Lism>` accepts are called **Lism Props**.
 |---|---|
 |**Common Props**|Basic shared properties|
 |**State Props**|Props for outputting classes classified as [State Modules](/docs/css-methodology//#state-modules)|
-|**CSS Props**|Props for outputting classes classified as [Prop Class](/docs/prop-class/)| */}
+|**CSS Props**|Props for outputting classes classified as [Property Class](/docs/property-class/)| */}
 
 
 
@@ -183,11 +183,11 @@ A set of props corresponding to [State Modules](/docs/css-methodology/) classes.
 | `isSide` | `is--side` | Side element |
 | `isSkipFlow` | `is--skipFlow` | Skip Flow spacing |
 | `isVertical` | `is--vertical` | Vertical writing mode |
-| `setGutter` | `set--gutter` | Horizontal gutter spacing |
-| `setShadow` | `set--shadow` | Apply shadow |
-| `setHov` | `set--hov` | Hover effect |
-| `setTransition` | `set--transition` | Transition |
-| `setPlain` | `set--plain` | Plain state |
+| `set="gutter"` | `set--gutter` | Horizontal gutter spacing |
+| `set="shadow"` | `set--shadow` | Apply shadow |
+| `set="hov"` | `set--hov` | Hover effect |
+| `set="transition"` | `set--transition` | Transition |
+| `set="plain"` | `set--plain` | Plain state |
 
 <Reference>
 [Learn about State Modules classes and usage examples](/docs/css-methodology/)
@@ -200,7 +200,7 @@ Major CSS properties can be specified using shorthand notation.
 For example, `font-size` can be written as `fz`, and `padding` as `p`.
 
 <Reference>
-[See the full list of available Props](/docs/prop-class/)
+[See the full list of available Props](/docs/property-class/)
 </Reference>
 
 <Spacer h='10'/>
@@ -217,7 +217,7 @@ The output format is determined by the value (`value`) specified via `prop={valu
 | Other values (variable-only) | `--{prop}` variable only | `bdw='2px'` → `--bdw:2px` |
 
 :::note[Notes]
-- **BP-supported properties**: Properties that can switch values at breakpoints. See the **BP** column in [Prop Class](/docs/prop-class).
+- **BP-supported properties**: Properties that can switch values at breakpoints. See the **BP** column in [Property Class](/docs/property-class).
 - **Variable-only properties**: Properties like `bds`, `bdc`, `bdw`, `keycolor` that always output only CSS variables (`--{prop}`).
 - When a matching token exists but has no dedicated class, the value is output as a CSS variable. (e.g., `c='red'` → `class="-c"` + `style="--c:var(--red)"`)
 :::
@@ -291,7 +291,7 @@ This is useful when you want to define the variable value in CSS, or when you wa
 <div id='output-utility'></div>
 #### Force output as a utility class with `:`
 
-Even if no corresponding Prop Class exists, prefixing a value with `:` will output the string after it as a utility class name.
+Even if no corresponding Property Class exists, prefixing a value with `:` will output the string after it as a utility class name.
 
 ```jsx
 <Lism p=':hoge'>...</Lism>
@@ -351,7 +351,7 @@ BP-supported properties can specify values per breakpoint (`sm`, `md`) using arr
 
 :::warning
 Whether a value actually changes at a breakpoint depends on whether that property supports responsive behavior.
-Check the **BP** (<small>short for breakpoint</small>) column in [Prop Class](/docs/prop-class) to see which properties are supported.
+Check the **BP** (<small>short for breakpoint</small>) column in [Property Class](/docs/property-class) to see which properties are supported.
 :::
 
 For properties that do not support responsive behavior by default (i.e., no CSS is provided), you can add support via [SCSS customization](/docs/customize/).

--- a/apps/docs/src/content/en/css-methodology.mdx
+++ b/apps/docs/src/content/en/css-methodology.mdx
@@ -73,7 +73,7 @@ To address the common problem of CSS specificity becoming overly complex, Lism d
     </tr>
     <tr>
       <td class='-whspace:nowrap'>Props<br/>`-`</td>
-      <td>**Prop Classes** (`.-{prop}:{val}`) tied to individual CSS properties.<br />This group is the only one placed outside of layers, giving it higher specificity while still allowing reasonable coexistence with external CSS.</td>
+      <td>**Property Classes** (`.-{prop}:{val}`) tied to individual CSS properties.<br />This group is the only one placed outside of layers, giving it higher specificity while still allowing reasonable coexistence with external CSS.</td>
     </tr>
   </tbody>
 </table>
@@ -151,14 +151,14 @@ Utility classes with a clear decorative or functional purpose are defined as fol
 
 
 
-### Prop Class
+### Property Class
 
-In Lism CSS, utility classes that correspond to a single CSS property are defined as **Prop Classes**.
+In Lism CSS, utility classes that correspond to a single CSS property are defined as **Property Classes**.
 
 Utility classes are provided for major properties, covering commonly used values and dedicated token values, with responsive support built in.
 
 
-Prop Classes come in three formats:
+Property Classes come in three formats:
 
 | Format | Description | Example |
 |---|---|---|
@@ -209,11 +209,11 @@ Prop Classes come in three formats:
 
 
 <Reference>
-See the [Prop Class reference page](/docs/prop-class) for the full list.
+See the [Property Class reference page](/docs/property-class) for the full list.
 </Reference>
 
 
-### Responsive Prop Classes
+### Responsive Property Classes
 
 The `.-{prop}_{bp}` class format combined with the `--{prop}_{bp}` variable format enables responsive styling.
 
@@ -264,7 +264,7 @@ When defining your own components (`.c--card`, `c--pricing`, etc.), place them i
 ```
 
 If you add custom classes that match Lism CSS's existing class categories (`set--`, `is--`, `l--`, `a--`, `u--`), use the same prefix and add them to the corresponding layer.
-For utility classes combining a CSS property and its value, use the Prop Class format `-{prop}:{value}`.
+For utility classes combining a CSS property and its value, use the Property Class format `-{prop}:{value}`.
 
 
 #### Adding custom classifications
@@ -327,10 +327,10 @@ By using simple numeric variations, you can expand them to `base-3`, `text-3`, a
 :::
 
 
-#### Variable names for Prop Classes
-- Custom properties corresponding to Prop Classes use `--{prop}`, expressed with the **same abbreviation as the class name**.
+#### Variable names for Property Classes
+- Custom properties corresponding to Property Classes use `--{prop}`, expressed with the **same abbreviation as the class name**.
   - Examples: `--p`, `--mx`, `--c`, `--bgc`, `--bdrs`
-- Breakpoint values for Prop Classes use `--{prop}_{bp}`.
+- Breakpoint values for Property Classes use `--{prop}_{bp}`.
   - Examples: `--p_sm`, `--mx_md`
 
 #### Variable names for elements
@@ -338,7 +338,7 @@ By using simple numeric variations, you can expand them to `base-3`, `text-3`, a
   - Examples: `--link-td`, `--headings-ff`, `--gutter-size`, `--under-offset`, `--hl-unit`, `--ov-bgc`
 - Variables for the primary functionality of a component or module class are expressed as a single block, like `--{propName}`.
   - Examples: `--sideW`, `--mainW` for `.l--sideMain`
-  - Note: When the property is also defined as a Prop Class, the same variable name can be used to allow overriding.
+  - Note: When the property is also defined as a Property Class, the same variable name can be used to allow overriding.
     - Example: `--c`, `--bgc` on `.c--button`
 - Properties for child elements of specific components or modules (e.g., `c--hoge_item`) use the format `--_{item}-{propName}`.
   - Example: `--_icon-size`
@@ -367,7 +367,7 @@ For the `{value}` part of `-{prop}:{value}`:
 
 ## Abbreviation Rules
 
-This section explains the abbreviation rules for both the `{prop}` and `{value}` parts of Prop Classes (`-{prop}:{value}`), as well as the corresponding CSS variable names and component prop keys.
+This section explains the abbreviation rules for both the `{prop}` and `{value}` parts of Property Classes (`-{prop}:{value}`), as well as the corresponding CSS variable names and component prop keys.
 
 ### The `{prop}` part
 

--- a/apps/docs/src/content/en/customize.mdx
+++ b/apps/docs/src/content/en/customize.mdx
@@ -30,10 +30,10 @@ The variables defined in `lism-css/scss/_setting.scss` can be overridden.
 <EmbedCode dirPath='packages/lism-css' srcPath='src/scss/_setting.scss' />
 
 - `$breakpoints`: Breakpoint value definitions
-- `$common_support_bp`: Breakpoints commonly supported across major Prop Classes
+- `$common_support_bp`: Breakpoints commonly supported across major Property Classes
 - `$is_container_query`: Whether to use container queries
-- `$default_important`: Whether to add `!important` to Prop Classes by default (`0` | `1`)
-- `$props`: Output configuration for Prop Classes
+- `$default_important`: Whether to add `!important` to Property Classes by default (`0` | `1`)
+- `$props`: Output configuration for Property Classes
 
 These can be overridden using `@use` with `with`.
 
@@ -83,14 +83,14 @@ After defining your overrides, import `lism-css/scss/main.scss` to apply the cus
   // Generate utility classes up to lg size
   $is_container_query: 0,
   // Output using media queries
-  $default_important: 1 // Add !important to Prop Classes by default
+  $default_important: 1 // Add !important to Property Classes by default
 );
 
 @use '../path-to/node_modules/lism-css/scss/main';
 ```
 
 
-<PreviewTitle>Customize Prop Class output</PreviewTitle>
+<PreviewTitle>Customize Property Class output</PreviewTitle>
 ```scss
 // Configuration overrides
 @use '../path-to/node_modules/lism-css/scss/setting' with (
@@ -177,7 +177,7 @@ const { props, tokens } = DEFAULT_CONFIG;
 
 export default {
   props: {
-    // Add Prop Class output
+    // Add Property Class output
     d: { presets: [...(props.d.presets || []), 'flex', 'grid'] },
     p: { utils: { box: '2em' } },
   },

--- a/apps/docs/src/content/en/module-class.mdx
+++ b/apps/docs/src/content/en/module-class.mdx
@@ -123,7 +123,7 @@ The value for vertical writing is managed via a token (`--vertical-mode`). (<spa
 <Preview>
   <PreviewTitle>Example: vertical writing at sm size and above</PreviewTitle>
   <PreviewArea p='0' resize>
-    <Flow setGutter py="20" w="100%" h="20em" className="is--vertical@sm set--bp">
+    <Flow set="gutter" py="20" w="100%" h="20em" className="is--vertical@sm set--bp">
       <DummyText lang="ja" length="s" />
       <DummyText lang="ja" length="l" offset="3" />
     </Flow>
@@ -140,7 +140,7 @@ The value for vertical writing is managed via a token (`--vertical-mode`). (<spa
   </PreviewCode>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx "is--vertical@sm set--bp"
-    <Flow setGutter py="20" w="100%" h="20em" className="is--vertical@sm set--bp">
+    <Flow set="gutter" py="20" w="100%" h="20em" className="is--vertical@sm set--bp">
       <p>ロレム・イプサムの座り雨。目まぐるしい文章の流れの中で、それは静かに歩く仮の言葉です。</p>
       <p>
         Elitも穏やかに続いていきますが、積み重ねられてきた「LiberroyとFoogの取り組み」は、余白のようなものです。作業が進むにつれて、工夫や考えとともに関心が折り重なりながらも、必要以上に主張せず彼らの作品は私たちに一定の示唆を与えてくれます。

--- a/apps/docs/src/content/en/modules/is--linkBox.mdx
+++ b/apps/docs/src/content/en/modules/is--linkBox.mdx
@@ -89,7 +89,7 @@ This approach also allows you to place additional links inside the LinkBox.
 <Preview>
   <PreviewTitle id='linkbox-demo02'>Example</PreviewTitle>
   <PreviewArea p='20'>
-    <LinkBox as="section" p="30" bgc="base" bd bdrs="30" setTransition hov="bxsh">
+    <LinkBox as="section" p="30" bgc="base" bd bdrs="30" set="transition" hov="bxsh">
       <Group fz="xl" fw="bold">
         <Link className="u--expandedLink" href="#linkbox-demo02">
           <Fragment>Heading link text</Fragment>
@@ -105,7 +105,7 @@ This approach also allows you to place additional links inside the LinkBox.
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx 'className="u--expandedLink"'
-    <LinkBox p="30" bgc="base" bd bdrs="30" setTransition hov="bxsh">
+    <LinkBox p="30" bgc="base" bd bdrs="30" set="transition" hov="bxsh">
       <Group fz="xl" fw="bold">
         <Link className="u--expandedLink" href="#linkbox-demo02">
           Heading link text

--- a/apps/docs/src/content/en/modules/l--frame.mdx
+++ b/apps/docs/src/content/en/modules/l--frame.mdx
@@ -218,7 +218,7 @@ A `<Frame>` component is distributed in `lism-css`.
 :::note
 ::title[About values available for `ar`]
 `ar` (the CSS Prop for `aspect-ratio`) is a general-purpose property that can be specified on any component.
-[See here for the available values.](/docs/prop-class/#aspect-ratio)
+[See here for the available values.](/docs/property-class/#aspect-ratio)
 :::
 
 

--- a/apps/docs/src/content/en/property-class.mdx
+++ b/apps/docs/src/content/en/property-class.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Prop Class'
-description: 'A complete list of Prop Classes that map to CSS properties, with usage examples.'
+title: 'Property Class'
+description: 'A complete list of Property Classes that map to CSS properties, with usage examples.'
 ---
 import { Lism, Flow, Container, Frame, Layer, Media, Box, Flex, Grid, Center, Columns, Spacer, Group, Text } from "lism-css/astro";
 import { DummyText } from '@lism-css/ui/astro';
@@ -44,9 +44,9 @@ export const PropTable = ({data={}, ...props}) => {
 Lism provides utility classes for the major CSS properties, making it easy to set frequently used values and tokens.
 For particularly important CSS properties, breakpoint-specific classes are also available.
 
-These are called [Prop Classes](/docs/css-methodology/#prop-class) and are defined in the format `-{prop}(:{value})` and `-{prop}_{bp}`.
+These are called [Property Classes](/docs/css-methodology/#property-class) and are defined in the format `-{prop}(:{value})` and `-{prop}_{bp}`.
 
-This page lists all available Prop Classes.
+This page lists all available Property Classes.
 
 
 :::info
@@ -54,7 +54,7 @@ You can change which classes are output by [customizing via SCSS](/docs/customiz
 :::
 
 
-{/* ## Full Prop Class list
+{/* ## Full Property Class list
 ...*/}
 
 

--- a/apps/docs/src/content/en/props/bd.mdx
+++ b/apps/docs/src/content/en/props/bd.mdx
@@ -1,6 +1,6 @@
 ---
 title: '-bd'
-description: 'How to use the -bd prop classes and related CSS variables for border styling.'
+description: 'How to use the -bd property classes and related CSS variables for border styling.'
 ---
 import { Box, Flex, Stack, Divider, Spacer } from 'lism-css/astro';
 import { DummyText } from '@lism-css/ui/astro';

--- a/apps/docs/src/content/en/props/hov.mdx
+++ b/apps/docs/src/content/en/props/hov.mdx
@@ -1,6 +1,6 @@
 ---
 title: '-hov'
-description: 'How to use the -hov prop classes for controlling hover behavior and transitions.'
+description: 'How to use the -hov property classes for controlling hover behavior and transitions.'
 ---
 
 import { Flex, Media, Layer, Spacer, Box, Center, Stack, Frame, LinkBox, Inline, Text } from 'lism-css/react';
@@ -9,7 +9,7 @@ import { Flex, Media, Layer, Spacer, Box, Center, Stack, Frame, LinkBox, Inline,
 This page introduces the CSS design for controlling hover behavior in Lism.
 
 
-In Lism, hover styles are defined using Prop classes that begin with `-hov:`.
+In Lism, hover styles are defined using Property classes that begin with `-hov:`.
 The `set--transition` class is used alongside them to configure transitions.
 
 
@@ -122,7 +122,7 @@ Combine this class with CSS variables to configure transition behavior.
 <Preview>
   <PreviewTitle>Example: combining `set--transition` to animate the bxsh intensity</PreviewTitle>
   <PreviewArea p='30'>
-    <LinkBox href="###" setTransition bxsh="10" hov={{ bxsh: '40' }} bd p="20">
+    <LinkBox href="###" set="transition" bxsh="10" hov={{ bxsh: '40' }} bd p="20">
       <p>LinkBox</p>
       <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
     </LinkBox>
@@ -136,8 +136,8 @@ Combine this class with CSS variables to configure transition behavior.
     ```
   </PreviewCode>
   <PreviewCode slot='tab' label='JSX'>
-  ```jsx "setTransition" "bxsh='10' hov=\{\{ bxsh: '40'\}\}"
-  <LinkBox href="###" setTransition bxsh="10" hov={{ bxsh: '40' }} bd p="20">
+  ```jsx 'set="transition"' "bxsh='10' hov=\{\{ bxsh: '40'\}\}"
+  <LinkBox href="###" set="transition" bxsh="10" hov={{ bxsh: '40' }} bd p="20">
     <p>LinkBox</p>
     <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
   </LinkBox>
@@ -149,7 +149,7 @@ Combine this class with CSS variables to configure transition behavior.
 <Preview>
   <PreviewTitle>Example: slowly transitioning the border-color</PreviewTitle>
   <PreviewArea p='30'>
-    <LinkBox href="###" setTransition hov={{ bdc: 'red' }} bd bdw="3px" bgc="base-2" p="20" style={{ '--hov-duration': '.5s' }}>
+    <LinkBox href="###" set="transition" hov={{ bdc: 'red' }} bd bdw="3px" bgc="base-2" p="20" style={{ '--hov-duration': '.5s' }}>
       <p>LinkBox</p>
       <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
     </LinkBox>
@@ -163,8 +163,8 @@ Combine this class with CSS variables to configure transition behavior.
     ```
   </PreviewCode>
   <PreviewCode slot='tab' label='JSX'>
-    ```jsx "setTransition" "--hov-duration"
-    <LinkBox href="###" setTransition hov={{ bdc: 'red' }} bd bdw="3px" bgc="base-2" p="20" style={{ '--hov-duration': '.5s' }}>
+    ```jsx 'set="transition"' "--hov-duration"
+    <LinkBox href="###" set="transition" hov={{ bdc: 'red' }} bd bdw="3px" bgc="base-2" p="20" style={{ '--hov-duration': '.5s' }}>
       <p>LinkBox</p>
       <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
     </LinkBox>
@@ -184,7 +184,7 @@ Combine this class with CSS variables to configure transition behavior.
 }`}>
   <PreviewTitle>Adding `.-hov:shadowUp`</PreviewTitle>
   <PreviewArea p='30'>
-    <LinkBox href="###" setTransition hov="shadowUp" bxsh="10" bd p="20">
+    <LinkBox href="###" set="transition" hov="shadowUp" bxsh="10" bd p="20">
       <p>LinkBox</p>
       <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
     </LinkBox>
@@ -210,7 +210,7 @@ Combine this class with CSS variables to configure transition behavior.
   </PreviewCode>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx 'hov="shadowUp"'
-    <LinkBox href="###" setTransition hov="shadowUp" bd p="20">
+    <LinkBox href="###" set="transition" hov="shadowUp" bd p="20">
       <p>LinkBox</p>
       <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
     </LinkBox>
@@ -251,9 +251,9 @@ By leveraging `set--hov`, you can trigger style changes on child elements when t
 <Preview>
   <PreviewTitle>Example using `-hov:to:show` and `-hov:to:zoom`</PreviewTitle>
   <PreviewArea p='20'>
-    <Frame isLinkBox setHov href="#banner-link" ar="16/9" bdrs="30">
-      <Media isLayer setTransition hov="to:zoom" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" loading="lazy" />
-      <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 40%)" style={{ backdropFilter: 'blur(6px)' }}>
+    <Frame isLinkBox set="hov" href="#banner-link" ar="16/9" bdrs="30">
+      <Media isLayer set="transition" hov="to:zoom" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" loading="lazy" />
+      <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 40%)" style={{ backdropFilter: 'blur(6px)' }}>
         <Center h="100%" c="#fff">
           <Inline fz="2xl" fs="italic" fw="light" lts="l" bdrs="99" px="20" py="10">
             <Fragment>View More</Fragment>
@@ -275,10 +275,10 @@ By leveraging `set--hov`, you can trigger style changes on child elements when t
     ```
   </PreviewCode>
   <PreviewCode slot='tab' label='JSX'>
-    ```jsx 'setHov' 'hov="to:show"' 'hov="to:zoom"' 'setTransition'
-    <Frame isLinkBox setHov href="#banner-link" ar="16/9" bdrs="30">
-      <Media isLayer setTransition hov="to:zoom" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" loading="lazy" />
-      <Layer setTransition hov="to:show" bgc="rgb(0 0 0 / 40%)" style={{ backdropFilter: 'blur(6px)' }}>
+    ```jsx 'set="hov"' 'hov="to:show"' 'hov="to:zoom"' 'set="transition"'
+    <Frame isLinkBox set="hov" href="#banner-link" ar="16/9" bdrs="30">
+      <Media isLayer set="transition" hov="to:zoom" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" loading="lazy" />
+      <Layer set="transition" hov="to:show" bgc="rgb(0 0 0 / 40%)" style={{ backdropFilter: 'blur(6px)' }}>
         <Center h="100%" c="#fff">
           <Inline fz="2xl" fs="italic" fw="light" lts="l" bdrs="99" px="20" py="10">
             View More

--- a/apps/docs/src/content/en/props/max-sz.mdx
+++ b/apps/docs/src/content/en/props/max-sz.mdx
@@ -10,7 +10,7 @@ Lism provides content size tokens in the form `--sz--{sz}` (where `{sz}` = `xs`,
 
 A set of utility classes using `-max-sz` is available for specifying the maximum inline size (`max-inline-size`) of content.
 
-{/* `is--wrapper` controls the content size via `max-inline-size`, so preset values for the `-max-sz` Prop class are provided to match. */}
+{/* `is--wrapper` controls the content size via `max-inline-size`, so preset values for the `-max-sz` Property class are provided to match. */}
 
 `-max-sz:{xs~xl}` directly maps to the corresponding `--sz--{xs~xl}` token.
 

--- a/apps/docs/src/content/en/responsive.mdx
+++ b/apps/docs/src/content/en/responsive.mdx
@@ -57,7 +57,7 @@ In Lism, responsive support is implemented by combining classes in the `.-{prop}
 
 :::warning
 Not all CSS properties support responsive switching.
-For details on which properties support breakpoint switching by default, refer to the [Prop Class list page](/docs/prop-class).
+For details on which properties support breakpoint switching by default, refer to the [Property Class list page](/docs/property-class).
 :::
 
 You can also toggle responsive support per property by [customizing via SCSS files](/docs/customize/).

--- a/apps/docs/src/content/en/set-class.mdx
+++ b/apps/docs/src/content/en/set-class.mdx
@@ -190,7 +190,7 @@ Sets the `transition` property using dedicated variables.
 <Preview>
   <PreviewTitle>Usage example</PreviewTitle>
   <PreviewArea p='30'>
-    <Lism setTransition hov={{c: 'red'}} style={{ '--hov-prop': 'color'}}>Example</Lism>
+    <Lism set="transition" hov={{c: 'red'}} style={{ '--hov-prop': 'color'}}>Example</Lism>
   </PreviewArea>
   <PreviewCode label="HTML" slot="tab">
     ```html
@@ -199,7 +199,7 @@ Sets the `transition` property using dedicated variables.
   </PreviewCode>
   <PreviewCode label="JSX" slot="tab">
     ```jsx
-    <Lism setTransition hov={{c: 'red'}} style={{ '--hov-prop': 'color'}}>Example</Lism>
+    <Lism set="transition" hov={{c: 'red'}} style={{ '--hov-prop': 'color'}}>Example</Lism>
     ```
   </PreviewCode>
 </Preview>
@@ -220,7 +220,7 @@ Apply `set--innerRs` to the parent element, then use `-bdrs:inner` on the child 
 <Preview>
   <PreviewTitle>Usage example</PreviewTitle>
   <PreviewArea p='30'>
-    <Lism setInnerRs p="15" bdrs="40" bd bxsh="20">
+    <Lism set="innerRs" p="15" bdrs="40" bd bxsh="20">
       <Frame bdrs="inner" ar="og">
         <img src="https://cdn.lism-css.com/img/u-5.jpg" width="1920" height="1280" alt="" />
       </Frame>
@@ -236,8 +236,8 @@ Apply `set--innerRs` to the parent element, then use `-bdrs:inner` on the child 
     ```
   </PreviewCode>
   <PreviewCode label="JSX" slot="tab">
-    ```jsx 'setInnerRs' 'bdrs="inner"' 'p="15" bdrs="40"'
-    <Lism setInnerRs p="15" bdrs="40" bd bxsh="20">
+    ```jsx 'set="innerRs"' 'bdrs="inner"' 'p="15" bdrs="40"'
+    <Lism set="innerRs" p="15" bdrs="40" bd bxsh="20">
       <Frame bdrs="inner" ar="og">
         <img src="https://cdn.lism-css.com/img/u-5.jpg" width="1920" height="1280" alt="" />
       </Frame>
@@ -285,7 +285,7 @@ It is provided as a separate class from padding utilities to reserve a consisten
 <Preview>
   <PreviewTitle>Example</PreviewTitle>
   <PreviewArea resize p='15'>
-    <Lism setGutter>
+    <Lism set="gutter">
       <p>Lorem ipsum content...</p>
       <p>Lorem ipsum content...</p>
       <p>Lorem ipsum content...</p>
@@ -302,7 +302,7 @@ It is provided as a separate class from padding utilities to reserve a consisten
   </PreviewCode>
   <PreviewCode slot='tab' label='JSX'>
   ```jsx
-  <Lism setGutter>
+  <Lism set="gutter">
     <p>Lorem ipsum content...</p>
     <p>Lorem ipsum content...</p>
     <p>Lorem ipsum content...</p>
@@ -322,7 +322,7 @@ It can be used as a workaround for properties that do not support [responsive br
 <Preview>
   <PreviewTitle>Example: changing text color to red at sm size and above</PreviewTitle>
   <PreviewArea resize>
-    <Lism setBp p="20" style={{ color: 'var(--_is_sm) red;' }}>
+    <Lism set="bp" p="20" style={{ color: 'var(--_is_sm) red;' }}>
       <p>Lorem ipsum dolor sit amet. Consectetur adipiscing elit, sed do eiusmod tempor Incididunt ut.</p>
     </Lism>
   </PreviewArea>
@@ -334,8 +334,8 @@ It can be used as a workaround for properties that do not support [responsive br
   ```
   </PreviewCode>
   <PreviewCode slot='tab' label='JSX'>
-    ```jsx "setBp" "var(--_is_sm) red"
-    <Lism setBp p="20" style={{ color: 'var(--_is_sm) red;' }}>
+    ```jsx 'set="bp"' "var(--_is_sm) red"
+    <Lism set="bp" p="20" style={{ color: 'var(--_is_sm) red;' }}>
       <p>Lorem ipsum dolor sit amet. Consectetur adipiscing elit, sed do eiusmod tempor Incididunt ut.</p>
     </Lism>
     ```
@@ -350,7 +350,7 @@ Combines with the `--mask` variable to apply a mask to the element itself.
 
 <EmbedCode dirPath='packages/lism-css' srcPath='src/scss/base/set/_mask.scss' />
 
-In Lism components, a string passed to the `setMask` prop is output as `--maskImg`. (When only `<svg>~</svg>` is passed, it is base64-encoded.)
+Use `set="mask"` to apply the `set--mask` class. Set the `--maskImg` variable manually via the `style` prop.
 
 <Preview>
   <PreviewTitle>Example</PreviewTitle>
@@ -362,7 +362,8 @@ In Lism components, a string passed to the `setMask` prop is output as `--maskIm
       alt=""
       loading="lazy"
       ar="og"
-      setMask={`<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path fill="#000000" d="M170.4,25.7c16.1,14.2,23.2,38.5,24.8,61.7c1.7,23.3-1.8,45.5-12.9,62.3c-11,16.9-29.3,28.6-48.8,34.5 c-19.4,5.9-40,6.1-59.5,0.4c-19.5-5.6-37.9-17.4-51.7-34.9c-14-17.5-23.2-40.8-18-60.2c5-19.4,24.5-34.7,43.5-48.4 s37.6-25.7,59.5-29.7C129.1,7.3,154.2,11.4,170.4,25.7z" /></svg>`}
+      set="mask"
+      style={{ '--maskImg': `url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjAwIDIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBmaWxsPSIjMDAwMDAwIiBkPSJNMTcwLjQsMjUuN2MxNi4xLDE0LjIsMjMuMiwzOC41LDI0LjgsNjEuN2MxLjcsMjMuMy0xLjgsNDUuNS0xMi45LDYyLjNjLTExLDE2LjktMjkuMywyOC42LTQ4LjgsMzQuNSBjLTE5LjQsNS45LTQwLDYuMS01OS41LDAuNGMtMTkuNS01LjYtMzcuOS0xNy40LTUxLjctMzQuOWMtMTQtMTcuNS0yMy4yLTQwLjgtMTgtNjAuMmM1LTE5LjQsMjQuNS0zNC43LDQzLjUtNDguNCBzMzcuNi0yNS43LDU5LjUtMjkuN0MxMjkuMSw3LjMsMTU0LjIsMTEuNCwxNzAuNCwyNS43eiIgLz48L3N2Zz4=")` }}
     />
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
@@ -374,7 +375,8 @@ In Lism components, a string passed to the `setMask` prop is output as `--maskIm
       alt=""
       loading="lazy"
       ar="og"
-      setMask={`<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path fill="#000000" d="M170.4,25.7c16.1,14.2,23.2,38.5,24.8,61.7c1.7,23.3-1.8,45.5-12.9,62.3c-11,16.9-29.3,28.6-48.8,34.5 c-19.4,5.9-40,6.1-59.5,0.4c-19.5-5.6-37.9-17.4-51.7-34.9c-14-17.5-23.2-40.8-18-60.2c5-19.4,24.5-34.7,43.5-48.4 s37.6-25.7,59.5-29.7C129.1,7.3,154.2,11.4,170.4,25.7z" /></svg>`}
+      set="mask"
+      style={{ '--maskImg': 'url("data:image/svg+xml;base64,...")' }}
     />
     ```
   </PreviewCode>

--- a/apps/docs/src/content/en/skills.mdx
+++ b/apps/docs/src/content/en/skills.mdx
@@ -16,7 +16,7 @@ The skill consists of 10 files:
 | `set-class.md` | `set--` classes — `set--plain`/`set--shadow`/`set--hov`/`set--transition`, etc. |
 | `module-class.md` | Module classes — is--/l--/a--/c-- class list and usage |
 | `utility-class.md` | Utility classes — u-- class list |
-| `prop-class.md` | Prop Class — `-{prop}:{value}` syntax, key Prop list |
+| `prop-class.md` | Property Class — `-{prop}:{value}` syntax, key Prop list |
 | `prop-responsive.md` | Responsive design — breakpoints, container queries, usage patterns |
 | `components.md` | Component system — core, layout, semantic, and UI component list |
 | `css-rules.md` | CSS design rules — Layer structure, naming conventions, prefixes, custom CSS rules |

--- a/apps/docs/src/content/en/tokens.mdx
+++ b/apps/docs/src/content/en/tokens.mdx
@@ -61,7 +61,7 @@ For details on each token and scaling rules, see [Typography Tokens](/docs/token
 |`70`|`--s70`|`168px`|
 |`80`|`--s80`|`272px`|
 
-Fibonacci-based spacing scale. For supported prop classes, see [Spacing Tokens](/docs/tokens/spacing/).
+Fibonacci-based spacing scale. For supported property classes, see [Spacing Tokens](/docs/tokens/spacing/).
 
 
 ## `RADIUS`

--- a/apps/docs/src/content/en/tokens/colors.mdx
+++ b/apps/docs/src/content/en/tokens/colors.mdx
@@ -82,7 +82,7 @@ The `u--cbox` utility class generates `color`, `background-color`, and `border-c
     <Lism className="u--cbox" keycolor="red" p="20">
       <DummyText length="codes" />
     </Lism>
-    <Lism className="u--cbox" keycolor="purple" bd bdrs="20" bxsh="20" setShadow p="20">
+    <Lism className="u--cbox" keycolor="purple" bd bdrs="20" bxsh="20" set="shadow" p="20">
       <DummyText length="codes" />
     </Lism>
     <Lism className="u--cbox" keycolor="brand" bdc="keycolor" bd-x-s bdw="4px" p="20">
@@ -99,7 +99,7 @@ The `u--cbox` utility class generates `color`, `background-color`, and `border-c
   <PreviewCode slot="tab" label='JSX'>
     ```jsx
     <Lism className='u--cbox' keycolor='red' p='20'>...</Lism>
-    <Lism className='u--cbox' keycolor='purple' bd bdrs='20' bxsh='20' setShadow p='20'>...</Lism>
+    <Lism className='u--cbox' keycolor='purple' bd bdrs='20' bxsh='20' set="shadow" p='20'>...</Lism>
     <Lism className='u--cbox' keycolor='brand' bdc='keycolor' bd-x-s bdw='4px' p='20'>...</Lism>
     ```
   </PreviewCode>
@@ -108,28 +108,28 @@ The `u--cbox` utility class generates `color`, `background-color`, and `border-c
 
 <PreviewTitle>Palette color list</PreviewTitle>
 <PreviewArea p='20' ov-y='auto' max-h='25rem'>
-  <Lism className="u--cbox" keycolor="red" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="red" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="orange" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="orange" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="yellow" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="yellow" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="green" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="green" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="blue" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="blue" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="purple" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="purple" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="pink" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="pink" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="gray" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="gray" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
 </PreviewArea>

--- a/apps/docs/src/content/en/tokens/spacing.mdx
+++ b/apps/docs/src/content/en/tokens/spacing.mdx
@@ -1,14 +1,14 @@
 ---
 title: 'Spacing Tokens'
 navtitle: 'Spacing'
-description: 'An overview of Fibonacci-based spacing tokens in Lism CSS and which prop classes support them.'
+description: 'An overview of Fibonacci-based spacing tokens in Lism CSS and which property classes support them.'
 ---
 
 import { Box, Stack, Cluster, Columns, Frame, Center, Text } from 'lism-css/astro';
 import { DummyText } from '@lism-css/ui/astro';
 import { SpacingDemos } from "@/content/token-previews.jsx";
 
-This page covers Fibonacci-based spacing tokens and the prop classes that support them.
+This page covers Fibonacci-based spacing tokens and the property classes that support them.
 
 ## SPACE: Spacing Scale
 
@@ -50,14 +50,14 @@ Reference: [On typography and spacing scaling design](https://css-notes.com/layo
   - 5, 15, 25, ...など、`5`の倍数は前後の値の中間値となるように計算 */}
 
 
-## Supported Prop Classes
+## Supported Property Classes
 
-Spacing tokens can be used with `padding`, `margin`, and `gap` prop classes.
+Spacing tokens can be used with `padding`, `margin`, and `gap` property classes.
 However, **not all properties support them**.
 
 ### Full Support (Token Values 5–80)
 
-The following properties have prop classes for all spacing tokens: `5`, `10`, `15`, `20`, `30`, `40`, `50`, `60`, `70`, `80`.
+The following properties have property classes for all spacing tokens: `5`, `10`, `15`, `20`, `30`, `40`, `50`, `60`, `70`, `80`.
 
 | Property | CSS | Class examples | BP |
 |---|---|---|---|
@@ -74,7 +74,7 @@ The following properties have prop classes for all spacing tokens: `5`, `10`, `1
 
 ### No Preset Classes
 
-The following properties do not have preset spacing token prop classes. However, you can still specify values via CSS custom properties (`--px-s`, etc.) or JSX props (`px-s="20"`, etc.).
+The following properties do not have preset spacing token property classes. However, you can still specify values via CSS custom properties (`--px-s`, etc.) or JSX props (`px-s="20"`, etc.).
 
 | Property | CSS |
 |---|---|
@@ -92,7 +92,7 @@ The following properties do not have preset spacing token prop classes. However,
 
 ### Margin Auto Support
 
-Margin properties also have `auto` prop classes in addition to spacing tokens.
+Margin properties also have `auto` property classes in addition to spacing tokens.
 
 | Property | CSS | Class |
 |---|---|---|
@@ -105,5 +105,5 @@ Margin properties also have `auto` prop classes in addition to spacing tokens.
 | `my-e` | `margin-block-end` | `-my-e:auto` |
 
 <Reference>
-For a full list of prop classes, see [Prop Class Reference](/docs/prop-class/).
+For a full list of property classes, see [Property Class Reference](/docs/property-class/).
 </Reference>

--- a/apps/docs/src/content/en/ui/NavMenu.mdx
+++ b/apps/docs/src/content/en/ui/NavMenu.mdx
@@ -367,7 +367,7 @@ An example of adding `fxd='row'` to `<NavMenu.Root>` to display items horizontal
         <NavMenu.Item hov="o">
           <NavMenu.Link href="#menu1">Menu item</NavMenu.Link>
         </NavMenu.Item>
-        <NavMenu.Item setHov pos="relative">
+        <NavMenu.Item set="hov" pos="relative">
           <NavMenu.Link href="#menu3" ai="center" g="5">
             <Fragment>
               Hover Menu Item <Icon icon="caret-down" style={{ translate: '10%' }} />
@@ -395,7 +395,7 @@ An example of adding `fxd='row'` to `<NavMenu.Root>` to display items horizontal
         <NavMenu.Item hov="o">
           <NavMenu.Link href="#menu1">Menu item</NavMenu.Link>
         </NavMenu.Item>
-        <NavMenu.Item setHov pos="relative">
+        <NavMenu.Item set="hov" pos="relative">
           <NavMenu.Link href="#menu3" ai="center" g="5">
             <Fragment>
               Hover Menu Item <Icon icon="caret-down" style={{ translate: '10%' }} />

--- a/apps/docs/src/content/en/ui/ShapeDivider.mdx
+++ b/apps/docs/src/content/en/ui/ShapeDivider.mdx
@@ -66,13 +66,13 @@ By specifying `flip` to mirror the shape, you can use the same SVG path for both
 <Preview>
   <PreviewTitle>Preview</PreviewTitle>
   <PreviewArea resize p='0' layout=''>
-    <Wrapper setGutter py="40">
+    <Wrapper set="gutter" py="40">
       <DummyText />
     </Wrapper>
     <ShapeDivider viewBox="0 0 10 10" level="4">
       <path d="M10,10V0L0,9.5V10L10,10z"></path>
     </ShapeDivider>
-    <Wrapper setGutter bgc="text" c="base">
+    <Wrapper set="gutter" bgc="text" c="base">
       <Box py="40">
         <DummyText length="l" />
       </Box>
@@ -80,19 +80,19 @@ By specifying `flip` to mirror the shape, you can use the same SVG path for both
     <ShapeDivider viewBox="0 0 10 10" level="4" flip="XY">
       <path d="M10,10V0L0,9.5V10L10,10z"></path>
     </ShapeDivider>
-    <Wrapper setGutter py="40">
+    <Wrapper set="gutter" py="40">
       <DummyText />
     </Wrapper>
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx "\<ShapeDivider" "\/ShapeDivider\>" 'flip="XY"'
-    <Wrapper setGutter py='40'>
+    <Wrapper set="gutter" py='40'>
       <DummyText />
     </Wrapper>
     <ShapeDivider viewBox='0 0 10 10' level='4'>
       <path d='M10,10V0L0,9.5V10L10,10z'></path>
     </ShapeDivider>
-    <Wrapper setGutter bgc='text' c='base'>
+    <Wrapper set="gutter" bgc='text' c='base'>
       <Box py='40'>
         <DummyText length='l' />
       </Box>
@@ -100,7 +100,7 @@ By specifying `flip` to mirror the shape, you can use the same SVG path for both
     <ShapeDivider viewBox='0 0 10 10' level='4' flip='XY'>
       <path d='M10,10V0L0,9.5V10L10,10z'></path>
     </ShapeDivider>
-    <Wrapper setGutter py='40'>
+    <Wrapper set="gutter" py='40'>
       <DummyText />
     </Wrapper>
     ```
@@ -117,7 +117,7 @@ Even when empty, `level` still controls the height, making it useful for managin
 <Preview>
   <PreviewTitle>Preview</PreviewTitle>
   <PreviewArea resize p='0' layout=''>
-    <Wrapper setGutter bgc="base">
+    <Wrapper set="gutter" bgc="base">
       <ShapeDivider isEmpty level="5" />
       <Box py="20">
         <DummyText length="l" />
@@ -126,7 +126,7 @@ Even when empty, `level` still controls the height, making it useful for managin
         <path d="M10,10V0L0,9.5V10L10,10z"></path>
       </ShapeDivider>
     </Wrapper>
-    <Wrapper setGutter bgc="text" c="base">
+    <Wrapper set="gutter" bgc="text" c="base">
       <Box py="40">
         <DummyText length="l" />
       </Box>
@@ -134,7 +134,7 @@ Even when empty, `level` still controls the height, making it useful for managin
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx "isEmpty" 'level="5"'
-    <Wrapper setGutter bgc='base'>
+    <Wrapper set="gutter" bgc='base'>
       <ShapeDivider isEmpty level='5' />
       <Box py='20'>
         <DummyText length='l' />
@@ -143,7 +143,7 @@ Even when empty, `level` still controls the height, making it useful for managin
         <path d='M10,10V0L0,9.5V10L10,10z'></path>
       </ShapeDivider>
     </Wrapper>
-    <Wrapper setGutter bgc='text' c='base'>
+    <Wrapper set="gutter" bgc='text' c='base'>
       <Box py='40'>
         <DummyText length='l' />
       </Box>
@@ -162,7 +162,7 @@ An example with animation enabled using `isAnimation`.
 <Preview>
   <PreviewTitle>Preview</PreviewTitle>
   <PreviewArea p='15' layout='' resize>
-    <Container pos="relative" setGutter>
+    <Container pos="relative" set="gutter">
       <ShapeDivider isEmpty level="7" />
       <Frame isLayer z="-1" max-w="100%">
         <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
@@ -177,7 +177,7 @@ An example with animation enabled using `isAnimation`.
         <path d="M100,7.5C91.5,5,77.1,11.8,54,8C34.6,4.8,14.4,4.1,0,8.5V10h100V7.5z"></path>
       </ShapeDivider>
     </Container>
-    <Container isWrapper="s" setGutter bgc="base" py="40">
+    <Container isWrapper="s" set="gutter" bgc="base" py="40">
       <DummyText length="l" />
     </Container>
   </PreviewArea>
@@ -189,7 +189,7 @@ An example with animation enabled using `isAnimation`.
         <Media src='https://cdn.lism-css.com/img/a-1.jpg' alt='' width='960' height='640' />
         <Layer bgc='black:50%' />
       </Frame>
-      <Wrapper contentSize='s' setGutter py='40' c='white'>
+      <Wrapper contentSize='s' set="gutter" py='40' c='white'>
         <DummyText length='xl' />
       </Wrapper>
       <ShapeDivider viewBox='0 0 100 10' isAnimation c='base' level='7'>
@@ -198,7 +198,7 @@ An example with animation enabled using `isAnimation`.
         <path d='M100,7.5C91.5,5,77.1,11.8,54,8C34.6,4.8,14.4,4.1,0,8.5V10h100V7.5z'></path>
       </ShapeDivider>
     </Container>
-    <Container isWrapper='s' setGutter bgc='base' py='40'>
+    <Container isWrapper='s' set="gutter" bgc='base' py='40'>
       <DummyText length='l' />
     </Container>
     ```
@@ -215,11 +215,11 @@ In such cases, using `stretch` and `offset` to shift the SVG can produce a more 
 <Preview>
   <PreviewTitle>Using `stretch` and `offset`</PreviewTitle>
   <PreviewArea resize p='0' layout=''>
-    <Container isWrapper="s" setGutter bgc="base" py="40">
+    <Container isWrapper="s" set="gutter" bgc="base" py="40">
       <ShapeDivider isEmpty level="4" />
       <DummyText length="l" />
     </Container>
-    <Container pos="relative" setGutter c="base" bgc="text">
+    <Container pos="relative" set="gutter" c="base" bgc="text">
       <ShapeDivider viewBox="0 0 100 10" c="base" flip="Y" level="8" stretch={1.1} offset="-5%">
         <path d="M100 6C89.3 3.3 82.7 9 70 9S48.4 3 38 3 24.5 6 17 6C7.4 6 0 0 0 0v10h100V6z"></path>
       </ShapeDivider>
@@ -230,18 +230,18 @@ In such cases, using `stretch` and `offset` to shift the SVG can produce a more 
         <path d="M100 6C89.3 3.3 82.7 9 70 9S48.4 3 38 3 24.5 6 17 6C7.4 6 0 0 0 0v10h100V6z"></path>
       </ShapeDivider>
     </Container>
-    <Container isWrapper="s" setGutter bgc="base" py="40">
+    <Container isWrapper="s" set="gutter" bgc="base" py="40">
       <DummyText length="l" />
       <ShapeDivider isEmpty level="4" />
     </Container>
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx "stretch=" "offset="
-    <Container isWrapper='s' setGutter bgc='base' py='40'>
+    <Container isWrapper='s' set="gutter" bgc='base' py='40'>
       <ShapeDivider isEmpty level='4' />
       <DummyText length='l' />
     </Container>
-    <Container pos='relative' setGutter c='base' bgc='text'>
+    <Container pos='relative' set="gutter" c='base' bgc='text'>
       <ShapeDivider viewBox='0 0 100 10' c='base' flip='Y' level='8' stretch={1.1} offset='-5%'>
         <path d='M100 6C89.3 3.3 82.7 9 70 9S48.4 3 38 3 24.5 6 17 6C7.4 6 0 0 0 0v10h100V6z'></path>
       </ShapeDivider>
@@ -252,7 +252,7 @@ In such cases, using `stretch` and `offset` to shift the SVG can produce a more 
         <path d='M100 6C89.3 3.3 82.7 9 70 9S48.4 3 38 3 24.5 6 17 6C7.4 6 0 0 0 0v10h100V6z'></path>
       </ShapeDivider>
     </Container>
-    <Container isWrapper='s' setGutter bgc='base' py='40'>
+    <Container isWrapper='s' set="gutter" bgc='base' py='40'>
       <DummyText length='l' />
       <ShapeDivider isEmpty level='4' />
     </Container>

--- a/apps/docs/src/content/en/ui/examples/Banner.mdx
+++ b/apps/docs/src/content/en/ui/examples/Banner.mdx
@@ -16,13 +16,13 @@ Examples of using Lism to display banner links.
 <Preview>
   <PreviewTitle>Preview</PreviewTitle>
   <PreviewArea p='20'>
-    <LinkBox layout="frame" href="#banner-link" hov="o" setTransition bdrs="20">
+    <LinkBox layout="frame" href="#banner-link" hov="o" set="transition" bdrs="20">
       <img src="https://picsum.photos/seed/hogeee/1200/400" alt="" width="800" height="200" />
     </LinkBox>
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx "Frame" "LinkBox"
-    <LinkBox layout="frame" href="#banner-link" hov="o" setTransition bdrs="20">
+    <LinkBox layout="frame" href="#banner-link" hov="o" set="transition" bdrs="20">
       <img src="https://picsum.photos/seed/hogeee/1200/400" alt="" width="800" height="200" />
     </LinkBox>
     ```
@@ -40,7 +40,7 @@ Examples of using Lism to display banner links.
 <Preview>
   <PreviewTitle>Overlaying content on an image with `Layer`</PreviewTitle>
   <PreviewArea p='20' resize>
-    <LinkBox layout="frame" href="#banner-link" hov="o" setTransition bdrs="20">
+    <LinkBox layout="frame" href="#banner-link" hov="o" set="transition" bdrs="20">
       <Media isLayer src="https://picsum.photos/seed/hogeee/1200/400" alt="" width="960" height="640" loading="lazy" />
       <Flex jc="between" ai="center" pos="relative" g="20" p="30" c="#fff" bgc="rgb(0 0 0 / 50%)" min-h="30cqw">
         <Stack g="10">
@@ -55,7 +55,7 @@ Examples of using Lism to display banner links.
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx
-    <LinkBox layout="frame" href="#banner-link" hov="o" setTransition bdrs="20">
+    <LinkBox layout="frame" href="#banner-link" hov="o" set="transition" bdrs="20">
       <Media isLayer src="https://picsum.photos/seed/hogeee/1200/400" alt="" width="960" height="640" loading="lazy" />
       <Flex jc="between" ai="center" pos="relative" g="20" p="30" c="#fff" bgc="rgb(0 0 0 / 50%)" min-h="30cqw">
         <Stack g="10">

--- a/apps/docs/src/content/en/ui/examples/Card.mdx
+++ b/apps/docs/src/content/en/ui/examples/Card.mdx
@@ -13,7 +13,7 @@ Examples of creating card-style content layouts.
 
 export const ExampleCard = (props) => {
   return(
-    <SideMain isLinkBox href='###' hov='bxsh' setTransition sideW='50%' bgc='base' bdrs='20' bxsh='10' ov='hidden' {...props}>
+    <SideMain isLinkBox href='###' hov='bxsh' set="transition" sideW='50%' bgc='base' bdrs='20' bxsh='10' ov='hidden' {...props}>
       <Frame isSide ar='16/9' >
         <Media src='https://cdn.lism-css.com/img/a-1.jpg' alt='' width='960' height='640' />
       </Frame>
@@ -52,7 +52,7 @@ Additionally, [`is--linkBox`](/docs/modules/is--linkBox/) is applied to make the
 <Preview>
   <PreviewTitle>Preview</PreviewTitle>
   <PreviewArea bg=':stripe' resize p='30'>
-    <SideMain isLinkBox href="###" hov="bxsh" setTransition sideW="50%" bgc="base" bdrs="20" bxsh="10" ov="hidden">
+    <SideMain isLinkBox href="###" hov="bxsh" set="transition" sideW="50%" bgc="base" bdrs="20" bxsh="10" ov="hidden">
       <Frame isSide ar="16/9">
         <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
       </Frame>
@@ -65,7 +65,7 @@ Additionally, [`is--linkBox`](/docs/modules/is--linkBox/) is applied to make the
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx "SideMain" 'as="a" isLinkBox'
-    <SideMain isLinkBox href="###" hov="bxsh" setTransition sideW="50%" bgc="base" bdrs="20" bxsh="10" ov="hidden">
+    <SideMain isLinkBox href="###" hov="bxsh" set="transition" sideW="50%" bgc="base" bdrs="20" bxsh="10" ov="hidden">
       <Frame isSide ar="16/9">
         <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
       </Frame>
@@ -91,7 +91,7 @@ When you want to make the entire card a link while also including a separate lin
 <Preview>
   <PreviewTitle>Example using `u--expandedLink`</PreviewTitle>
   <PreviewArea bg=':stripe' resize p='30'>
-    <SideMain isLinkBox hov="bxsh" setTransition sideW="50%" bgc="base" bdrs="20" bxsh="10" ov="hidden">
+    <SideMain isLinkBox hov="bxsh" set="transition" sideW="50%" bgc="base" bdrs="20" bxsh="10" ov="hidden">
       <Frame isSide ar="16/9" pos="relative">
         <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
         <Link href="#badge-link" pos="absolute" t="0" r="0" fz="s" bgc="black" c="white" m="20" px="15" bdrs="99" td="none" hov="neutral">Category</Link>
@@ -107,7 +107,7 @@ When you want to make the entire card a link while also including a separate lin
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx "isLinkBox" "\<Link " "u--expandedLink"
-    <SideMain isLinkBox hov="bxsh" setTransition sideW="50%" bgc="base" bdrs="20" bxsh="10" ov="hidden">
+    <SideMain isLinkBox hov="bxsh" set="transition" sideW="50%" bgc="base" bdrs="20" bxsh="10" ov="hidden">
       <Frame isSide ar="16/9" pos="relative">
         <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
         <Link href="#badge-link" pos="absolute" t="0" r="0" fz="s" bgc="black" c="white" m="20" px="15" bdrs="99" td="none" hov="neutral">
@@ -230,7 +230,7 @@ When you want to make the entire card a link while also including a separate lin
 <Preview>
   <PreviewTitle>When specifying an aspect ratio on the media side in Flex, it locks to that ratio when the content side is shorter.</PreviewTitle>
   <PreviewArea bg=':stripe' resize p='20'>
-    <LinkBox href="#_" layout="flex" p="15" c="text" bgc="base" bd bdw="2px" bdc="base-2" bdrs="20" hov="bxsh" setHov setTransition>
+    <LinkBox href="#_" layout="flex" p="15" c="text" bgc="base" bd bdw="2px" bdc="base-2" bdrs="20" hov="bxsh" set={["hov", "transition"]}>
       <Frame w={['25%', '30%']} ar="1/1" fxsh="0" bdrs="10">
         <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
       </Frame>
@@ -243,7 +243,7 @@ When you want to make the entire card a link while also including a separate lin
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
     ```jsx 'ar="1/1"'
-    <LinkBox href="#_" layout="flex" p="15" c="text" bgc="base" bd bdw="2px" bdc="base-2" bdrs="20" hov="bxsh" setHov setTransition>
+    <LinkBox href="#_" layout="flex" p="15" c="text" bgc="base" bd bdw="2px" bdc="base-2" bdrs="20" hov="bxsh" set={["hov", "transition"]}>
       <Frame w={['25%', '30%']} ar="1/1" fxsh="0" bdrs="10">
         <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
       </Frame>
@@ -283,11 +283,10 @@ An example using `Grid` to toggle between horizontal and vertical layouts at a b
       bdrs="20"
       bxsh="10"
       hov="bxsh"
-      setHov
-      setTransition
+      set={["hov", "transition"]}
     >
       <Frame ga="img" aslf="stretch" ar={['og', '1/1']} max-w="100%" pos="relative" bdrs="20" bxsh="10">
-        <Media css={{ scale: 'var(--_isHov, 1.25)' }} setTransition src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
+        <Media css={{ scale: 'var(--_isHov, 1.25)' }} set="transition" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
       </Frame>
       <Stack g="20" p="15">
         <h3 className="-fz:l">Card Title</h3>
@@ -312,11 +311,10 @@ An example using `Grid` to toggle between horizontal and vertical layouts at a b
       bdrs="20"
       bxsh="10"
       hov="bxsh"
-      setHov
-      setTransition
+      set={["hov", "transition"]}
     >
       <Frame ga="img" aslf="stretch" ar={['og', '1/1']} max-w="100%" pos="relative" bdrs="20" bxsh="10">
-        <Media css={{ scale: 'var(--_isHov, 1.25)' }} setTransition src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
+        <Media css={{ scale: 'var(--_isHov, 1.25)' }} set="transition" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
       </Frame>
       <Stack g="20" p="15">
         <h3 className="-fz:l">Card Title</h3>
@@ -347,7 +345,7 @@ The following example requires a custom `.-hov\:to\:slide` class to be defined s
 }`}>
   <PreviewTitle>Preview</PreviewTitle>
   <PreviewArea bg=':stripe' p='20'>
-    <LinkBox href="#card-a" pos="relative" bdrs="20" bxsh="20" ov="hidden" setHov max-w="xs" mx="auto">
+    <LinkBox href="#card-a" pos="relative" bdrs="20" bxsh="20" ov="hidden" set="hov" max-w="xs" mx="auto">
       <Frame ar="1/1">
         <img src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
       </Frame>
@@ -356,7 +354,7 @@ The following example requires a custom `.-hov\:to\:slide` class to be defined s
         <Layer style={{ backdropFilter: 'blur(6px) brightness(1.1)' }} />
         <Box pos="relative" z="1" c="white" lh="s">
           <h3 className="u--trim -fz:l">Card Title</h3>
-          <Grid setTransition hov="to:slide" my="15">
+          <Grid set="transition" hov="to:slide" my="15">
             <Box ov="hidden">
               <DummyText py="5" fz="s" lh="xs" />
             </Box>
@@ -367,8 +365,8 @@ The following example requires a custom `.-hov\:to\:slide` class to be defined s
     </LinkBox>
   </PreviewArea>
   <PreviewCode slot='tab' label='JSX'>
-  ```jsx "setHov" 'hov="to:slide"'
-  <LinkBox href="#card-a" pos="relative" bdrs="20" bxsh="20" ov="hidden" setHov max-w="xs" mx="auto">
+  ```jsx 'set="hov"' 'hov="to:slide"'
+  <LinkBox href="#card-a" pos="relative" bdrs="20" bxsh="20" ov="hidden" set="hov" max-w="xs" mx="auto">
     <Frame ar="1/1">
       <img src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
     </Frame>
@@ -377,7 +375,7 @@ The following example requires a custom `.-hov\:to\:slide` class to be defined s
       <Layer style={{ backdropFilter: 'blur(6px) brightness(1.1)' }} />
       <Box pos="relative" z="1" c="white" lh="s">
         <h3 className="u--trim -fz:l">Card Title</h3>
-        <Grid setTransition hov="to:slide" my="15">
+        <Grid set="transition" hov="to:slide" my="15">
           <Box ov="hidden">
             <DummyText py="5" fz="s" lh="xs" />
           </Box>

--- a/apps/docs/src/content/en/ui/examples/Hero.mdx
+++ b/apps/docs/src/content/en/ui/examples/Hero.mdx
@@ -20,7 +20,7 @@ Examples of creating hero content sections.
   <PreviewTitle>Example 1</PreviewTitle>
   <PreviewArea resize>
     <Stack isContainer max-sz="full" min-h="50vh" bgc="base-2">
-      <Flow isWrapper setGutter my="auto">
+      <Flow isWrapper set="gutter" my="auto">
         <Text fw="bold" fz="xl">DEMO 01</Text>
         <DummyText length="l" lang="ja" />
       </Flow>
@@ -29,7 +29,7 @@ Examples of creating hero content sections.
   <PreviewCode>
     ```jsx
     <Stack isContainer max-sz="full" min-h="50vh" bgc="base-2">
-      <Flow isWrapper setGutter my="auto">
+      <Flow isWrapper set="gutter" my="auto">
         <Text fw="bold" fz="xl">
           DEMO 01
         </Text>
@@ -57,7 +57,7 @@ Examples of creating hero content sections.
           <div>XXX</div>
         </Flex>
       </Flex>
-      <Flow isWrapper setGutter my="auto" z="0">
+      <Flow isWrapper set="gutter" my="auto" z="0">
         <Text fw="bold" fz="xl">DEMO 02</Text>
         <DummyText length="l" />
       </Flow>
@@ -78,7 +78,7 @@ Examples of creating hero content sections.
           <div>XXX</div>
         </Flex>
       </Flex>
-      <Flow isWrapper setGutter my="auto" z="0">
+      <Flow isWrapper set="gutter" my="auto" z="0">
         <Text fw="bold" fz="xl">
           DEMO 02
         </Text>
@@ -104,7 +104,7 @@ The following example also uses the opt-in component [`<ShapeDivider>`](/docs/ui
 <Preview>
   <PreviewTitle>With ShapDivide & Layers</PreviewTitle>
   <PreviewArea resize>
-    <Stack isContainer max-sz="full" setGutter pos="relative" min-h="50vh" c="white" g="15">
+    <Stack isContainer max-sz="full" set="gutter" pos="relative" min-h="50vh" c="white" g="15">
       <ShapeDivider viewBox="0 0 10 10" c="base" level="6" flip="XY" z="1">
         <path d="M10,10V0L0,9.5V10L10,10z" />
       </ShapeDivider>
@@ -123,7 +123,7 @@ The following example also uses the opt-in component [`<ShapeDivider>`](/docs/ui
   </PreviewArea>
   <PreviewCode>
     ```jsx "\<Frame isLayer" "\<ShapeDivider"
-    <Stack isContainer max-sz="full" setGutter pos="relative" min-h="50vh" c="white" g="15">
+    <Stack isContainer max-sz="full" set="gutter" pos="relative" min-h="50vh" c="white" g="15">
       <ShapeDivider viewBox="0 0 10 10" c="base" level="6" flip="Y" z="1">
         <path d="M10,10V0L0,9.5V10L10,10z" />
       </ShapeDivider>
@@ -150,7 +150,7 @@ The following example also uses the opt-in component [`<ShapeDivider>`](/docs/ui
   <PreviewTitle>Using clipPath to create a diagonal transition between sections with background images</PreviewTitle>
   <PreviewArea resize p='20'>
     <Box max-sz="full" style={{ '--slopeH': 'clamp(2rem, 4cqw, 4rem)' }}>
-      <Stack isContainer max-sz="full" setGutter pos="relative" min-h="50vh" c="white" g="15">
+      <Stack isContainer max-sz="full" set="gutter" pos="relative" min-h="50vh" c="white" g="15">
         <ShapeDivider viewBox="0 0 10 10" h="var(--slopeH)" c="base" flip="Y" z="1">
           <path d="M10,10V0L0,9.5V10L10,10z"></path>
         </ShapeDivider>
@@ -164,7 +164,7 @@ The following example also uses the opt-in component [`<ShapeDivider>`](/docs/ui
         </Flow>
         <Spacer h="var(--slopeH)" />
       </Stack>
-      <Stack isContainer max-sz="full" setGutter pos="relative" min-h="50vh" c="white" my-s="calc(0px - var(--slopeH))">
+      <Stack isContainer max-sz="full" set="gutter" pos="relative" min-h="50vh" c="white" my-s="calc(0px - var(--slopeH))">
         <Frame
           isLayer
           style={{
@@ -188,7 +188,7 @@ The following example also uses the opt-in component [`<ShapeDivider>`](/docs/ui
   <PreviewCode>
     ```jsx "--slopeH"
     <Box max-sz="full" style={{ '--slopeH': 'clamp(2.5rem, 1.25rem + 5cqw, 5rem)' }}>
-      <Stack isContainer max-sz="full" setGutter pos="relative" min-h="50vh" c="white" g="15">
+      <Stack isContainer max-sz="full" set="gutter" pos="relative" min-h="50vh" c="white" g="15">
         <ShapeDivider viewBox="0 0 10 10" h="var(--slopeH)" c="base" flip="Y" z="1">
           <path d="M10,10V0L0,9.5V10L10,10z"></path>
         </ShapeDivider>
@@ -204,7 +204,7 @@ The following example also uses the opt-in component [`<ShapeDivider>`](/docs/ui
         </Flow>
         <Spacer h="var(--slopeH)" />
       </Stack>
-      <Stack isContainer max-sz="full" setGutter pos="relative" min-h="50vh" c="white" my-s="calc(0px - var(--slopeH))">
+      <Stack isContainer max-sz="full" set="gutter" pos="relative" min-h="50vh" c="white" my-s="calc(0px - var(--slopeH))">
         <Frame
           isLayer
           style={{

--- a/apps/docs/src/content/en/utility-class.mdx
+++ b/apps/docs/src/content/en/utility-class.mdx
@@ -26,7 +26,7 @@ Generates `--c`, `--bgc`, and `--bdc` from the `--keycolor` variable using `colo
     <Lism className="u--cbox" keycolor="red" p="20">
       <DummyText length="codes" />
     </Lism>
-    <Lism className="u--cbox" keycolor="purple" bd bdrs="20" bxsh="20" setShadow p="20">
+    <Lism className="u--cbox" keycolor="purple" bd bdrs="20" bxsh="20" set="shadow" p="20">
       <DummyText length="codes" />
     </Lism>
     <Lism className="u--cbox" keycolor="brand" bdc="keycolor" bd-x-s bdw="4px" p="20">
@@ -118,83 +118,83 @@ Generates `--c`, `--bgc`, and `--bdc` from the `--keycolor` variable using `colo
 
 <PreviewTitle>Palette color list</PreviewTitle>
 <PreviewArea p='20' ov-y='auto' max-h='25rem'>
-  <Lism className="u--cbox" keycolor="red" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="red" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="orange" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="orange" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="yellow" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="yellow" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="purple" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="purple" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="green" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="green" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="blue" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="blue" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="purple" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="purple" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="pink" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="pink" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="gray" bd bdrs="20" bxsh="20" setShadow p="20">
+  <Lism className="u--cbox" keycolor="gray" bd bdrs="20" bxsh="20" set="shadow" p="20">
     <DummyText length="codes" />
   </Lism>
   <hr />
-  <Lism className="u--cbox" keycolor="red" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" setShadow p="20">
+  <Lism className="u--cbox" keycolor="red" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" set="shadow" p="20">
     <Inline c="keycolor" fw="bold">
       <Fragment>Title Text</Fragment>
     </Inline>
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="orange" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" setShadow p="20">
+  <Lism className="u--cbox" keycolor="orange" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" set="shadow" p="20">
     <Inline c="keycolor" fw="bold">
       <Fragment>Title Text</Fragment>
     </Inline>
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="yellow" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" setShadow p="20">
+  <Lism className="u--cbox" keycolor="yellow" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" set="shadow" p="20">
     <Inline c="keycolor" fw="bold">
       <Fragment>Title Text</Fragment>
     </Inline>
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="purple" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" setShadow p="20">
+  <Lism className="u--cbox" keycolor="purple" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" set="shadow" p="20">
     <Inline c="keycolor" fw="bold">
       <Fragment>Title Text</Fragment>
     </Inline>
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="green" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" setShadow p="20">
+  <Lism className="u--cbox" keycolor="green" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" set="shadow" p="20">
     <Inline c="keycolor" fw="bold">
       <Fragment>Title Text</Fragment>
     </Inline>
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="blue" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" setShadow p="20">
+  <Lism className="u--cbox" keycolor="blue" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" set="shadow" p="20">
     <Inline c="keycolor" fw="bold">
       <Fragment>Title Text</Fragment>
     </Inline>
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="purple" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" setShadow p="20">
+  <Lism className="u--cbox" keycolor="purple" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" set="shadow" p="20">
     <Inline c="keycolor" fw="bold">
       <Fragment>Title Text</Fragment>
     </Inline>
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="pink" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" setShadow p="20">
+  <Lism className="u--cbox" keycolor="pink" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" set="shadow" p="20">
     <Inline c="keycolor" fw="bold">
       <Fragment>Title Text</Fragment>
     </Inline>
     <DummyText length="codes" />
   </Lism>
-  <Lism className="u--cbox" keycolor="gray" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" setShadow p="20">
+  <Lism className="u--cbox" keycolor="gray" bd-x-s bdc="keycolor" bdw="4px" bxsh="10" set="shadow" p="20">
     <Inline c="keycolor" fw="bold">
       <Fragment>Title Text</Fragment>
     </Inline>


### PR DESCRIPTION
## Summary
- `apps/docs/src/content/en/` 配下の英語ドキュメント24ファイルを更新
- `prop-class.mdx` → `property-class.mdx` にファイルリネーム（`git mv`）
- 全ファイルで「Prop Class」→「Property Class」、「prop-class」→「property-class」の用語・URLリネーム
- `setXxxx` 形式の props を `set="xxx"` / `set={["xxx", "yyy"]}` 形式に統一更新
- `setMask` セクションを `set="mask"` + 手動 `--maskImg` 設定に書き換え
- コードハイライトマーカーも新記法に合わせて更新

Closes #191

## Test plan
- [x] `rg 'Prop Class'` でゼロ件を確認
- [x] `rg 'set(Gutter|Shadow|Hov|Transition|Plain|InnerRs|Bp|Mask)'` でゼロ件を確認
- [x] `rg 'prop-class'` で skills.mdx のスキルファイル名参照のみ残存を確認（正常）

🤖 Generated with [Claude Code](https://claude.com/claude-code)