### PR TITLE
refactor(create-lism): @lism-css/cli を bundle して自己完結化

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build:core:css": "turbo run build:css --filter=./packages/lism-css",
     "build:ui": "turbo run build --filter=./packages/lism-ui",
     "build:mcp": "turbo run build --filter=./packages/mcp",
+    "build:cli": "turbo run build --filter=./packages/lism-cli --filter=./packages/create-lism",
     "build:docs": "turbo run build --filter=./apps/docs",
     "check:docs": "pnpm build:core && pnpm --filter lism-docs exec astro check",
     "merge:dev": "git checkout main && git merge dev",
@@ -31,7 +32,7 @@
     "publish:core": "pnpm run build:core && pnpm --filter lism-css publish",
     "publish:ui": "pnpm run build:ui && pnpm --filter @lism-css/ui publish --access public",
     "publish:mcp": "pnpm run build:mcp && pnpm --filter @lism-css/mcp publish --access public",
-    "publish:cli": "pnpm --filter @lism-css/cli publish --access public",
+    "publish:cli": "pnpm run build:cli && pnpm --filter @lism-css/cli publish --access public --no-git-checks && pnpm --filter create-lism publish --access public --no-git-checks",
     "sync:cdn-versions": "node scripts/sync-cdn-versions.mjs",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "publish:core": "pnpm run build:core && pnpm --filter lism-css publish",
     "publish:ui": "pnpm run build:ui && pnpm --filter @lism-css/ui publish --access public",
     "publish:mcp": "pnpm run build:mcp && pnpm --filter @lism-css/mcp publish --access public",
-    "publish:cli": "pnpm run build:cli && pnpm --filter @lism-css/cli publish --access public --no-git-checks && pnpm --filter create-lism publish --access public --no-git-checks",
+    "publish:cli": "pnpm run build:cli && pnpm --filter @lism-css/cli publish --access public && pnpm --filter create-lism publish --access public",
     "sync:cdn-versions": "node scripts/sync-cdn-versions.mjs",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "publish:core": "pnpm run build:core && pnpm --filter lism-css publish",
     "publish:ui": "pnpm run build:ui && pnpm --filter @lism-css/ui publish --access public",
     "publish:mcp": "pnpm run build:mcp && pnpm --filter @lism-css/mcp publish --access public",
-    "publish:cli": "pnpm run build:cli && pnpm --filter @lism-css/cli publish --access public && pnpm --filter create-lism publish --access public",
+    "publish:cli": "pnpm run build:cli && pnpm --filter @lism-css/cli publish --access public && pnpm --filter create-lism publish",
     "sync:cdn-versions": "node scripts/sync-cdn-versions.mjs",
     "prepare": "husky"
   },

--- a/packages/create-lism/README.md
+++ b/packages/create-lism/README.md
@@ -2,7 +2,7 @@
 
 [Lism CSS](https://lism-css.com) のスターターテンプレートから新規プロジェクトを生成する CLI ラッパーです。`pnpm create lism` / `npm create lism@latest` から呼び出せます。
 
-内部では [`@lism-css/cli`](https://www.npmjs.com/package/@lism-css/cli) の `lism create` を呼んでいます。
+内部ロジックは [`@lism-css/cli`](https://www.npmjs.com/package/@lism-css/cli) の `lism create` と共通です（バンドル済み）。
 
 ## 使い方
 

--- a/packages/create-lism/package.json
+++ b/packages/create-lism/package.json
@@ -16,10 +16,8 @@
     "dev": "tsup --watch",
     "prepublishOnly": "pnpm build"
   },
-  "dependencies": {
-    "@lism-css/cli": "workspace:*"
-  },
   "devDependencies": {
+    "@lism-css/cli": "workspace:*",
     "@types/node": "^25.5.0",
     "tsup": "^8.0.0",
     "typescript": "^5.8.3"

--- a/packages/create-lism/package.json
+++ b/packages/create-lism/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-lism",
   "version": "0.1.0",
-  "description": "Scaffold a new Lism CSS project (thin wrapper around @lism-css/cli create)",
+  "description": "Scaffold a new Lism CSS project",
   "type": "module",
   "bin": {
     "create-lism": "./bin/create-lism.mjs"

--- a/packages/create-lism/tsup.config.ts
+++ b/packages/create-lism/tsup.config.ts
@@ -10,5 +10,7 @@ export default defineConfig({
   banner: {
     js: "import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);",
   },
-  noExternal: ['@lism-css/cli', '@inquirer/prompts', 'commander', 'giget', 'jiti', 'picocolors'],
+  // node 標準モジュール以外はすべて bundle に内包する。
+  // lism-cli の依存変更に追従不要にするためハードコードを避ける。
+  noExternal: [/.*/],
 });

--- a/packages/create-lism/tsup.config.ts
+++ b/packages/create-lism/tsup.config.ts
@@ -6,4 +6,9 @@ export default defineConfig({
   dts: false,
   clean: true,
   target: 'node18',
+  shims: true,
+  banner: {
+    js: "import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);",
+  },
+  noExternal: ['@lism-css/cli', '@inquirer/prompts', 'commander', 'giget', 'jiti', 'picocolors'],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,11 +342,10 @@ importers:
         version: link:../../packages/lism-css
 
   packages/create-lism:
-    dependencies:
+    devDependencies:
       '@lism-css/cli':
         specifier: workspace:*
         version: link:../lism-cli
-    devDependencies:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0


### PR DESCRIPTION
## Summary

- `create-lism` を `@lism-css/cli` の薄いラッパーから **自己完結バンドル型** に変更（create-vite / create-vue / create-astro と同じ構成）
- `@lism-css/cli` を `dependencies` から削除し、tsup の `noExternal` で bundle に内包
- `publish:cli` を「cli + create-lism を連続 publish」する script に拡張

## 背景

`create-lism` は `runCreate` を import するだけの薄いラッパーで、`@lism-css/cli` を `workspace:*` で参照していた。しかし publish 時に固定バージョンへ置換されるため、cli を更新するたびに create-lism 側の dependencies も追従が必要だった。また、モノレポ内で自前パッケージを外部依存として再取得する構造（`"beta"` 指定パターン）も検討したが、`packages/create-lism/node_modules/@lism-css/cli` に npm 公開版が二重に展開されてしまう違和感があり、最終的に主流の **「本体に依存せずバンドルする」** 方式を採用した。

## 変更内容

### `packages/create-lism/`
- `package.json`: `@lism-css/cli` を `dependencies` → `devDependencies` (`workspace:*`) に移動
- `tsup.config.ts`:
  - `noExternal` で `@lism-css/cli` とその依存（`@inquirer/prompts`, `commander`, `giget`, `jiti`, `picocolors`）を bundle に内包
  - ESM bundle 内の動的 require（`yoctocolors-cjs` 等）に対応するため `shims: true` + `banner` で `createRequire` を注入

### root `package.json`
- `build:cli` を新設: cli と create-lism を turbo で一括ビルド（`^build` 依存により cli が先に走る）
- `publish:cli` を拡張: `build:cli` 実行 → `@lism-css/cli` publish → `create-lism` publish の順で実行

## 配布パッケージのサイズ

```
package size:   290.9 kB  (圧縮)
unpacked size: 984.3 kB
total files:   8
dependencies:  なし
```

## Test plan

- [x] `pnpm run build:cli` で cli → create-lism の順でビルド成功
- [x] `node packages/create-lism/bin/create-lism.mjs --help` でヘルプ表示確認
- [x] `npm pack --dry-run` で `dependencies` ナシで配布されることを確認
- [ ] publish 後、別環境で `pnpm create lism` の実行確認（リリース時）

🤖 Generated with [Claude Code](https://claude.com/claude-code)