### PR TITLE
refactor(lism-css): Decorator から clipPath/boxSizing 専用 props を削除

### DIFF
--- a/.claude/skills/lism-css-guide/primitives/a--decorator.md
+++ b/.claude/skills/lism-css-guide/primitives/a--decorator.md
@@ -13,8 +13,6 @@
 | Prop | 説明 |
 |------|------|
 | `size` | デコレーターのサイズを一括指定。この指定があると `w`（`width`）に値が渡され、自動で `ar="1/1"`（`aspect-ratio:1/1`）が付与される |
-| `clipPath` | `style.clipPath` に渡す |
-| `boxSizing` | `style.boxSizing` に渡す |
 
 ## Usage
 

--- a/apps/docs/src/components/ex/BalloonBox/index.jsx
+++ b/apps/docs/src/components/ex/BalloonBox/index.jsx
@@ -17,43 +17,39 @@ export default function BalloonBox({ variant = 'left', bdw = '1px', bdc, bgc, ke
   switch (variant) {
     case 'left':
       parentProps = { jc: 's', pl: '1em' };
-      decoProps = {
-        t: '50%',
-        l: '0',
+      decoProps = { t: '50%', l: '0' };
+      decoStyle = {
         rotate: '45deg',
         translate: '-50% -50%',
+        clipPath: 'polygon(0% 0%, 0% 100%, 100% 100%)',
       };
-      decoStyle = { clipPath: 'polygon(0% 0%, 0% 100%, 100% 100%)' };
       break;
     case 'right':
       parentProps = { jc: 'e', pr: '1em' };
-      decoProps = {
-        t: '50%',
-        l: '100%',
+      decoProps = { t: '50%', l: '100%' };
+      decoStyle = {
         rotate: '-45deg',
         translate: '-50% -50%',
+        clipPath: 'polygon(0% 100%, 100% 0%, 100% 100%)',
       };
-      decoStyle = { clipPath: 'polygon(0% 100%, 100% 0%, 100% 100%)' };
       break;
     case 'top':
       parentProps = { jc: 'c', pt: '1em' };
-      decoProps = {
-        t: '0',
-        l: '50%',
+      decoProps = { t: '0', l: '50%' };
+      decoStyle = {
         rotate: '45deg',
         translate: '-50% -50%',
+        clipPath: 'polygon(0% 0%, 0% 100%, 100% 0%)',
       };
-      decoStyle = { clipPath: 'polygon(0% 0%, 0% 100%, 100% 0%)' };
       break;
     case 'bottom':
       parentProps = { jc: 'c', pb: '1em' };
-      decoProps = {
-        t: '100%',
-        l: '50%',
+      decoProps = { t: '100%', l: '50%' };
+      decoStyle = {
         rotate: '45deg',
         translate: '-50% -50%',
+        clipPath: 'polygon(100% 0%, 0% 100%, 100% 100%)',
       };
-      decoStyle = { clipPath: 'polygon(100% 0%, 0% 100%, 100% 100%)' };
       break;
     default:
       break;

--- a/apps/docs/src/components/ex/BalloonBox/index.jsx
+++ b/apps/docs/src/components/ex/BalloonBox/index.jsx
@@ -13,7 +13,7 @@ export default function BalloonBox({ variant = 'left', bdw = '1px', bdc, bgc, ke
 
   let parentProps = {};
   let decoProps = {};
-  // let wrapProps = {};
+  let decoStyle = {};
   switch (variant) {
     case 'left':
       parentProps = { jc: 's', pl: '1em' };
@@ -22,8 +22,8 @@ export default function BalloonBox({ variant = 'left', bdw = '1px', bdc, bgc, ke
         l: '0',
         rotate: '45deg',
         translate: '-50% -50%',
-        clipPath: 'polygon(0% 0%, 0% 100%, 100% 100%)',
       };
+      decoStyle = { clipPath: 'polygon(0% 0%, 0% 100%, 100% 100%)' };
       break;
     case 'right':
       parentProps = { jc: 'e', pr: '1em' };
@@ -32,8 +32,8 @@ export default function BalloonBox({ variant = 'left', bdw = '1px', bdc, bgc, ke
         l: '100%',
         rotate: '-45deg',
         translate: '-50% -50%',
-        clipPath: 'polygon(0% 100%, 100% 0%, 100% 100%)',
       };
+      decoStyle = { clipPath: 'polygon(0% 100%, 100% 0%, 100% 100%)' };
       break;
     case 'top':
       parentProps = { jc: 'c', pt: '1em' };
@@ -42,8 +42,8 @@ export default function BalloonBox({ variant = 'left', bdw = '1px', bdc, bgc, ke
         l: '50%',
         rotate: '45deg',
         translate: '-50% -50%',
-        clipPath: 'polygon(0% 0%, 0% 100%, 100% 0%)',
       };
+      decoStyle = { clipPath: 'polygon(0% 0%, 0% 100%, 100% 0%)' };
       break;
     case 'bottom':
       parentProps = { jc: 'c', pb: '1em' };
@@ -52,8 +52,8 @@ export default function BalloonBox({ variant = 'left', bdw = '1px', bdc, bgc, ke
         l: '50%',
         rotate: '45deg',
         translate: '-50% -50%',
-        clipPath: 'polygon(100% 0%, 0% 100%, 100% 100%)',
       };
+      decoStyle = { clipPath: 'polygon(100% 0%, 0% 100%, 100% 100%)' };
       break;
     default:
       break;
@@ -63,7 +63,7 @@ export default function BalloonBox({ variant = 'left', bdw = '1px', bdc, bgc, ke
     <Flex {...parentProps} {...props} className={atts(className, 'c--balloonBox', variant && `c--balloonBox--${variant}`)}>
       <Lism pos="relative" bd p="20" w="fit-content" bdw={bdw} bdrs={bdrs} {...colorProps}>
         {children}
-        <Decorator pos="absolute" size="0.875em" bd="inherit" bgc="inherit" boxSizing="content-box" {...decoProps} />
+        <Decorator pos="absolute" size="0.875em" bd="inherit" bgc="inherit" {...decoProps} style={{ boxSizing: 'content-box', ...decoStyle }} />
       </Lism>
     </Flex>
   );

--- a/apps/docs/src/content/en/primitives/a--decorator.mdx
+++ b/apps/docs/src/content/en/primitives/a--decorator.mdx
@@ -29,7 +29,6 @@ div.a--decorator[aria-hidden="true"]
 |Prop|Description|
 |---|---|
 | `size` | Sets the decorator's size (width and height) at once.<br/>When specified, the value is passed to `w` (`width`) and `ar='1/1'` (`aspect-ratio:1/1`) is applied automatically. |
-| `clipPath`,`boxSizing` | Passed to `style.clipPath` and `style.boxSizing` respectively. |
 
 
 ## Usage

--- a/apps/docs/src/content/ja/primitives/a--decorator.mdx
+++ b/apps/docs/src/content/ja/primitives/a--decorator.mdx
@@ -29,7 +29,6 @@ div.a--decorator[aria-hidden="true"]
 |Prop|説明 |
 |---|---|
 | `size` | デコレーターのサイズ（横幅・高さ）を一括指定します。<br/>この指定がある場合、指定したサイズは`w`(`width`)に渡され、`ar='1/1'`(`aspect-ratio:1/1`)が自動で付与されます。 |
-| `clipPath`,`boxSizing` | `style.clipPath`,`style.boxSizing`へ渡します|
 
 
 ## Usage

--- a/packages/lism-css/src/components/atomic/Decorator/Decorator.stories.tsx
+++ b/packages/lism-css/src/components/atomic/Decorator/Decorator.stories.tsx
@@ -50,6 +50,6 @@ export const WithClipPath: Story = {
   args: {
     size: '100px',
     bgc: 'blue',
-    clipPath: 'polygon(50% 0%, 0% 100%, 100% 100%)',
+    style: { clipPath: 'polygon(50% 0%, 0% 100%, 100% 100%)' },
   },
 };

--- a/packages/lism-css/src/components/atomic/Decorator/Decorator.tsx
+++ b/packages/lism-css/src/components/atomic/Decorator/Decorator.tsx
@@ -4,8 +4,6 @@ import type { CssValue } from '../../../lib/types/LayoutProps';
 
 export interface DecoratorOwnProps {
   size?: CssValue;
-  clipPath?: string;
-  boxSizing?: string;
 }
 
 export type DecoratorProps = LismComponentProps & DecoratorOwnProps;

--- a/packages/lism-css/src/lib/getAtomicProps.ts
+++ b/packages/lism-css/src/lib/getAtomicProps.ts
@@ -15,8 +15,6 @@ interface PropConfig {
 interface AtomicOwnProps {
   // decorator 固有
   size?: CssValue;
-  clipPath?: string;
-  boxSizing?: string;
 }
 
 type AtomicSpecificKeys = keyof AtomicOwnProps;
@@ -78,12 +76,8 @@ function getSpacerProps(props: InputProps): InputProps {
   return next;
 }
 
-function getDecoratorProps({ size, clipPath, boxSizing, style, ...props }: InputProps): InputProps {
-  const newStyle: StyleWithCustomProps = { ...style } as StyleWithCustomProps;
-  if (clipPath) newStyle.clipPath = clipPath;
-  if (boxSizing) newStyle.boxSizing = boxSizing as StyleWithCustomProps['boxSizing'];
-
-  const next: InputProps = { ...props, style: newStyle };
+function getDecoratorProps({ size, ...props }: InputProps): InputProps {
+  const next: InputProps = { ...props };
   if (size) {
     next.ar = '1/1';
     next.w = size;

--- a/packages/lism-css/src/lib/getLismProps.test.ts
+++ b/packages/lism-css/src/lib/getLismProps.test.ts
@@ -62,16 +62,6 @@ describe('getLismProps', () => {
       expect(result.style?.['--w']).toBe('100px');
     });
 
-    test('atomic=decorator で clipPath が style に設定される', () => {
-      const result = getLismProps({ atomic: 'decorator', clipPath: 'circle(50%)' } as LismProps & Record<string, unknown>);
-      expect(result.style?.clipPath).toBe('circle(50%)');
-    });
-
-    test('atomic=decorator で boxSizing が style に設定される', () => {
-      const result = getLismProps({ atomic: 'decorator', boxSizing: 'border-box' } as LismProps & Record<string, unknown>);
-      expect(result.style?.boxSizing).toBe('border-box');
-    });
-
     test('atomic=icon で a--icon が追加される', () => {
       const result = getLismProps({ atomic: 'icon' });
       expect(result.className).toContain('a--icon');

--- a/packages/lism-css/src/lib/types/AtomicProps.ts
+++ b/packages/lism-css/src/lib/types/AtomicProps.ts
@@ -23,8 +23,6 @@ export interface SpacerAtomicProps {
 export interface DecoratorAtomicProps {
   atomic: 'decorator';
   size?: CssValue;
-  clipPath?: string;
-  boxSizing?: string;
 }
 
 // icon（内部用。user-facing では案内しない）


### PR DESCRIPTION
## Summary

- Decorator コンポーネントから clipPath / boxSizing の専用 props を削除
- これらは `style` prop 経由で直接指定できるため、独自のショートカットは冗長だった
- 型定義（AtomicProps / DecoratorOwnProps）、`getAtomicProps` の処理、対応するテストをあわせて削除
- 使用箇所（BalloonBox, Decorator.stories の WithClipPath）は `style` prop 経由に移行
- ドキュメント（ja / en の a--decorator.mdx, lism-css-guide スキル）の Props 表から該当行を削除

## 変更前後の使い方

\`\`\`jsx
// Before
<Decorator clipPath="circle(50%)" boxSizing="content-box" />

// After
<Decorator style={{ clipPath: 'circle(50%)', boxSizing: 'content-box' }} />
\`\`\`

## Test plan

- [x] \`nr typecheck\` — 0 errors
- [x] \`nr lint\` — pass
- [x] \`packages/lism-css\` の vitest — 677 tests passed
- [ ] Docs サイトで BalloonBox の各 variant（left/right/top/bottom）が崩れていないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)