### PR TITLE
refactor(lism-ui): getProps.ts の mergeSet('plain', set) を set デフォルト引数に簡素化

### DIFF
--- a/packages/lism-ui/src/components/Accordion/astro/Button.astro
+++ b/packages/lism-ui/src/components/Accordion/astro/Button.astro
@@ -2,12 +2,18 @@
 import { Lism } from 'lism-css/astro';
 import atts from 'lism-css/lib/helper/atts';
 import Icon from './Icon.astro';
-import { getButtonProps } from '../getProps';
+import { defaultProps } from '../getProps';
 
 const { isOpen = false, accID = '__LISM_ACC_ID__', class: className, ...props } = Astro.props || {};
 ---
 
-<Lism {...getButtonProps(props)} class={atts(className, 'c--accordion_button')} aria-controls={accID} aria-expanded={isOpen ? 'true' : 'false'}>
+<Lism
+  {...defaultProps.button}
+  {...props}
+  class={atts(className, 'c--accordion_button')}
+  aria-controls={accID}
+  aria-expanded={isOpen ? 'true' : 'false'}
+>
   <slot />
   <Icon />
 </Lism>

--- a/packages/lism-ui/src/components/Accordion/getProps.ts
+++ b/packages/lism-ui/src/components/Accordion/getProps.ts
@@ -34,19 +34,6 @@ export function getHeadingProps({ as = 'div', role, set = 'plain', ...props }: A
   return returnProps;
 }
 
-export function getButtonProps({ set = 'plain', ...props }: { set?: unknown; [key: string]: unknown }) {
-  return {
-    as: 'button',
-    layout: 'flex',
-    set,
-    g: '10',
-    w: '100%',
-    ai: 'center',
-    jc: 'between',
-    ...props,
-  };
-}
-
 export function getPanelProps({ _contextID, accID = '__LISM_ACC_ID__', isOpen = false, ...props }: AccordionPanelProps) {
   const panelProps = {
     id: _contextID || accID,
@@ -61,6 +48,15 @@ export function getPanelProps({ _contextID, accID = '__LISM_ACC_ID__', isOpen = 
 }
 
 export const defaultProps = {
+  button: {
+    as: 'button',
+    layout: 'flex',
+    set: 'plain',
+    g: '10',
+    w: '100%',
+    ai: 'center',
+    jc: 'between',
+  },
   icon: {
     atomic: 'icon',
     as: 'span',

--- a/packages/lism-ui/src/components/Accordion/getProps.ts
+++ b/packages/lism-ui/src/components/Accordion/getProps.ts
@@ -1,5 +1,3 @@
-import mergeSet from 'lism-css/lib/helper/mergeSet';
-
 export type AccordionRootProps = {
   allowMultiple?: boolean;
   [key: string]: unknown;
@@ -23,10 +21,10 @@ export function getRootProps({ allowMultiple, ...props }: AccordionRootProps) {
   return props;
 }
 
-export function getHeadingProps({ as = 'div', role, set, ...props }: AccordionHeadingProps) {
+export function getHeadingProps({ as = 'div', role, set = 'plain', ...props }: AccordionHeadingProps) {
   const returnProps: Record<string, unknown> = {
     as,
-    set: mergeSet('plain', set),
+    set,
     ...props,
   };
 
@@ -36,11 +34,11 @@ export function getHeadingProps({ as = 'div', role, set, ...props }: AccordionHe
   return returnProps;
 }
 
-export function getButtonProps({ set, ...props }: { set?: unknown; [key: string]: unknown }) {
+export function getButtonProps({ set = 'plain', ...props }: { set?: unknown; [key: string]: unknown }) {
   return {
     as: 'button',
     layout: 'flex',
-    set: mergeSet('plain', set),
+    set,
     g: '10',
     w: '100%',
     ai: 'center',

--- a/packages/lism-ui/src/components/Accordion/react/Accordion.tsx
+++ b/packages/lism-ui/src/components/Accordion/react/Accordion.tsx
@@ -7,8 +7,8 @@ import { Lism, Stack, type LismComponentProps } from 'lism-css/react';
 import {
   getRootProps,
   getHeadingProps,
-  getButtonProps,
   getPanelProps,
+  defaultProps,
   type AccordionRootProps,
   type AccordionHeadingProps,
   type AccordionPanelProps,
@@ -92,7 +92,8 @@ export function Button<T extends ElementType = 'button'>({ children, className, 
 
   return (
     <Lism
-      {...(getButtonProps(props as Record<string, unknown>) as object)}
+      {...(defaultProps.button as object)}
+      {...(props as object)}
       className={atts(className, 'c--accordion_button')}
       aria-controls={accID}
       aria-expanded="false"

--- a/packages/lism-ui/src/components/Chat/astro/Chat.astro
+++ b/packages/lism-ui/src/components/Chat/astro/Chat.astro
@@ -22,7 +22,7 @@ interface Props {
 }
 
 const { name, avatar, flow = 's', variant = 'speak', class: className, ...inputProps } = Astro.props;
-const { 'data-chat-dir': direction, ...chatProps } = getChatProps({ variant, ...inputProps });
+const { 'data-chat-dir': direction, ...chatProps } = getChatProps(inputProps);
 ---
 
 <Grid class={atts(className, buildModifierClass('c--chat', { variant }))} data-chat-dir={direction} {...chatProps}>

--- a/packages/lism-ui/src/components/Chat/getProps.ts
+++ b/packages/lism-ui/src/components/Chat/getProps.ts
@@ -35,7 +35,6 @@ export const defaultProps = {
 } as const;
 
 export type ChatProps = {
-  variant?: string;
   direction?: string;
   keycolor?: string;
   [key: string]: unknown;

--- a/packages/lism-ui/src/components/Chat/getProps.ts
+++ b/packages/lism-ui/src/components/Chat/getProps.ts
@@ -44,7 +44,7 @@ export type ChatProps = {
 /**
  * Chat コンポーネントのルートプロパティを生成（className以外の共通props）
  */
-export default function getChatProps({ variant: _variant = 'speak', direction = 'start', keycolor = 'gray', ...props }: ChatProps) {
+export default function getChatProps({ direction = 'start', keycolor = 'gray', ...props }: ChatProps) {
   return {
     keycolor,
     'data-chat-dir': direction,

--- a/packages/lism-ui/src/components/Chat/react/Chat.tsx
+++ b/packages/lism-ui/src/components/Chat/react/Chat.tsx
@@ -23,7 +23,7 @@ export default function Chat<T extends ElementType = 'div'>({
   children,
   ...props
 }: Props<T>) {
-  const { 'data-chat-dir': direction, ...chatProps } = getChatProps({ variant, ...props });
+  const { 'data-chat-dir': direction, ...chatProps } = getChatProps(props);
 
   return (
     <Grid className={atts(className, buildModifierClass('c--chat', { variant }))} data-chat-dir={direction} {...chatProps}>

--- a/packages/lism-ui/src/components/Details/astro/Title.astro
+++ b/packages/lism-ui/src/components/Details/astro/Title.astro
@@ -1,9 +1,9 @@
 ---
 import { Lism } from 'lism-css/astro';
 import atts from 'lism-css/lib/helper/atts';
-import { getTitleProps } from '../getProps';
+import { defaultProps } from '../getProps';
 
 const { class: className, ...props } = Astro.props || {};
 ---
 
-<Lism {...getTitleProps(props)} class={atts(className, 'c--details_title')}><slot /></Lism>
+<Lism {...defaultProps.title} {...props} class={atts(className, 'c--details_title')}><slot /></Lism>

--- a/packages/lism-ui/src/components/Details/getProps.ts
+++ b/packages/lism-ui/src/components/Details/getProps.ts
@@ -1,17 +1,9 @@
-export function getTitleProps({ set = 'plain', ...props }: { set?: unknown; [key: string]: unknown }) {
-  return {
-    as: 'span',
-    fx: '1',
-    set,
-    ...props,
-  };
-}
-
 /**
  * 各サブコンポーネント用のデフォルトプロパティ
  */
 export const defaultProps = {
   summary: { layout: 'flex', g: '10', ai: 'center' },
+  title: { as: 'span', fx: '1', set: 'plain' },
   icon: { atomic: 'icon', as: 'span', 'aria-hidden': 'true' },
   content: { layout: 'flow', flow: 's' },
 } as const;

--- a/packages/lism-ui/src/components/Details/getProps.ts
+++ b/packages/lism-ui/src/components/Details/getProps.ts
@@ -1,10 +1,8 @@
-import mergeSet from 'lism-css/lib/helper/mergeSet';
-
-export function getTitleProps({ set, ...props }: { set?: unknown; [key: string]: unknown }) {
+export function getTitleProps({ set = 'plain', ...props }: { set?: unknown; [key: string]: unknown }) {
   return {
     as: 'span',
     fx: '1',
-    set: mergeSet('plain', set),
+    set,
     ...props,
   };
 }

--- a/packages/lism-ui/src/components/Details/react/Details.tsx
+++ b/packages/lism-ui/src/components/Details/react/Details.tsx
@@ -5,7 +5,7 @@ import type { ElementType } from 'react';
 import getLismProps from 'lism-css/lib/getLismProps';
 import { Lism, type LismComponentProps } from 'lism-css/react';
 import atts from 'lism-css/lib/helper/atts';
-import { getTitleProps, defaultProps } from '../getProps';
+import { defaultProps } from '../getProps';
 
 // スタイルのインポート
 import '../_style.css';
@@ -46,7 +46,7 @@ export function Summary<T extends ElementType = 'summary'>({ children, className
  */
 export function Title<T extends ElementType = 'span'>({ children, className, ...props }: LismComponentProps<T>) {
   return (
-    <Lism {...(getTitleProps(props as Record<string, unknown>) as object)} className={atts(className, 'c--details_title')}>
+    <Lism {...(defaultProps.title as object)} {...(props as object)} className={atts(className, 'c--details_title')}>
       {children}
     </Lism>
   );

--- a/packages/lism-ui/src/components/Modal/astro/CloseBtn.astro
+++ b/packages/lism-ui/src/components/Modal/astro/CloseBtn.astro
@@ -1,21 +1,20 @@
 ---
 // import type { LismProps } from 'lism-css/types';
 import { Lism, Icon } from 'lism-css/astro';
-import { getCloseBtnProps } from '../getProps';
+import { defaultProps } from '../getProps';
 
 // Propsの定義
 // interface Props extends LismProps {}
 const { modalId = '', icon, srText = 'Close', ...props } = Astro.props || {};
-const btnProps = getCloseBtnProps(props);
 ---
 
 {
   Astro.slots.has('default') ? (
-    <Lism data-modal-close={modalId} {...btnProps}>
+    <Lism data-modal-close={modalId} {...defaultProps.closeBtn} {...props}>
       <slot />
     </Lism>
   ) : (
-    <Lism data-modal-close={modalId} {...btnProps}>
+    <Lism data-modal-close={modalId} {...defaultProps.closeBtn} {...props}>
       <Icon icon={icon || 'x'} />
       <span class="u--srOnly">{srText || 'Close'}</span>
     </Lism>

--- a/packages/lism-ui/src/components/Modal/astro/OpenBtn.astro
+++ b/packages/lism-ui/src/components/Modal/astro/OpenBtn.astro
@@ -1,13 +1,13 @@
 ---
 // import type { LismProps } from 'lism-css/types';
 import { Lism } from 'lism-css/astro';
-import { getOpenBtnProps } from '../getProps';
+import { defaultProps } from '../getProps';
 
 // Propsの定義
 // interface Props extends LismProps {}
 const { modalId = '', ...props } = Astro.props || {};
 ---
 
-<Lism data-modal-open={modalId} {...getOpenBtnProps(props)}>
+<Lism data-modal-open={modalId} {...defaultProps.openBtn} {...props}>
   <slot />
 </Lism>

--- a/packages/lism-ui/src/components/Modal/getProps.ts
+++ b/packages/lism-ui/src/components/Modal/getProps.ts
@@ -1,5 +1,3 @@
-import mergeSet from 'lism-css/lib/helper/mergeSet';
-
 export type ModalRootProps = {
   set?: string;
   duration?: string;
@@ -13,14 +11,14 @@ export type ModalInnerProps = {
   [key: string]: unknown;
 };
 
-export function getProps({ set, duration, style = {}, ...props }: ModalRootProps) {
+export function getProps({ set = 'plain', duration, style = {}, ...props }: ModalRootProps) {
   if (duration) {
     style['--duration'] = duration;
   }
 
   return {
     as: 'dialog',
-    set: mergeSet('plain', set),
+    set,
     style,
     ...props,
   };
@@ -36,20 +34,20 @@ export function getInnerProps({ offset, style = {}, ...props }: ModalInnerProps)
   };
 }
 
-export function getOpenBtnProps({ set, ...props }: Record<string, unknown>) {
+export function getOpenBtnProps({ set = 'plain', ...props }: Record<string, unknown>) {
   return {
     as: 'button',
-    set: mergeSet('plain', set),
+    set,
     hov: 'o',
     d: 'inline-flex',
     ...props,
   };
 }
 
-export function getCloseBtnProps({ set, ...props }: Record<string, unknown>) {
+export function getCloseBtnProps({ set = 'plain', ...props }: Record<string, unknown>) {
   return {
     as: 'button',
-    set: mergeSet('plain', set),
+    set,
     hov: 'o',
     d: 'inline-flex',
     ...props,

--- a/packages/lism-ui/src/components/Modal/getProps.ts
+++ b/packages/lism-ui/src/components/Modal/getProps.ts
@@ -34,22 +34,17 @@ export function getInnerProps({ offset, style = {}, ...props }: ModalInnerProps)
   };
 }
 
-export function getOpenBtnProps({ set = 'plain', ...props }: Record<string, unknown>) {
-  return {
+export const defaultProps = {
+  openBtn: {
     as: 'button',
-    set,
+    set: 'plain',
     hov: 'o',
     d: 'inline-flex',
-    ...props,
-  };
-}
-
-export function getCloseBtnProps({ set = 'plain', ...props }: Record<string, unknown>) {
-  return {
+  },
+  closeBtn: {
     as: 'button',
-    set,
+    set: 'plain',
     hov: 'o',
     d: 'inline-flex',
-    ...props,
-  };
-}
+  },
+} as const;

--- a/packages/lism-ui/src/components/Modal/react/CloseBtn.tsx
+++ b/packages/lism-ui/src/components/Modal/react/CloseBtn.tsx
@@ -1,6 +1,6 @@
 import type { ElementType } from 'react';
 import { Lism, Icon, type LismComponentProps, type IconProps } from 'lism-css/react';
-import { getCloseBtnProps } from '../getProps';
+import { defaultProps } from '../getProps';
 
 type CloseBtnProps<T extends ElementType = 'button'> = LismComponentProps<T> & {
   modalId?: string;
@@ -10,7 +10,7 @@ type CloseBtnProps<T extends ElementType = 'button'> = LismComponentProps<T> & {
 
 export default function CloseBtn<T extends ElementType = 'button'>({ children, modalId = '', icon, srText = 'Close', ...props }: CloseBtnProps<T>) {
   return (
-    <Lism data-modal-close={modalId} {...(getCloseBtnProps(props as Record<string, unknown>) as object)}>
+    <Lism data-modal-close={modalId} {...(defaultProps.closeBtn as object)} {...(props as object)}>
       {children ? (
         children
       ) : (

--- a/packages/lism-ui/src/components/Modal/react/OpenBtn.tsx
+++ b/packages/lism-ui/src/components/Modal/react/OpenBtn.tsx
@@ -1,6 +1,6 @@
 import type { ElementType } from 'react';
 import { Lism, type LismComponentProps } from 'lism-css/react';
-import { getOpenBtnProps } from '../getProps';
+import { defaultProps } from '../getProps';
 
 type OpenBtnProps<T extends ElementType = 'button'> = LismComponentProps<T> & {
   modalId?: string;
@@ -8,7 +8,7 @@ type OpenBtnProps<T extends ElementType = 'button'> = LismComponentProps<T> & {
 
 export default function OpenBtn<T extends ElementType = 'button'>({ children, modalId = '', ...props }: OpenBtnProps<T>) {
   return (
-    <Lism data-modal-open={modalId} {...(getOpenBtnProps(props as Record<string, unknown>) as object)}>
+    <Lism data-modal-open={modalId} {...(defaultProps.openBtn as object)} {...(props as object)}>
       {children}
     </Lism>
   );

--- a/packages/lism-ui/src/components/Tabs/astro/Tab.astro
+++ b/packages/lism-ui/src/components/Tabs/astro/Tab.astro
@@ -2,7 +2,7 @@
 // import type { LismProps } from 'lism-css/types';
 import { Lism } from 'lism-css/astro';
 import atts from 'lism-css/lib/helper/atts';
-import { getTabProps } from '../getProps';
+import { defaultProps } from '../getProps';
 
 // export interface Props extends LismProps {
 // 	// controlId: string;
@@ -14,6 +14,13 @@ const { tabId = 'tab', index = 0, isActive, class: className, ...props } = Astro
 const controlId = `${tabId}-${index}`;
 ---
 
-<Lism {...getTabProps(props)} class={atts(className, 'c--tabs_tab')} role="tab" aria-controls={controlId} aria-selected={isActive ? 'true' : 'false'}>
+<Lism
+  {...defaultProps.tab}
+  {...props}
+  class={atts(className, 'c--tabs_tab')}
+  role="tab"
+  aria-controls={controlId}
+  aria-selected={isActive ? 'true' : 'false'}
+>
   <slot />
 </Lism>

--- a/packages/lism-ui/src/components/Tabs/getProps.ts
+++ b/packages/lism-ui/src/components/Tabs/getProps.ts
@@ -1,7 +1,6 @@
-export function getTabProps({ set = 'plain', ...props }: { set?: unknown; [key: string]: unknown }) {
-  return {
+export const defaultProps = {
+  tab: {
     as: 'button',
-    set,
-    ...props,
-  };
-}
+    set: 'plain',
+  },
+} as const;

--- a/packages/lism-ui/src/components/Tabs/getProps.ts
+++ b/packages/lism-ui/src/components/Tabs/getProps.ts
@@ -1,9 +1,7 @@
-import mergeSet from 'lism-css/lib/helper/mergeSet';
-
-export function getTabProps({ set, ...props }: { set?: unknown; [key: string]: unknown }) {
+export function getTabProps({ set = 'plain', ...props }: { set?: unknown; [key: string]: unknown }) {
   return {
     as: 'button',
-    set: mergeSet('plain', set),
+    set,
     ...props,
   };
 }

--- a/packages/lism-ui/src/components/Tabs/react/Tab.tsx
+++ b/packages/lism-ui/src/components/Tabs/react/Tab.tsx
@@ -1,6 +1,6 @@
 import { Lism, type LismComponentProps } from 'lism-css/react';
 import atts from 'lism-css/lib/helper/atts';
-import { getTabProps } from '../getProps';
+import { defaultProps } from '../getProps';
 
 type TabProps = LismComponentProps & {
   tabId?: string;
@@ -13,7 +13,8 @@ export default function Tab({ tabId = 'tab', index = 0, isActive = false, classN
 
   return (
     <Lism
-      {...(getTabProps(props as Record<string, unknown>) as object)}
+      {...(defaultProps.tab as object)}
+      {...(props as object)}
       className={atts(className, 'c--tabs_tab')}
       role="tab"
       aria-controls={controlId}


### PR DESCRIPTION
## Summary

`packages/lism-ui` の各 `getProps.ts` で使っていた `mergeSet('plain', set)` を、シンプルにデフォルト引数 `set = 'plain'` へ置き換えた。

これらのコンポーネント（Modal / Accordion / Tabs / Details）では、ユーザー側から `set` を追加・除外したいユースケースはほぼ想定されないため、合成ではなく上書きで十分。また、除外マーカー（`-plain`）については最終段階の `getLismProps` 内で `mergeSet(undefined, rawSet)` が走るため、コンポーネント側で `mergeSet` を使わなくても打ち消しは効く。

結果として `mergeSet` の import が 4 ファイル分不要になり、コードがよりシンプルになった。

Closes #266

## Changes

- `packages/lism-ui/src/components/Modal/getProps.ts`: `getProps` / `getOpenBtnProps` / `getCloseBtnProps`（3 箇所）
- `packages/lism-ui/src/components/Accordion/getProps.ts`: `getHeadingProps` / `getButtonProps`（2 箇所）
- `packages/lism-ui/src/components/Tabs/getProps.ts`: `getTabProps`（1 箇所）
- `packages/lism-ui/src/components/Details/getProps.ts`: `getTitleProps`（1 箇所）
- 上記 4 ファイルから `mergeSet` の import を削除

## Test plan

- [x] `nr typecheck` が通ることを確認（エラー 0）
- [ ] `-plain` 打ち消しマーカーが従来通り機能するか確認（最終段階の `getLismProps` で処理されるため、実動作で確認）
- [ ] ユーザーが `set` を明示した場合にデフォルトの `plain` が上書きされることを確認