### PR TITLE
リストの padding-inline-start を --list-px-s に変更

### DIFF
--- a/.claude/skills/lism-css-guide/base-styles.md
+++ b/.claude/skills/lism-css-guide/base-styles.md
@@ -69,6 +69,12 @@ Reset CSS に加え、`@layer lism-base` 内で HTML タグに基本スタイル
 | `--link-td-thickness` | `auto` | 下線の太さ |
 | `--link-td-color` | `currentColor` | 下線の色 |
 
+### リスト（ul, ol）
+
+| 変数 | フォールバック | 用途 |
+|------|------------|------|
+| `--list-px-s` | `var(--s30)` | リストの `padding-inline-start` |
+
 ### テーブル（table, td, th）
 
 | 変数 | フォールバック | 用途 |

--- a/apps/docs/src/content/en/base-styles.mdx
+++ b/apps/docs/src/content/en/base-styles.mdx
@@ -189,11 +189,15 @@ hr {
 :is(ul, ol):where(:not([class])),
 :is(ul, ol):where([class^='-']) {
   list-style: revert;
-  padding-inline-start: var(--s30);
+  padding-inline-start: var(--list-px-s, var(--s30));
 }
 ```
 
 While the Reset CSS removes list styles from elements with a class, this rule restores the browser default list style for lists with no class, or with only a Property Class (a class starting with `-`).
+
+| Variable | Fallback | Purpose |
+|------|------------|------|
+| `--list-px-s` | `var(--s30)` | List `padding-inline-start` |
 
 
 ### Definition lists (dl)

--- a/apps/docs/src/content/ja/base-styles.mdx
+++ b/apps/docs/src/content/ja/base-styles.mdx
@@ -194,11 +194,15 @@ hr {
 :is(ul, ol):where(:not([class])),
 :is(ul, ol):where([class^='-']) {
   list-style: revert;
-  padding-inline-start: var(--s30);
+  padding-inline-start: var(--list-px-s, var(--s30));
 }
 ```
 
-クラスを持たないリスト、または Property Classしかクラスを持たない（class属性が `-` で始まる）リストに対して、ブラウザデフォルトスタイルを復活させています。（余白はスペーシングトークンで管理）
+クラスを持たないリスト、または Property Classしかクラスを持たない（class属性が `-` で始まる）リストに対して、ブラウザデフォルトスタイルを復活させています。
+
+| 変数 | フォールバック | 用途 |
+|------|------------|------|
+| `--list-px-s` | `var(--s30)` | リストの `padding-inline-start` |
 
 
 ### 定義リスト（dl）

--- a/packages/lism-css/src/scss/base/_html.scss
+++ b/packages/lism-css/src/scss/base/_html.scss
@@ -99,7 +99,7 @@ hr {
 :is(ul, ol):where(:not([class])),
 :is(ul, ol):where([class^='-']) {
   list-style: revert;
-  padding-inline-start: var(--s30);
+  padding-inline-start: var(--list-px-s, var(--s30));
 }
 
 dt {


### PR DESCRIPTION
## Summary

リストの `padding-inline-start` にハードコードされていた `var(--s30)` を、カスタムプロパティ `--list-px-s` で上書き可能にしました。デフォルト値は `var(--s30)` のまま維持されます。

Closes #224

## Changes

- `_html.scss`: `padding-inline-start: var(--s30)` → `var(--list-px-s, var(--s30))` に変更
- スキル `base-styles.md`: リストセクションにカスタムプロパティの説明を追記
- ドキュメント `base-styles.mdx`（ja/en）: コード例とカスタムプロパティ表を更新

## Test plan

- CSS ビルドが正常に完了することを確認済み
- `--list-px-s` を未定義の場合、`--s30` がフォールバックとして適用されることを確認
- `--list-px-s` を定義した場合、その値が優先されることを確認