### PR TITLE
chore: eslint-plugin-astro を導入し .astro ファイルの ESLint 設定を追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,15 @@
 {
-	"editor.formatOnSave": true,
-	"editor.formatOnPaste": true,
-	"editor.defaultFormatter": "esbenp.prettier-vscode",
-	"[scss]": {
-		"editor.defaultFormatter": "esbenp.prettier-vscode"
-	},
-	"[astro]": {
-		"editor.defaultFormatter": "esbenp.prettier-vscode"
-	}
-	// "html.format.enable": false,
-	// "javascript.format.enable": false,
-	// "typescript.format.enable": false
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[scss]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[astro]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact", "astro", "svelte"]
+  // "html.format.enable": false,
+  // "javascript.format.enable": false,
+  // "typescript.format.enable": false
 }

--- a/apps/docs/src/components/mdx/ImportPackage.astro
+++ b/apps/docs/src/components/mdx/ImportPackage.astro
@@ -17,7 +17,7 @@ const { version: pkgVersion } = JSON.parse(readFileSync(resolve(process.cwd(), '
 
 const getCopyCode = (name: string) => `import { ${component} } from '${packageName}${name}';`;
 
-const jsImportCode = `<script type=\"module\" src=\"https://cdn.jsdelivr.net/npm/${packageName}@${pkgVersion}/dist/scripts/${script}\"></script>`;
+const jsImportCode = `<script type="module" src="https://cdn.jsdelivr.net/npm/${packageName}@${pkgVersion}/dist/scripts/${script}"></script>`;
 
 const cssImportCode = `<link href="https://cdn.jsdelivr.net/npm/${packageName}@${pkgVersion}/dist/${css}" rel="stylesheet" />`;
 ---

--- a/apps/docs/src/pages/preview/templates/news/news002/en.astro
+++ b/apps/docs/src/pages/preview/templates/news/news002/en.astro
@@ -12,7 +12,7 @@ import './_style.css';
       <Flex gr={['1', '1 / 2']} gc={['1', '1 / 2']} ai="flex-end" jc="flex-start">
         <h2>News</h2>
       </Flex>
-      <Box gr="2" , gc={['1', '1 / 3']}>
+      <Box gr="2" gc={['1', '1 / 3']}>
         <Grid gtc={['1fr', 'repeat(auto-fit, minmax(300px, 1fr))']} gtr="auto auto" g="40">
           <Grid as="a" gtr="subgrid" gr="span 2" g="0" isBoxLink href="#" bdrs="10" bxsh="20" ov="hidden" set="hov transition" hov="bxsh">
             <Frame as="figure" ar="og" pos="relative">

--- a/apps/docs/src/pages/preview/templates/news/news002/index.astro
+++ b/apps/docs/src/pages/preview/templates/news/news002/index.astro
@@ -12,7 +12,7 @@ import './_style.css';
       <Flex gr={['1', '1 / 2']} gc={['1', '1 / 2']} ai="flex-end" jc="flex-start">
         <h2>お知らせ</h2>
       </Flex>
-      <Box gr="2" , gc={['1', '1 / 3']}>
+      <Box gr="2" gc={['1', '1 / 3']}>
         <Grid gtc={['1fr', 'repeat(auto-fit, minmax(300px, 1fr))']} gtr="auto auto" g="40">
           <Grid as="a" gtr="subgrid" gr="span 2" g="0" isBoxLink href="#" bdrs="10" bxsh="20" ov="hidden" set="hov transition" hov="bxsh">
             <Frame as="figure" ar="og" pos="relative">

--- a/apps/docs/src/pages/preview/templates/section/section002-2/en.astro
+++ b/apps/docs/src/pages/preview/templates/section/section002-2/en.astro
@@ -8,7 +8,7 @@ import './_style.css';
 
 <DemoLayout title="Section002-2">
   <Container isWrapper="l" py="50" set="gutter">
-    <Grid gtc={['auto', null, 'minmax(20rem, 1fr) 1fr']} gtr={['1fr', null, '1fr auto auto 1fr']} g="40 60" }>
+    <Grid gtc={['auto', null, 'minmax(20rem, 1fr) 1fr']} gtr={['1fr', null, '1fr auto auto 1fr']} g="40 60">
       <Stack gr={['1', null, '2']} g="40">
         <h2 class="u--trim">Enriching Everyday Life</h2>
         <p class="u--trim">

--- a/apps/docs/src/pages/preview/templates/section/section002-2/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section002-2/index.astro
@@ -8,7 +8,7 @@ import './_style.css';
 
 <DemoLayout title="Section002-2">
   <Container isWrapper="l" py="50" set="gutter">
-    <Grid gtc={['auto', null, 'minmax(20rem, 1fr) 1fr']} gtr={['1fr', null, '1fr auto auto 1fr']} g="40 60" }>
+    <Grid gtc={['auto', null, 'minmax(20rem, 1fr) 1fr']} gtr={['1fr', null, '1fr auto auto 1fr']} g="40 60">
       <Stack gr={['1', null, '2']} g="40">
         <h2 class="u--trim">暮らしを、もっと豊かに</h2>
         <p class="u--trim">

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,6 @@ export default defineConfig(
       'packages/lism-css/config.d.ts',
       '**/.prettierrc.cjs',
       '**/.stylelintrc.mjs',
-      '**/.astro/**',
       '**/vite.config.*',
     ],
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,8 @@ import eslintConfigPrettier from 'eslint-config-prettier/flat';
 import globals from 'globals';
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
+import astro from 'eslint-plugin-astro';
+import astroParser from 'astro-eslint-parser';
 
 export default defineConfig(
   {
@@ -26,9 +28,6 @@ export default defineConfig(
       '**/.stylelintrc.mjs',
       '**/.astro/**',
       '**/vite.config.*',
-      // lism-ui: Astro 向けファイルは tsconfig から除外されているため lint 対象外
-      'packages/lism-ui/src/**/astro/**',
-      'packages/lism-ui/src/components/astro.ts',
     ],
   },
   eslintConfigPrettier,
@@ -106,5 +105,30 @@ export default defineConfig(
       '@typescript-eslint/no-unsafe-call': 'off',
     },
   },
-  ...storybook.configs['flat/recommended']
+  ...storybook.configs['flat/recommended'],
+  {
+    files: ['packages/lism-ui/src/**/astro/**/*.ts', 'packages/lism-ui/src/components/astro.ts'],
+    extends: [tseslint.configs.disableTypeChecked],
+    languageOptions: {
+      parserOptions: { projectService: false },
+    },
+  },
+  ...astro.configs.recommended,
+  {
+    files: ['**/*.astro'],
+    languageOptions: {
+      parser: astroParser,
+      parserOptions: {
+        parser: tseslint.parser,
+        projectService: false,
+        project: null,
+        tsconfigRootDir: import.meta.dirname,
+      },
+      globals: { astroHTML: 'readonly' },
+    },
+    rules: {
+      'react/no-unknown-property': 'off',
+      'no-irregular-whitespace': 'off',
+    },
+  }
 );

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "astro-eslint-parser": "^1.4.0",
     "autoprefixer": "^10.4.27",
     "cross-env": "^7.0.3",
     "cssnano": "^7.1.3",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
-    "astro-eslint-parser": "^1.4.0",
     "eslint-plugin-astro": "^1.7.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-storybook": "^10.3.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "cssnano": "^7.1.3",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
+    "astro-eslint-parser": "^1.4.0",
+    "eslint-plugin-astro": "^1.7.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-storybook": "^10.3.3",
     "globals": "^16.5.0",

--- a/packages/lism-ui/package.json
+++ b/packages/lism-ui/package.json
@@ -19,7 +19,7 @@
     "build:css": "node build-css.js",
     "typecheck": "tsc --noEmit",
     "lint": "pnpm lint:eslint && pnpm lint:style",
-    "lint:eslint": "eslint '**/*.{js,mjs,ts,tsx}'",
+    "lint:eslint": "eslint '**/*.{js,mjs,ts,tsx,astro}'",
     "lint:style": "stylelint '**/*.{css,scss}'",
     "prepack": "case \"$npm_execpath\" in *pnpm*) ;; *) echo 'Error: Use pnpm publish' && exit 1;; esac"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
+      astro-eslint-parser:
+        specifier: ^1.4.0
+        version: 1.4.0
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.8)
@@ -29,6 +32,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.4)
+      eslint-plugin-astro:
+        specifier: ^1.7.0
+        version: 1.7.0(eslint@9.39.4)
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.4)
@@ -2356,6 +2362,10 @@ packages:
       react: '>= 16.8'
       react-dom: '>= 16.8'
 
+  '@pkgr/core@0.2.9':
+    resolution: { integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA== }
+    engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
+
   '@polka/url@1.0.0-next.29':
     resolution: { integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww== }
 
@@ -3234,6 +3244,10 @@ packages:
     resolution: { integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg== }
     hasBin: true
 
+  astro-eslint-parser@1.4.0:
+    resolution: { integrity: sha512-+QDcgc7e+au6EZ0YjMmRRjNoQo5bDMlaR45aWDoFsuxQTCM9qmCHRoiKJPELgckJ8Wmr7vcfpa9eCDHBFh6G4w== }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
   astro-expressive-code@0.41.7:
     resolution: { integrity: sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ== }
     peerDependencies:
@@ -3243,6 +3257,12 @@ packages:
     resolution: { integrity: sha512-r3iIvmB6JvQxsdJLvapybKKq7Bojd1iQK6CCx5P55eRnXJIyUpHx/1UB/GdMm+em/lwaCUasxHCmIO0lCLV2uA== }
     engines: { node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0' }
     hasBin: true
+
+  astrojs-compiler-sync@1.1.1:
+    resolution: { integrity: sha512-0mKvB9sDQRIZPsEJadw6OaFbGJ92cJPPR++ICca9XEyiUAZqgVuk25jNmzHPT0KF80rI94trSZrUR5iHFXGGOQ== }
+    engines: { node: ^18.18.0 || >=20.9.0 }
+    peerDependencies:
+      '@astrojs/compiler': '>=0.27.0'
 
   async-function@1.0.0:
     resolution: { integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA== }
@@ -3814,6 +3834,10 @@ packages:
     resolution: { integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g== }
     engines: { node: '>=0.12' }
 
+  entities@7.0.1:
+    resolution: { integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA== }
+    engines: { node: '>=0.12' }
+
   env-paths@2.2.1:
     resolution: { integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A== }
     engines: { node: '>=6' }
@@ -3899,11 +3923,23 @@ packages:
     resolution: { integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw== }
     engines: { node: '>=12' }
 
+  eslint-compat-utils@0.6.5:
+    resolution: { integrity: sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ== }
+    engines: { node: '>=12' }
+    peerDependencies:
+      eslint: '>=6.0.0'
+
   eslint-config-prettier@10.1.8:
     resolution: { integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w== }
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
+
+  eslint-plugin-astro@1.7.0:
+    resolution: { integrity: sha512-89xpAn528UKCdmyysbg0AHHqi6sqcK89wXnJIpu4F0mFBN03zATEBNK7pRtMfl6gwtMOm5ECXs+Wz5qDHhwTFw== }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: '>=8.57.0'
 
   eslint-plugin-react-hooks@5.2.0:
     resolution: { integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg== }
@@ -6314,6 +6350,10 @@ packages:
   sync-message-port@1.2.0:
     resolution: { integrity: sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg== }
     engines: { node: '>=16.0.0' }
+
+  synckit@0.11.12:
+    resolution: { integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ== }
+    engines: { node: ^14.18.0 || >=16.0.0 }
 
   table@6.9.0:
     resolution: { integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A== }
@@ -8922,6 +8962,8 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@pkgr/core@0.2.9': {}
+
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -9980,6 +10022,23 @@ snapshots:
 
   astring@1.9.0: {}
 
+  astro-eslint-parser@1.4.0:
+    dependencies:
+      '@astrojs/compiler': 3.0.1
+      '@typescript-eslint/scope-manager': 8.58.0
+      '@typescript-eslint/types': 8.58.0
+      astrojs-compiler-sync: 1.1.1(@astrojs/compiler@3.0.1)
+      debug: 4.4.3
+      entities: 7.0.1
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
   astro-expressive-code@0.41.7(astro@6.1.2(@types/node@25.5.0)(rollup@4.60.1)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)):
     dependencies:
       astro: 6.1.2(@types/node@25.5.0)(rollup@4.60.1)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)
@@ -10172,6 +10231,11 @@ snapshots:
       - typescript
       - uploadthing
       - yaml
+
+  astrojs-compiler-sync@1.1.1(@astrojs/compiler@3.0.1):
+    dependencies:
+      '@astrojs/compiler': 3.0.1
+      synckit: 0.11.12
 
   async-function@1.0.0: {}
 
@@ -10723,6 +10787,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   env-paths@2.2.1: {}
 
   environment@1.1.0: {}
@@ -10946,9 +11012,28 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  eslint-compat-utils@0.6.5(eslint@9.39.4):
+    dependencies:
+      eslint: 9.39.4
+      semver: 7.7.4
+
   eslint-config-prettier@10.1.8(eslint@9.39.4):
     dependencies:
       eslint: 9.39.4
+
+  eslint-plugin-astro@1.7.0(eslint@9.39.4):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@typescript-eslint/types': 8.58.0
+      astro-eslint-parser: 1.4.0
+      eslint: 9.39.4
+      eslint-compat-utils: 0.6.5(eslint@9.39.4)
+      globals: 16.5.0
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.39.4):
     dependencies:
@@ -14103,6 +14188,10 @@ snapshots:
       sync-message-port: 1.2.0
 
   sync-message-port@1.2.0: {}
+
+  synckit@0.11.12:
+    dependencies:
+      '@pkgr/core': 0.2.9
 
   table@6.9.0:
     dependencies:


### PR DESCRIPTION
## Summary

- `eslint-plugin-astro` / `astro-eslint-parser` をルート devDependencies に追加
- `eslint.config.mjs` に Astro 向けパーサー・ルール設定を追加（VSCode ESLint 拡張対応）
- `packages/lism-ui` の lint スクリプトに `.astro` を追加
- `.vscode/settings.json` の `eslint.validate` に `astro` を追加
- docs テンプレートの既存構文エラーを修正（余分なカンマ・`}`）

## 主な変更点

### `eslint.config.mjs`
- `astroParser` を明示的に指定（`...astro.configs.recommended` の暗黙的なパーサーではなく）
- `.astro` テンプレートで `react/no-unknown-property` / `no-irregular-whitespace` を無効化
- `packages/lism-ui/src/**/astro/**/*.ts` と `src/components/astro.ts` を `disableTypeChecked` 対象に設定

## Test plan

- [ ] `pnpm run lint` が全パッケージでエラーなく通ること
- [ ] VSCode で `.astro` ファイルを開いたとき `Parsing error: Unexpected token {` が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)