### PR TITLE
refactor: l--grid の CSS変数削除と Badge/Button の _propConfig 廃止

### DIFF
--- a/apps/docs/src/content/en/modules/l--grid.mdx
+++ b/apps/docs/src/content/en/modules/l--grid.mdx
@@ -57,7 +57,7 @@ A component for arranging content in a **Grid layout**.
   </PreviewCode>
   <PreviewCode slot='tab' label='HTML'>
     ```html
-    <div class="l--grid -g:15 -gtc" style="--gtc: auto 1fr auto">
+    <div class="l--grid -gtc -g:15" style="--gtc: auto 1fr auto">
       <div class="l--center -p:20 -bgc:base-2">L</div>
       <div class="l--center -p:20 -bd">Center</div>
       <div class="l--center -p:20 -bgc:base-2">R</div>

--- a/apps/docs/src/content/en/property-class.mdx
+++ b/apps/docs/src/content/en/property-class.mdx
@@ -481,7 +481,7 @@ Here are some examples of positioning elements with `position: absolute`.
   </PreviewArea>
   <PreviewCode slot="tab" label="HTML">
   ```html "-gc:1/-1" "--gtc:"
-  <div class="l--grid -g:20" style="--gtc: repeat(2, 1fr)">
+  <div class="l--grid -g:20 -gtc" style="--gtc: repeat(2, 1fr)">
     <div class="-gc:1/-1 -bd -p:10 -bgc:base-2">Item A</div>
     <div class="-bd -p:10 -bgc:base-2">Item B</div>
     <div class="-bd -p:10 -bgc:base-2">Item C</div>
@@ -498,8 +498,6 @@ Here are some examples of positioning elements with `position: absolute`.
   ```
   </PreviewCode>
 </Preview>
-
-In the above Examples, `--gtc` variable is accepted even without a `-gtc` class because `l--grid` receives `--gtc`.
 
 
 ### Places

--- a/apps/docs/src/content/en/ui/Badge.mdx
+++ b/apps/docs/src/content/en/ui/Badge.mdx
@@ -134,9 +134,10 @@ Provided as `Badge` (`.c--badge`) from the `@lism-css/ui` package.
   <PreviewCode slot='tab' label='HTML'>
     ```html
     <div class="l--cluster -g:15">
-      <span class="c--badge -fz:xs -lh:xs -py:5 -px:10 -bdrs:10">Badge</span>
-      <span class="c--badge -fz:xs -lh:xs -py:5 -px:10 -bdrs:10" style="--bgc: var(--red)">Badge</span>
-      ... ...
+      <span class="c--badge -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:10">Badge</span>
+      <span class="c--badge -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:10 -bgc" style="--bgc: var(--red)">Badge</span>
+      <span class="c--badge -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:10 -bgc" style="--bgc: var(--orange)">Badge</span>
+      ...
     </div>
     ```
   </PreviewCode>

--- a/apps/docs/src/content/en/ui/Button.mdx
+++ b/apps/docs/src/content/en/ui/Button.mdx
@@ -140,22 +140,8 @@ Provided as `Button` (`.c--button`) from the `@lism-css/ui` package.
     <div class="l--flex -g:15">
       <a class="c--button l--flex -lh:s -py:10 -px:20 -hov:o" href="###">Button</a>
       <a class="c--button l--flex -lh:s -py:10 -px:20 -hov:o -bgc:brand -bdrs:10" href="###">Button</a>
-      <a class="c--button l--flex -lh:s -py:10 -px:20 -hov:o -bdrs:99" style="--bgc: #d13d5e" href="###">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 256 256"
-          width="1em"
-          height="1em"
-          fill="currentColor"
-          focusable="false"
-          class="a--icon"
-          aria-hidden="true"
-        >
-          <path
-            d="M230.14,58.87A8,8,0,0,0,224,56H62.68L56.6,22.57A8,8,0,0,0,48.73,16H24a8,8,0,0,0,0,16h18L67.56,172.29a24,24,0,0,0,5.33,11.27,28,28,0,1,0,44.4,8.44h45.42A27.75,27.75,0,0,0,160,204a28,28,0,1,0,28-28H91.17a8,8,0,0,1-7.87-6.57L80.13,152h116a24,24,0,0,0,23.61-19.71l12.16-66.86A8,8,0,0,0,230.14,58.87ZM104,204a12,12,0,1,1-12-12A12,12,0,0,1,104,204Zm96,0a12,12,0,1,1-12-12A12,12,0,0,1,200,204Zm4-74.57A8,8,0,0,1,196.1,136H77.22L65.59,72H214.41Z"
-          ></path>
-        </svg>
-        Button
+      <a class="c--button l--flex -lh:s -py:10 -px:20 -hov:o -bgc -bdrs:99" style="--bgc: #d13d5e" href="###">
+        <svg class="a--icon"...>...</svg>Button
       </a>
     </div>
     ```
@@ -195,22 +181,8 @@ Provided as `Button` (`.c--button`) from the `@lism-css/ui` package.
     <div class="l--flex -g:15">
       <a class="c--button c--button--outline l--flex -lh:s -py:10 -px:20 -hov:o" href="###">Button</a>
       <a class="c--button c--button--outline l--flex -lh:s -py:10 -px:20 -hov:o -c:brand -bdrs:10" href="###">Button</a>
-      <a class="c--button c--button--outline l--flex -lh:s -py:10 -px:20 -hov:o -bdrs:99" style="--c: #d13d5e" href="###">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 256 256"
-          width="1em"
-          height="1em"
-          fill="currentColor"
-          focusable="false"
-          class="a--icon"
-          aria-hidden="true"
-        >
-          <path
-            d="M230.14,58.87A8,8,0,0,0,224,56H62.68L56.6,22.57A8,8,0,0,0,48.73,16H24a8,8,0,0,0,0,16h18L67.56,172.29a24,24,0,0,0,5.33,11.27,28,28,0,1,0,44.4,8.44h45.42A27.75,27.75,0,0,0,160,204a28,28,0,1,0,28-28H91.17a8,8,0,0,1-7.87-6.57L80.13,152h116a24,24,0,0,0,23.61-19.71l12.16-66.86A8,8,0,0,0,230.14,58.87ZM104,204a12,12,0,1,1-12-12A12,12,0,0,1,104,204Zm96,0a12,12,0,1,1-12-12A12,12,0,0,1,200,204Zm4-74.57A8,8,0,0,1,196.1,136H77.22L65.59,72H214.41Z"
-          ></path>
-        </svg>
-        Button
+      <a class="c--button c--button--outline l--flex -lh:s -py:10 -px:20 -hov:o -c -bdrs:99" style="--c: #d13d5e" href="###">
+        <svg class="a--icon"...>...</svg>Button
       </a>
     </div>
     ```
@@ -457,7 +429,7 @@ An example of building a Button using only lism-css, without `@lism-css/ui`.
       <a href="###" class="-d:inline-flex -w:fit -td:none -c:inherit -bd -lh:s -py:10 -px:20 -bdrs:20 -hov:o">Button</a>
     </div>
     <a
-      class="l--grid -ji:center -ai:center -px:15 -py:10 -g:30 -w -td:none -bgc:text -c:base -bdrs:20 -hov:neutral"
+      class="l--grid -ji:center -ai:center -px:15 -py:10 -g:30 -w -gtc -td:none -bgc:text -c:base -bdrs:20 -hov:neutral"
       style="--w: 16rem; --gtc: 1em 1fr 1em"
       href="###"
     >

--- a/apps/docs/src/content/ja/modules/l--grid.mdx
+++ b/apps/docs/src/content/ja/modules/l--grid.mdx
@@ -57,7 +57,7 @@ import { DummyText } from '@lism-css/ui/astro';
   </PreviewCode>
   <PreviewCode slot='tab' label='HTML'>
     ```html
-    <div class="l--grid -g:15 -gtc" style="--gtc: auto 1fr auto">
+    <div class="l--grid -gtc -g:15" style="--gtc: auto 1fr auto">
       <div class="l--center -p:20 -bgc:base-2">L</div>
       <div class="l--center -p:20 -bd">Center</div>
       <div class="l--center -p:20 -bgc:base-2">R</div>

--- a/apps/docs/src/content/ja/property-class.mdx
+++ b/apps/docs/src/content/ja/property-class.mdx
@@ -481,7 +481,7 @@ export const LinkSPACE = () => <a href="/docs/tokens/spacing/"><code>SPACE</code
   </PreviewArea>
   <PreviewCode slot="tab" label="HTML">
   ```html "-gc:1/-1" "--gtc:"
-  <div class="l--grid -g:20" style="--gtc: repeat(2, 1fr)">
+  <div class="l--grid -g:20 -gtc" style="--gtc: repeat(2, 1fr)">
     <div class="-gc:1/-1 -bd -p:10 -bgc:base-2">Item A</div>
     <div class="-bd -p:10 -bgc:base-2">Item B</div>
     <div class="-bd -p:10 -bgc:base-2">Item C</div>
@@ -498,8 +498,6 @@ export const LinkSPACE = () => <a href="/docs/tokens/spacing/"><code>SPACE</code
   ```
   </PreviewCode>
 </Preview>
-
-上記 Examples で`-gtc`クラスがなくても`--gtc`変数が受け取れているのは、`l--grid`が `--gtc`を受け取るためです。
 
 
 ### Places

--- a/apps/docs/src/content/ja/ui/Badge.mdx
+++ b/apps/docs/src/content/ja/ui/Badge.mdx
@@ -24,9 +24,7 @@ import { Badge } from '@lism-css/ui/astro';
     <Cluster g="15">
       <Badge>Badge</Badge>
       <Badge variant="outline">Badge</Badge>
-      <Badge className="u--cbox" keycolor="blue" bdrs="99">
-        Badge
-      </Badge>
+      <Badge className="u--cbox" keycolor="blue" bdrs="99">Badge</Badge>
     </Cluster>
     ```
   </PreviewCode>
@@ -35,9 +33,7 @@ import { Badge } from '@lism-css/ui/astro';
     <div class="l--cluster -g:15">
       <span class="c--badge -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:10">Badge</span>
       <span class="c--badge c--badge--outline -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:10">Badge</span>
-      <span class="u--cbox c--badge -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:99" style="--keycolor:var(--blue)">
-        Badge
-      </span>
+      <span class="u--cbox c--badge -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:99" style="--keycolor:var(--blue)">Badge</span>
     </div>
     ```
   </PreviewCode>
@@ -124,18 +120,10 @@ import { Badge } from '@lism-css/ui/astro';
       <Badge bgc="orange">Badge</Badge>
       <Badge bgc="yellow">Badge</Badge>
       <Badge bgc="green">Badge</Badge>
-      <Badge bgc="blue" bdrs="99">
-        Badge
-      </Badge>
-      <Badge bgc="purple" bdrs="99">
-        Badge
-      </Badge>
-      <Badge bgc="pink" bdrs="99">
-        Badge
-      </Badge>
-      <Badge bgc="gray" bdrs="99">
-        Badge
-      </Badge>
+      <Badge bgc="blue" bdrs="99">Badge</Badge>
+      <Badge bgc="purple" bdrs="99">Badge</Badge>
+      <Badge bgc="pink" bdrs="99">Badge</Badge>
+      <Badge bgc="gray" bdrs="99">Badge</Badge>
     </Cluster>
     ```
   </PreviewCode>
@@ -143,8 +131,9 @@ import { Badge } from '@lism-css/ui/astro';
     ```html
     <div class="l--cluster -g:15">
       <span class="c--badge -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:10">Badge</span>
-      <span class="c--badge -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:10" style="--bgc: var(--red)">Badge</span>
-      ... ...
+      <span class="c--badge -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:10 -bgc" style="--bgc: var(--red)">Badge</span>
+      <span class="c--badge -d:inline-flex -fz:xs -lh:xs -py:5 -px:10 -bdrs:10 -bgc" style="--bgc: var(--orange)">Badge</span>
+      ...
     </div>
     ```
   </PreviewCode>
@@ -190,19 +179,8 @@ import { Badge } from '@lism-css/ui/astro';
     ```jsx
     <Cluster g="15">
       <Badge variant="outline">Badge</Badge>
-      <Badge variant="outline" c="red">
-        Badge
-      </Badge>
-      <Badge variant="outline" c="orange">
-        Badge
-      </Badge>
-      ...
-      <Badge variant="outline" c="blue" fz="xs" bdrs="99">
-        Badge
-      </Badge>
-      <Badge variant="outline" c="purple" fz="xs" bdrs="99">
-        Badge
-      </Badge>
+      <Badge variant="outline" c="red">Badge</Badge>
+      <Badge variant="outline" c="orange">Badge</Badge>
       ...
     </Cluster>
     ```
@@ -244,15 +222,9 @@ import { Badge } from '@lism-css/ui/astro';
   <PreviewCode slot='tab' label='JSX'>
     ```jsx
     <Cluster g="15">
-      <Badge className="u--cbox" keycolor="red">
-        Red
-      </Badge>
-      <Badge className="u--cbox" keycolor="orange">
-        Orange
-      </Badge>
-      <Badge className="u--cbox" keycolor="yellow">
-        Yellow
-      </Badge>
+      <Badge className="u--cbox" keycolor="red">Red</Badge>
+      <Badge className="u--cbox" keycolor="orange">Orange</Badge>
+      <Badge className="u--cbox" keycolor="yellow">Yellow</Badge>
       ...
     </Cluster>
     ```
@@ -286,13 +258,9 @@ import { BookIcon } from '@phosphor-icons/react';
     ```jsx
     <Cluster g="15" ai="center">
       <Badge d="inline-flex" g="5" px-s="10" ai="center">
-        <Icon icon="star-fill" style={{ translate: '-10% 0' }} />
-        Badge
-      </Badge>
+        <Icon icon="star-fill" style={{ translate: '-10% 0' }} />Badge</Badge>
       <Badge variant="outline" d="inline-flex" g="5" px-s="10" ai="center" bdrs="10">
-        <Icon icon="tag" style={{ translate: '-10% 0' }} />
-        Badge
-      </Badge>
+        <Icon icon="tag" style={{ translate: '-10% 0' }} />Badge</Badge>
     </Cluster>
     ```
   </PreviewCode>
@@ -321,15 +289,9 @@ import { BookIcon } from '@phosphor-icons/react';
   <PreviewCode slot='tab' label='JSX'>
     ```jsx
     <Cluster g="15">
-      <Lism as="span" fz="xs" lh="xs" py="5" px="10" bgc="text" c="base" bdrs="10">
-        Badge
-      </Lism>
-      <Lism as="span" fz="xs" lh="xs" py="5" px="10" bd bdc="current" bdrs="10">
-        Badge
-      </Lism>
-      <Lism as="span" className="u--cbox" keycolor="blue" bd bdc="keycolor:base:40%" fz="xs" lh="xs" py="5" px="10" bdrs="99">
-        Badge
-      </Lism>
+      <Lism as="span" fz="xs" lh="xs" py="5" px="10" bgc="text" c="base" bdrs="10">Badge</Lism>
+      <Lism as="span" fz="xs" lh="xs" py="5" px="10" bd bdc="current" bdrs="10">Badge</Lism>
+      <Lism as="span" className="u--cbox" keycolor="blue" bd bdc="keycolor:base:40%" fz="xs" lh="xs" py="5" px="10" bdrs="99">Badge</Lism>
     </Cluster>
     ```
   </PreviewCode>

--- a/apps/docs/src/content/ja/ui/Button.mdx
+++ b/apps/docs/src/content/ja/ui/Button.mdx
@@ -78,9 +78,7 @@ import { ArrowRightIcon, ShoppingCartSimpleIcon } from "@phosphor-icons/react";
   <PreviewCode slot='tab' label='React / Astro'>
     ```jsx
     <Button href="">
-      (<Icon />
-      )TEXT(
-      <Icon />)
+      (<Icon />)TEXT(<Icon />)
     </Button>
     ```
   </PreviewCode>
@@ -130,12 +128,9 @@ import { ArrowRightIcon, ShoppingCartSimpleIcon } from "@phosphor-icons/react";
     ```jsx
     <Flex g="15">
       <Button href="###">Button</Button>
-      <Button href="###" bgc="brand" bdrs="10">
-        Button
-      </Button>
+      <Button href="###" bgc="brand" bdrs="10">Button</Button>
       <Button href="###" bgc="#d13d5e" bdrs="99">
-        <Icon icon="cart" />
-        Button
+        <Icon icon="cart" />Button
       </Button>
     </Flex>
     ```
@@ -145,22 +140,8 @@ import { ArrowRightIcon, ShoppingCartSimpleIcon } from "@phosphor-icons/react";
     <div class="l--flex -g:15">
       <a class="c--button l--flex -lh:s -py:10 -px:20 -hov:o" href="###">Button</a>
       <a class="c--button l--flex -lh:s -py:10 -px:20 -hov:o -bgc:brand -bdrs:10" href="###">Button</a>
-      <a class="c--button l--flex -lh:s -py:10 -px:20 -hov:o -bdrs:99" style="--bgc: #d13d5e" href="###">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 256 256"
-          width="1em"
-          height="1em"
-          fill="currentColor"
-          focusable="false"
-          class="a--icon"
-          aria-hidden="true"
-        >
-          <path
-            d="M230.14,58.87A8,8,0,0,0,224,56H62.68L56.6,22.57A8,8,0,0,0,48.73,16H24a8,8,0,0,0,0,16h18L67.56,172.29a24,24,0,0,0,5.33,11.27,28,28,0,1,0,44.4,8.44h45.42A27.75,27.75,0,0,0,160,204a28,28,0,1,0,28-28H91.17a8,8,0,0,1-7.87-6.57L80.13,152h116a24,24,0,0,0,23.61-19.71l12.16-66.86A8,8,0,0,0,230.14,58.87ZM104,204a12,12,0,1,1-12-12A12,12,0,0,1,104,204Zm96,0a12,12,0,1,1-12-12A12,12,0,0,1,200,204Zm4-74.57A8,8,0,0,1,196.1,136H77.22L65.59,72H214.41Z"
-          ></path>
-        </svg>
-        Button
+      <a class="c--button l--flex -lh:s -py:10 -px:20 -hov:o -bgc -bdrs:99" style="--bgc: #d13d5e" href="###">
+        <svg class="a--icon"...>...</svg>Button
       </a>
     </div>
     ```
@@ -187,12 +168,9 @@ import { ArrowRightIcon, ShoppingCartSimpleIcon } from "@phosphor-icons/react";
     ```jsx
     <Flex g="15">
       <Button href="###">Button</Button>
-      <Button href="###" variant="outline" c="brand" bdrs="10">
-        Button
-      </Button>
+      <Button href="###" variant="outline" c="brand" bdrs="10">Button</Button>
       <Button href="###" variant="outline" c="#d13d5e" bdrs="99">
-        <Icon icon="cart" />
-        Button
+        <Icon icon="cart" />Button
       </Button>
     </Flex>
     ```
@@ -202,22 +180,8 @@ import { ArrowRightIcon, ShoppingCartSimpleIcon } from "@phosphor-icons/react";
     <div class="l--flex -g:15">
       <a class="c--button c--button--outline l--flex -lh:s -py:10 -px:20 -hov:o" href="###">Button</a>
       <a class="c--button c--button--outline l--flex -lh:s -py:10 -px:20 -hov:o -c:brand -bdrs:10" href="###">Button</a>
-      <a class="c--button c--button--outline l--flex -lh:s -py:10 -px:20 -hov:o -bdrs:99" style="--c: #d13d5e" href="###">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 256 256"
-          width="1em"
-          height="1em"
-          fill="currentColor"
-          focusable="false"
-          class="a--icon"
-          aria-hidden="true"
-        >
-          <path
-            d="M230.14,58.87A8,8,0,0,0,224,56H62.68L56.6,22.57A8,8,0,0,0,48.73,16H24a8,8,0,0,0,0,16h18L67.56,172.29a24,24,0,0,0,5.33,11.27,28,28,0,1,0,44.4,8.44h45.42A27.75,27.75,0,0,0,160,204a28,28,0,1,0,28-28H91.17a8,8,0,0,1-7.87-6.57L80.13,152h116a24,24,0,0,0,23.61-19.71l12.16-66.86A8,8,0,0,0,230.14,58.87ZM104,204a12,12,0,1,1-12-12A12,12,0,0,1,104,204Zm96,0a12,12,0,1,1-12-12A12,12,0,0,1,200,204Zm4-74.57A8,8,0,0,1,196.1,136H77.22L65.59,72H214.41Z"
-          ></path>
-        </svg>
-        Button
+      <a class="c--button c--button--outline l--flex -lh:s -py:10 -px:20 -hov:o -c -bdrs:99" style="--c: #d13d5e" href="###">
+        <svg class="a--icon"...>...</svg>Button
       </a>
     </div>
     ```
@@ -499,7 +463,7 @@ import { ArrowRightIcon, ShoppingCartSimpleIcon } from "@phosphor-icons/react";
       <a href="###" class="-d:inline-flex -w:fit -td:none -c:inherit -bd -lh:s -py:10 -px:20 -bdrs:20 -hov:o">Button</a>
     </div>
     <a
-      class="l--grid -ji:center -ai:center -px:15 -py:10 -g:30 -w -td:none -bgc:text -c:base -bdrs:20 -hov:neutral"
+      class="l--grid -ji:center -ai:center -px:15 -py:10 -g:30 -w -gtc -td:none -bgc:text -c:base -bdrs:20 -hov:neutral"
       style="--w: 16rem; --gtc: 1em 1fr 1em"
       href="###"
     >

--- a/packages/lism-css/src/lib/getLayoutProps.test.ts
+++ b/packages/lism-css/src/lib/getLayoutProps.test.ts
@@ -16,27 +16,14 @@ describe('getLayoutProps', () => {
   });
 
   describe('grid レイアウト', () => {
-    test('grid レイアウトの場合、_propConfig が設定される', () => {
-      const result = getLayoutProps('grid', {});
-      expect(result._propConfig).toBeDefined();
-      expect(result._propConfig?.gta).toEqual({ isVar: 1 });
-      expect(result._propConfig?.gtc).toEqual({ isVar: 1 });
-      expect(result._propConfig?.gtr).toEqual({ isVar: 1 });
-    });
-
-    test('既存の _propConfig がある場合、マージされる', () => {
-      const result = getLayoutProps('grid', {
-        _propConfig: { customProp: { isVar: 2 } },
-      });
-      expect(result._propConfig?.customProp).toEqual({ isVar: 2 });
-      expect(result._propConfig?.gta).toEqual({ isVar: 1 });
-      expect(result._propConfig?.gtc).toEqual({ isVar: 1 });
-      expect(result._propConfig?.gtr).toEqual({ isVar: 1 });
-    });
-
     test('lismClass に l--grid が追加される', () => {
       const result = getLayoutProps('grid', {});
       expect(result.lismClass).toBe('l--grid');
+    });
+
+    test('_propConfig は自動付与されない', () => {
+      const result = getLayoutProps('grid', {});
+      expect(result._propConfig).toBeUndefined();
     });
   });
 

--- a/packages/lism-css/src/lib/getLayoutProps.ts
+++ b/packages/lism-css/src/lib/getLayoutProps.ts
@@ -57,13 +57,8 @@ export default function getLayoutProps<P extends InputProps>(layout: LayoutType 
   return rest as Omit<P, LayoutSpecificKeys> & BaseProps;
 }
 
-function getGridProps({ _propConfig = {}, ...props }: InputProps): BaseProps {
-  // gt系のベース値は l--grid は 変数のみでいい
-  _propConfig.gta = { isVar: 1 };
-  _propConfig.gtc = { isVar: 1 };
-  _propConfig.gtr = { isVar: 1 };
-
-  return { ...props, _propConfig };
+function getGridProps(props: InputProps): BaseProps {
+  return { ...props };
 }
 
 function getSideMainProps({ sideW, mainW, style, ...props }: InputProps): BaseProps {

--- a/packages/lism-css/src/scss/modules/layout/_grid.scss
+++ b/packages/lism-css/src/scss/modules/layout/_grid.scss
@@ -1,10 +1,5 @@
 .l--grid {
-  --gtr: none;
-  --gtc: none;
-  --gta: none;
   display: grid;
-  grid-template: var(--gtr) / var(--gtc);
-  grid-template-areas: var(--gta);
 
   > * {
     min-width: 0;

--- a/packages/lism-ui/src/components/Badge/astro/Badge.astro
+++ b/packages/lism-ui/src/components/Badge/astro/Badge.astro
@@ -3,14 +3,8 @@ import { Lism } from 'lism-css/astro';
 import '../_style.css';
 
 const props = Astro.props;
-
-// c--badge では c, bgc は 変数で受け取る
-const _propConfig = {
-  c: { isVar: 1 },
-  bgc: { isVar: 1 },
-};
 ---
 
-<Lism lismClass="c--badge" as="span" d="inline-flex" fz="xs" lh="xs" py="5" px="10" bdrs="10" _propConfig={_propConfig} {...props}>
+<Lism lismClass="c--badge" as="span" d="inline-flex" fz="xs" lh="xs" py="5" px="10" bdrs="10" {...props}>
   <slot />
 </Lism>

--- a/packages/lism-ui/src/components/Badge/react/Badge.tsx
+++ b/packages/lism-ui/src/components/Badge/react/Badge.tsx
@@ -3,11 +3,5 @@ import { Lism, type LismComponentProps } from 'lism-css/react';
 import '../_style.css';
 
 export default function Badge<T extends ElementType = 'span'>(props: LismComponentProps<T>) {
-  // c--badge では c, bgc は 変数で受け取る
-  const _propConfig = {
-    c: { isVar: 1 },
-    bgc: { isVar: 1 },
-  };
-
-  return <Lism lismClass="c--badge" as="span" d="inline-flex" fz="xs" lh="xs" py="5" px="10" bdrs="10" _propConfig={_propConfig} {...props} />;
+  return <Lism lismClass="c--badge" as="span" d="inline-flex" fz="xs" lh="xs" py="5" px="10" bdrs="10" {...props} />;
 }

--- a/packages/lism-ui/src/components/Button/astro/Button.astro
+++ b/packages/lism-ui/src/components/Button/astro/Button.astro
@@ -3,14 +3,8 @@ import { Flex } from 'lism-css/astro';
 import '../_style.css';
 
 const props = Astro.props;
-
-// c--button では c, bgc は 変数で受け取る
-const _propConfig = {
-  c: { isVar: 1 },
-  bgc: { isVar: 1 },
-};
 ---
 
-<Flex lismClass="c--button" as="a" lh="s" py="10" px="20" hov="o" _propConfig={_propConfig} {...props}>
+<Flex lismClass="c--button" as="a" lh="s" py="10" px="20" hov="o" {...props}>
   <slot />
 </Flex>

--- a/packages/lism-ui/src/components/Button/react/Button.tsx
+++ b/packages/lism-ui/src/components/Button/react/Button.tsx
@@ -3,11 +3,5 @@ import { Flex, type LismComponentProps } from 'lism-css/react';
 import '../_style.css';
 
 export default function Button<T extends ElementType = 'a'>(props: LismComponentProps<T>) {
-  // c--button では c, bgc は 変数で受け取る
-  const _propConfig = {
-    c: { isVar: 1 },
-    bgc: { isVar: 1 },
-  };
-
-  return <Flex lismClass="c--button" as="a" lh="s" py="10" px="20" hov="o" _propConfig={_propConfig} {...props} />;
+  return <Flex lismClass="c--button" as="a" lh="s" py="10" px="20" hov="o" {...props} />;
 }

--- a/packages/lism-ui/src/components/Chat/_style.css
+++ b/packages/lism-ui/src/components/Chat/_style.css
@@ -1,9 +1,9 @@
 @layer lism-modules {
   .c--chat {
     --cbox-bgPct: 8%;
-    --gta: 'avatar name' 'avatar body';
-    --gtc: auto 1fr;
-    --gtr: minmax(1.5rem, auto) auto;
+    grid-template-areas: 'avatar name' 'avatar body';
+    grid-template-columns: auto 1fr;
+    grid-template-rows: minmax(1.5rem, auto) auto;
     --_avator-size: clamp(48px, 32px + 5cqw, 64px); /* @320px:40px ~ @640:64px */
     --_deco-size: calc(min(var(--_avator-size), 80px) / 4 + 0.25rem);
     --_deco-mask: none;
@@ -46,8 +46,8 @@
   [data-chat-dir='end'] {
     --_deco-scale: -1 1;
     --_deco-inset-x: calc(100% - 1px) auto;
-    --gta: 'name avatar' 'body avatar';
-    --gtc: 1fr auto;
+    grid-template-areas: 'name avatar' 'body avatar';
+    grid-template-columns: 1fr auto;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #211

- `l--grid` から `--gtr` / `--gtc` / `--gta` CSS変数と `grid-template` 宣言を削除し、`display: grid` + `> * { min-width: 0 }` のみに簡素化
- `getGridProps()` の `_propConfig` 自動付与を削除
- Badge / Button コンポーネントの `_propConfig` 使用を削除（`-c` / `-bgc` クラスが余分に付くが動作に影響なし）
- Chat コンポーネントの `--gta` / `--gtc` / `--gtr` を `grid-template-areas` / `grid-template-columns` / `grid-template-rows` の直接指定に変更

> **Note:** `_propConfig` 機構自体（`getLismProps` / `LismPropsData`）は残す → #225 で別途検討

## Test plan

- [x] `pnpm test` 全テスト通過
- [x] ドキュメントサイトで Grid / Chat / Badge / Button の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)