### PR TITLE
fix: d プロパティに inline/inline-block を追加し、テストを実装に合わせて修正

### DIFF
--- a/packages/lism-css/config/defaults/props.ts
+++ b/packages/lism-css/config/defaults/props.ts
@@ -52,7 +52,7 @@ export default {
 
   d: {
     prop: 'display',
-    presets: ['none', 'block', 'flex', 'inline-flex', 'grid', 'inline-grid'],
+    presets: ['none', 'block', 'flex', 'inline-flex', 'grid', 'inline-grid', 'inline', 'inline-block'],
     bp: 1,
   },
   o: { prop: 'opacity', presets: ['0'], token: 'o', tokenClass: 1 },

--- a/packages/lism-css/src/components/Lism/Lism.test.tsx
+++ b/packages/lism-css/src/components/Lism/Lism.test.tsx
@@ -541,6 +541,26 @@ describe('Lism', () => {
         expect(element).toHaveClass('-d:block');
       });
 
+      test('d="inline" を指定できる', () => {
+        render(
+          <Lism d="inline" data-testid="lism">
+            test
+          </Lism>
+        );
+        const element = screen.getByTestId('lism');
+        expect(element).toHaveClass('-d:inline');
+      });
+
+      test('d="inline-block" を指定できる', () => {
+        render(
+          <Lism d="inline-block" data-testid="lism">
+            test
+          </Lism>
+        );
+        const element = screen.getByTestId('lism');
+        expect(element).toHaveClass('-d:inline-block');
+      });
+
       test('d="inline-flex" を指定できる', () => {
         render(
           <Lism d="inline-flex" data-testid="lism">

--- a/packages/lism-css/src/components/Lism/Lism.test.tsx
+++ b/packages/lism-css/src/components/Lism/Lism.test.tsx
@@ -541,14 +541,14 @@ describe('Lism', () => {
         expect(element).toHaveClass('-d:block');
       });
 
-      test('d="in-flex" を指定できる', () => {
+      test('d="inline-flex" を指定できる', () => {
         render(
-          <Lism d="in-flex" data-testid="lism">
+          <Lism d="inline-flex" data-testid="lism">
             test
           </Lism>
         );
         const element = screen.getByTestId('lism');
-        expect(element).toHaveClass('-d:in-flex');
+        expect(element).toHaveClass('-d:inline-flex');
       });
 
       test('v（visibility）を指定できる', () => {
@@ -590,7 +590,7 @@ describe('Lism', () => {
           </Lism>
         );
         const element = screen.getByTestId('lism');
-        expect(element).toHaveClass('-pos:rel');
+        expect(element).toHaveClass('-pos:relative');
       });
 
       test('pos="absolute" を指定できる', () => {
@@ -600,7 +600,7 @@ describe('Lism', () => {
           </Lism>
         );
         const element = screen.getByTestId('lism');
-        expect(element).toHaveClass('-pos:abs');
+        expect(element).toHaveClass('-pos:absolute');
       });
 
       test('pos="fixed" を指定できる', () => {
@@ -783,22 +783,22 @@ describe('Lism', () => {
 
         test('fxd（flex-direction）を指定できる', () => {
           render(
-            <Lism fxd="col" data-testid="lism">
+            <Lism fxd="column" data-testid="lism">
               test
             </Lism>
           );
           const element = screen.getByTestId('lism');
-          expect(element).toHaveClass('-fxd:col');
+          expect(element).toHaveClass('-fxd:column');
         });
 
-        test('fxd="row-r" を指定できる', () => {
+        test('fxd="row-reverse" を指定できる', () => {
           render(
-            <Lism fxd="row-r" data-testid="lism">
+            <Lism fxd="row-reverse" data-testid="lism">
               test
             </Lism>
           );
           const element = screen.getByTestId('lism');
-          expect(element).toHaveClass('-fxd:row-r');
+          expect(element).toHaveClass('-fxd:row-reverse');
         });
 
         test('fx（flex）を指定できる', () => {
@@ -875,12 +875,12 @@ describe('Lism', () => {
 
         test('gaf（grid-auto-flow）を指定できる', () => {
           render(
-            <Lism gaf="col" data-testid="lism">
+            <Lism gaf="column" data-testid="lism">
               test
             </Lism>
           );
           const element = screen.getByTestId('lism');
-          expect(element).toHaveClass('-gaf:col');
+          expect(element).toHaveClass('-gaf:column');
         });
 
         test('ga（grid-area）を指定できる', () => {
@@ -1034,12 +1034,12 @@ describe('Lism', () => {
 
       test('ovwrap（overflow-wrap）を指定できる', () => {
         render(
-          <Lism ovwrap="any" data-testid="lism">
+          <Lism ovwrap="anywhere" data-testid="lism">
             test
           </Lism>
         );
         const element = screen.getByTestId('lism');
-        expect(element).toHaveClass('-ovwrap:any');
+        expect(element).toHaveClass('-ovwrap:anywhere');
       });
     });
 

--- a/packages/lism-css/src/lib/types/PropValueTypes.spec-d.ts
+++ b/packages/lism-css/src/lib/types/PropValueTypes.spec-d.ts
@@ -40,7 +40,21 @@ describe('PropValueTypes', () => {
   it('d には presets と utils の値を設定できる（レスポンシブ対応）', () => {
     // bp: 1 なので Responsive でラップされる
     expectTypeOf<PropValueTypes['d']>().toEqualTypeOf<
-      Responsive<'none' | 'block' | 'flex' | 'inline-flex' | 'grid' | 'inline-grid' | (string & {}) | number | boolean | null | undefined>
+      Responsive<
+        | 'none'
+        | 'block'
+        | 'flex'
+        | 'inline-flex'
+        | 'grid'
+        | 'inline-grid'
+        | 'inline'
+        | 'inline-block'
+        | (string & {})
+        | number
+        | boolean
+        | null
+        | undefined
+      >
     >();
   });
 
@@ -176,7 +190,19 @@ describe('ResponsivePropValueTypes', () => {
     type DProp = Props['d'];
 
     expectTypeOf<DProp>().toEqualTypeOf<
-      'none' | 'block' | 'flex' | 'inline-flex' | 'grid' | 'inline-grid' | (string & {}) | number | boolean | null | undefined
+      | 'none'
+      | 'block'
+      | 'flex'
+      | 'inline-flex'
+      | 'grid'
+      | 'inline-grid'
+      | 'inline'
+      | 'inline-block'
+      | (string & {})
+      | number
+      | boolean
+      | null
+      | undefined
     >();
   });
 });

--- a/packages/lism-css/src/scss/_prop-config.scss
+++ b/packages/lism-css/src/scss/_prop-config.scss
@@ -105,6 +105,8 @@ $props: (
       'inline-flex': 'inline-flex',
       'grid': 'grid',
       'inline-grid': 'inline-grid',
+      'inline': 'inline',
+      'inline-block': 'inline-block',
     ),
     bp: 1,
   ),


### PR DESCRIPTION
## Summary

- **#193**: `d`（display）プロパティの presets に `inline`, `inline-block` を追加
- **#205**: テストが実装に存在しない短縮値を使っていた7件を修正

## 変更内容

- `config/defaults/props.ts`: `d` の presets に `inline`, `inline-block` を追加
- `Lism.test.tsx`: 実装と不一致だった7件のテストを修正
  - `d="in-flex"` → `d="inline-flex"`
  - `pos` の期待値を `-pos:relative`, `-pos:absolute` に修正
  - `fxd` の入力を `column`, `row-reverse` に修正
  - `gaf` の入力を `column` に修正
  - `ovwrap` の入力を `anywhere` に修正
- `PropValueTypes.spec-d.ts`: `d` の型テストに `'inline' | 'inline-block'` を追加
- `_prop-config.scss`: ビルドで自動再生成

Closes #193
Closes #205

## Test plan

- [x] `pnpm --filter lism-css test` — 全661テスト通過
- [x] `pnpm build` — 全体ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)