### PR TITLE
fix(lism-ui): React/Astro 初期 props 不一致の修正（6件）

### DIFF
--- a/packages/lism-ui/src/components/Accordion/astro/Button.astro
+++ b/packages/lism-ui/src/components/Accordion/astro/Button.astro
@@ -14,10 +14,10 @@ const { isOpen = false, accID = '__LISM_ACC_ID__', class: className, ...props } 
   w="100%"
   ai="center"
   jc="between"
-  {...props}
   class={atts(className, 'c--accordion_button')}
   aria-controls={accID}
   aria-expanded={isOpen ? 'true' : 'false'}
+  {...props}
 >
   <slot />
   <Icon />

--- a/packages/lism-ui/src/components/Accordion/astro/Icon.astro
+++ b/packages/lism-ui/src/components/Accordion/astro/Icon.astro
@@ -5,4 +5,4 @@ import atts from 'lism-css/lib/helper/atts';
 const { class: className, ...props } = Astro.props || {};
 ---
 
-<Lism atomic="icon" as="span" pi="center" fxsh="0" aria-hidden="true" {...props} class={atts(className, 'c--accordion_icon')} />
+<Lism atomic="icon" as="span" pi="center" fxsh="0" aria-hidden="true" class={atts(className, 'c--accordion_icon')} {...props} />

--- a/packages/lism-ui/src/components/Accordion/react/Button.tsx
+++ b/packages/lism-ui/src/components/Accordion/react/Button.tsx
@@ -35,9 +35,9 @@ export default function Button<T extends ElementType = 'button'>({
       w="100%"
       ai="center"
       jc="between"
-      {...(props as object)}
       aria-controls={accID}
       aria-expanded={isOpen ? 'true' : 'false'}
+      {...(props as object)}
     >
       {children}
       <Icon />

--- a/packages/lism-ui/src/components/Accordion/react/Button.tsx
+++ b/packages/lism-ui/src/components/Accordion/react/Button.tsx
@@ -8,6 +8,7 @@ import Icon from './Icon';
 
 type ButtonProps<T extends ElementType = 'button'> = LismComponentProps<T> & {
   accID?: string;
+  isOpen?: boolean;
 };
 
 /**
@@ -18,6 +19,7 @@ export default function Button<T extends ElementType = 'button'>({
   children,
   className,
   accID: _accID = '__LISM_ACC_ID__',
+  isOpen = false,
   ...props
 }: ButtonProps<T>) {
   const ctx = useContext(AccordionContext);
@@ -35,7 +37,7 @@ export default function Button<T extends ElementType = 'button'>({
       jc="between"
       {...(props as object)}
       aria-controls={accID}
-      aria-expanded="false"
+      aria-expanded={isOpen ? 'true' : 'false'}
     >
       {children}
       <Icon />

--- a/packages/lism-ui/src/components/Accordion/react/Icon.tsx
+++ b/packages/lism-ui/src/components/Accordion/react/Icon.tsx
@@ -3,5 +3,5 @@ import { Lism, type LismComponentProps } from 'lism-css/react';
 
 // CSS疑似要素（::before / ::after）でアイコンを描画するコンポーネント
 export default function Icon({ className, ...props }: LismComponentProps) {
-  return <Lism atomic="icon" as="span" pi="center" fxsh="0" aria-hidden="true" {...props} className={atts(className, 'c--accordion_icon')} />;
+  return <Lism atomic="icon" as="span" pi="center" fxsh="0" aria-hidden="true" className={atts(className, 'c--accordion_icon')} {...props} />;
 }

--- a/packages/lism-ui/src/components/Badge/astro/Badge.astro
+++ b/packages/lism-ui/src/components/Badge/astro/Badge.astro
@@ -15,6 +15,6 @@ const { class: className, variant, ...props } = Astro.props;
   py="5"
   px="10"
   bdrs="10"
-  {...props}
-  class={atts(className, buildModifierClass('c--badge', { variant }))}><slot /></Lism
+  class={atts(className, buildModifierClass('c--badge', { variant }))}
+  {...props}><slot /></Lism
 >

--- a/packages/lism-ui/src/components/Badge/react/Badge.tsx
+++ b/packages/lism-ui/src/components/Badge/react/Badge.tsx
@@ -17,8 +17,8 @@ export default function Badge<T extends ElementType = 'span'>(props: LismCompone
       py="5"
       px="10"
       bdrs="10"
-      {...rest}
       className={atts(className, buildModifierClass('c--badge', { variant }))}
+      {...rest}
     />
   );
 }

--- a/packages/lism-ui/src/components/Button/astro/Button.astro
+++ b/packages/lism-ui/src/components/Button/astro/Button.astro
@@ -7,4 +7,4 @@ import '../_style.css';
 const { class: className, variant, ...props } = Astro.props;
 ---
 
-<Flex as="a" lh="s" py="10" px="20" hov="o" {...props} class={atts(className, buildModifierClass('c--button', { variant }))}><slot /></Flex>
+<Flex as="a" lh="s" py="10" px="20" hov="o" class={atts(className, buildModifierClass('c--button', { variant }))} {...props}><slot /></Flex>

--- a/packages/lism-ui/src/components/Button/react/Button.tsx
+++ b/packages/lism-ui/src/components/Button/react/Button.tsx
@@ -8,5 +8,5 @@ type ButtonOwnProps = { variant?: string };
 
 export default function Button<T extends ElementType = 'a'>(props: LismComponentProps<T> & ButtonOwnProps) {
   const { variant, className, ...rest } = props as { variant?: string; className?: string } & Record<string, unknown>;
-  return <Flex as="a" lh="s" py="10" px="20" hov="o" {...rest} className={atts(className, buildModifierClass('c--button', { variant }))} />;
+  return <Flex as="a" lh="s" py="10" px="20" hov="o" className={atts(className, buildModifierClass('c--button', { variant }))} {...rest} />;
 }

--- a/packages/lism-ui/src/components/Chat/astro/Chat.astro
+++ b/packages/lism-ui/src/components/Chat/astro/Chat.astro
@@ -26,7 +26,7 @@ const { name, avatar, flow = 's', variant = 'speak', direction = 'start', class:
 <Grid class={atts(className, buildModifierClass('c--chat', { variant }))} keycolor="gray" data-chat-dir={direction} ji={direction} {...props}>
   {
     avatar && (
-      <Frame class="c--chat_avatar" bgc="base" ar="1/1" bdrs="99" aria-hidden="true" src={avatar} alt="">
+      <Frame class="c--chat_avatar" bgc="base" ar="1/1" bdrs="99" aria-hidden="true">
         <img src={avatar} alt="" width="60" height="60" decoding="async" />
       </Frame>
     )

--- a/packages/lism-ui/src/components/Details/astro/Content.astro
+++ b/packages/lism-ui/src/components/Details/astro/Content.astro
@@ -11,5 +11,5 @@ const { class: className, ...props } = Astro.props || {};
 ---
 
 <Lism class="c--details_body">
-  <Lism layout="flow" flow="s" {...props} class={atts(className, 'c--details_content')}><slot /></Lism>
+  <Lism layout="flow" flow="s" class={atts(className, 'c--details_content')} {...props}><slot /></Lism>
 </Lism>

--- a/packages/lism-ui/src/components/Details/astro/Icon.astro
+++ b/packages/lism-ui/src/components/Details/astro/Icon.astro
@@ -9,4 +9,4 @@ import atts from 'lism-css/lib/helper/atts';
 const { class: className, ...props } = Astro.props || {};
 ---
 
-<Lism atomic="icon" as="span" aria-hidden="true" {...props} class={atts(className, 'c--details_icon')}><slot /></Lism>
+<Lism atomic="icon" as="span" aria-hidden="true" class={atts(className, 'c--details_icon')} {...props}><slot /></Lism>

--- a/packages/lism-ui/src/components/Details/astro/Summary.astro
+++ b/packages/lism-ui/src/components/Details/astro/Summary.astro
@@ -5,4 +5,4 @@ import atts from 'lism-css/lib/helper/atts';
 const { class: className, ...props } = Astro.props || {};
 ---
 
-<Lism as="summary" layout="flex" g="10" ai="center" {...props} class={atts(className, 'c--details_summary')}><slot /></Lism>
+<Lism as="summary" layout="flex" g="10" ai="center" class={atts(className, 'c--details_summary')} {...props}><slot /></Lism>

--- a/packages/lism-ui/src/components/Details/astro/Title.astro
+++ b/packages/lism-ui/src/components/Details/astro/Title.astro
@@ -5,4 +5,4 @@ import atts from 'lism-css/lib/helper/atts';
 const { class: className, ...props } = Astro.props || {};
 ---
 
-<Lism as="span" fx="1" set="plain" {...props} class={atts(className, 'c--details_title')}><slot /></Lism>
+<Lism as="span" fx="1" set="plain" class={atts(className, 'c--details_title')} {...props}><slot /></Lism>

--- a/packages/lism-ui/src/components/Details/react/Content.tsx
+++ b/packages/lism-ui/src/components/Details/react/Content.tsx
@@ -8,7 +8,7 @@ import atts from 'lism-css/lib/helper/atts';
 export default function Content<T extends ElementType = 'div'>({ children, className, ...props }: LismComponentProps<T>) {
   return (
     <Lism className="c--details_body">
-      <Lism layout="flow" flow="s" {...(props as object)} className={atts(className, 'c--details_content')}>
+      <Lism layout="flow" flow="s" className={atts(className, 'c--details_content')} {...(props as object)}>
         {children}
       </Lism>
     </Lism>

--- a/packages/lism-ui/src/components/Details/react/Icon.tsx
+++ b/packages/lism-ui/src/components/Details/react/Icon.tsx
@@ -7,7 +7,7 @@ import atts from 'lism-css/lib/helper/atts';
  */
 export default function Icon<T extends ElementType = 'span'>({ children, className, ...props }: LismComponentProps<T>) {
   return (
-    <Lism atomic="icon" as="span" aria-hidden="true" {...(props as object)} className={atts(className, 'c--details_icon')}>
+    <Lism atomic="icon" as="span" aria-hidden="true" className={atts(className, 'c--details_icon')} {...(props as object)}>
       {children}
     </Lism>
   );

--- a/packages/lism-ui/src/components/Details/react/Summary.tsx
+++ b/packages/lism-ui/src/components/Details/react/Summary.tsx
@@ -8,7 +8,7 @@ import atts from 'lism-css/lib/helper/atts';
  */
 export default function Summary<T extends ElementType = 'summary'>({ children, className, ...props }: LismComponentProps<T>) {
   return (
-    <Lism as="summary" layout="flex" g="10" ai="center" {...(props as object)} className={atts(className, 'c--details_summary')}>
+    <Lism as="summary" layout="flex" g="10" ai="center" className={atts(className, 'c--details_summary')} {...(props as object)}>
       {children}
     </Lism>
   );

--- a/packages/lism-ui/src/components/Details/react/Title.tsx
+++ b/packages/lism-ui/src/components/Details/react/Title.tsx
@@ -7,7 +7,7 @@ import atts from 'lism-css/lib/helper/atts';
  */
 export default function Title<T extends ElementType = 'span'>({ children, className, ...props }: LismComponentProps<T>) {
   return (
-    <Lism as="span" fx="1" set="plain" {...(props as object)} className={atts(className, 'c--details_title')}>
+    <Lism as="span" fx="1" set="plain" className={atts(className, 'c--details_title')} {...(props as object)}>
       {children}
     </Lism>
   );

--- a/packages/lism-ui/src/components/DummyImage/astro/DummyImage.astro
+++ b/packages/lism-ui/src/components/DummyImage/astro/DummyImage.astro
@@ -4,4 +4,4 @@ import { Lism } from 'lism-css/astro';
 const props = Astro.props;
 ---
 
-<Lism as="img" src="https://cdn.lism-css.com/dummy-image.jpg" width="600" height="400" alt="" {...props} />
+<Lism as="img" src="https://cdn.lism-css.com/dummy-image.jpg" width={600} height={400} alt="" {...props} />

--- a/packages/lism-ui/src/components/DummyText/react/DummyText.tsx
+++ b/packages/lism-ui/src/components/DummyText/react/DummyText.tsx
@@ -9,7 +9,7 @@ type DummyTextProps<T extends ElementType = 'p'> = LismComponentProps<T> & {
   offset?: number;
 };
 
-export default function DummyText<T extends ElementType = 'p'>({ pre = '', length = 'm', lang = 'en', offset = 0, ...props }: DummyTextProps<T>) {
+export default function DummyText<T extends ElementType = 'p'>({ as, pre = '', length = 'm', lang = 'en', offset = 0, ...props }: DummyTextProps<T>) {
   const content = getContent({ pre, lang, length, offset });
-  return <Lism {...(props as LismComponentProps)} dangerouslySetInnerHTML={{ __html: content }} />;
+  return <Lism as={as ?? 'p'} {...(props as LismComponentProps)} dangerouslySetInnerHTML={{ __html: content }} />;
 }

--- a/packages/lism-ui/src/components/Modal/astro/Body.astro
+++ b/packages/lism-ui/src/components/Modal/astro/Body.astro
@@ -6,4 +6,4 @@ import atts from 'lism-css/lib/helper/atts';
 const { class: className, ...props } = Astro.props || {};
 ---
 
-<Lism {...props} class={atts(className, 'c--modal_body')}><slot /></Lism>
+<Lism class={atts(className, 'c--modal_body')} {...props}><slot /></Lism>

--- a/packages/lism-ui/src/components/Modal/react/Body.tsx
+++ b/packages/lism-ui/src/components/Modal/react/Body.tsx
@@ -3,7 +3,7 @@ import atts from 'lism-css/lib/helper/atts';
 
 export default function ModalBody({ children, className, ...props }: LismComponentProps) {
   return (
-    <Lism {...props} className={atts(className, 'c--modal_body')}>
+    <Lism className={atts(className, 'c--modal_body')} {...props}>
       {children}
     </Lism>
   );

--- a/packages/lism-ui/src/components/NavMenu/react/Link.tsx
+++ b/packages/lism-ui/src/components/NavMenu/react/Link.tsx
@@ -1,11 +1,12 @@
+import type { ElementType } from 'react';
 import { Flex, type LismComponentProps } from 'lism-css/react';
 import atts from 'lism-css/lib/helper/atts';
 
-type LinkProps = LismComponentProps & { href?: string };
+type LinkProps = LismComponentProps<ElementType> & { href?: string };
 
-export default function Link({ children, className, ...props }: LinkProps) {
+export default function Link({ children, className, as = 'span', ...props }: LinkProps) {
   return (
-    <Flex as={props.href ? 'a' : 'span'} className={atts(className, 'c--navMenu_link')} c="inherit" {...props}>
+    <Flex as={props.href ? 'a' : as} className={atts(className, 'c--navMenu_link')} c="inherit" {...props}>
       {children}
     </Flex>
   );

--- a/packages/lism-ui/src/components/Tabs/astro/Tab.astro
+++ b/packages/lism-ui/src/components/Tabs/astro/Tab.astro
@@ -9,7 +9,7 @@ import atts from 'lism-css/lib/helper/atts';
 // 	tabId?: string | number;
 // 	index?: number;
 // }
-const { tabId = 'tab', index = 0, isActive, class: className, ...props } = Astro.props;
+const { tabId = 'tab', index = 0, isActive = false, class: className, ...props } = Astro.props;
 const controlId = `${tabId}-${index}`;
 ---
 

--- a/packages/lism-ui/src/components/Tabs/astro/Tab.astro
+++ b/packages/lism-ui/src/components/Tabs/astro/Tab.astro
@@ -16,11 +16,11 @@ const controlId = `${tabId}-${index}`;
 <Lism
   as="button"
   set="plain"
-  {...props}
   class={atts(className, 'c--tabs_tab')}
   role="tab"
   aria-controls={controlId}
   aria-selected={isActive ? 'true' : 'false'}
+  {...props}
 >
   <slot />
 </Lism>

--- a/packages/lism-ui/src/components/Tabs/astro/TabList.astro
+++ b/packages/lism-ui/src/components/Tabs/astro/TabList.astro
@@ -6,4 +6,4 @@ import atts from 'lism-css/lib/helper/atts';
 const { class: className, ...props } = Astro.props;
 ---
 
-<Lism role="tablist" {...props} class={atts(className, 'c--tabs_list')}><slot /></Lism>
+<Lism role="tablist" class={atts(className, 'c--tabs_list')} {...props}><slot /></Lism>

--- a/packages/lism-ui/src/components/Tabs/astro/TabPanel.astro
+++ b/packages/lism-ui/src/components/Tabs/astro/TabPanel.astro
@@ -12,4 +12,4 @@ const { tabId = 'tab', index = 0, isActive = false, class: className, ...props }
 const controlId = `${tabId}-${index}`;
 ---
 
-<Lism id={controlId} role="tabpanel" aria-hidden={isActive ? 'false' : 'true'} {...props} class={atts(className, 'c--tabs_panel')}><slot /></Lism>
+<Lism id={controlId} role="tabpanel" aria-hidden={isActive ? 'false' : 'true'} class={atts(className, 'c--tabs_panel')} {...props}><slot /></Lism>

--- a/packages/lism-ui/src/components/Tabs/react/Tab.tsx
+++ b/packages/lism-ui/src/components/Tabs/react/Tab.tsx
@@ -14,11 +14,11 @@ export default function Tab({ tabId = 'tab', index = 0, isActive = false, classN
     <Lism
       as="button"
       set="plain"
-      {...props}
       className={atts(className, 'c--tabs_tab')}
       role="tab"
       aria-controls={controlId}
       aria-selected={isActive ? 'true' : 'false'}
+      {...props}
     />
   );
 }

--- a/packages/lism-ui/src/components/Tabs/react/TabList.tsx
+++ b/packages/lism-ui/src/components/Tabs/react/TabList.tsx
@@ -2,5 +2,5 @@ import { Lism, type LismComponentProps } from 'lism-css/react';
 import atts from 'lism-css/lib/helper/atts';
 
 export default function TabList({ className, ...props }: LismComponentProps) {
-  return <Lism role="tablist" {...props} className={atts(className, 'c--tabs_list')} />;
+  return <Lism role="tablist" className={atts(className, 'c--tabs_list')} {...props} />;
 }

--- a/packages/lism-ui/src/components/Tabs/react/TabPanel.tsx
+++ b/packages/lism-ui/src/components/Tabs/react/TabPanel.tsx
@@ -10,5 +10,5 @@ type TabPanelProps = LismComponentProps & {
 export default function TabPanel({ tabId = 'tab', isActive = false, index = 0, className, ...props }: TabPanelProps) {
   const controlId = `${tabId}-${index}`;
 
-  return <Lism id={controlId} role="tabpanel" aria-hidden={isActive ? 'false' : 'true'} {...props} className={atts(className, 'c--tabs_panel')} />;
+  return <Lism id={controlId} role="tabpanel" aria-hidden={isActive ? 'false' : 'true'} className={atts(className, 'c--tabs_panel')} {...props} />;
 }


### PR DESCRIPTION
## Summary

`/check-ui-props` コマンドで検出された React/Astro サブコンポーネント間の初期 props 差分 6 件を修正する。いずれも lism-ui のレンダリング結果に影響する差分で、修正漏れ・コピペミス・表記ゆれが混在していた。

修正後は全 42 ペアで差分 0 件を確認済み。

Closes #275

## Changes

- **Accordion/Button**: React 側に `isOpen = false` prop を追加し `aria-expanded` を動的化。`setAccordion.ts` の runtime DOM 操作と両立する初期値反映のみを行う責務分担（Issue コメントの方針に従う）
- **Chat/Chat (astro)**: `<Frame>` に誤って渡っていた `src={avatar} alt=""` を削除し React 側に揃える
- **DummyImage (astro)**: `width`/`height` を数値リテラル `{600}` / `{400}` に統一
- **NavMenu/Link (react)**: `as` prop を受け取れるよう対応し `as={props.href ? 'a' : as}` に変更。`LismComponentProps<ElementType>` で generic を明示し `as` の型が `'div'` に絞られないようにした
- **Tabs/Tab (astro)**: `isActive = false` デフォルトを追加し React 側に揃える
- **DummyText (react)**: `as` を関数引数で受け取り `<Lism as={as ?? 'p'} />` にランタイムデフォルトを追加（既存の Text.tsx パターンに準拠）

## Test plan

- [x] `nr typecheck` が通ること
- [x] `/check-ui-props` 再実行で差分 0 件になること
- [ ] 各コンポーネントの Storybook / docs での表示確認