### PR TITLE
fix(cli): lism ui add のコンポーネント名に kebab-case 等を受け付ける

### DIFF
--- a/apps/docs/src/content/en/installation.mdx
+++ b/apps/docs/src/content/en/installation.mdx
@@ -162,21 +162,20 @@ import { Accordion, Tabs, Button } from '@lism-css/ui/astro';
 
 ### Copy to your project with the CLI
 
-Using `@lism-css/cli`'s `lism ui add`, you can copy UI component source code directly into your project and customize it freely. Component names are specified in kebab-case (e.g. `NavMenu` → `nav-menu`).
+Using `@lism-css/cli`'s `lism ui add`, you can copy UI component source code directly into your project and customize it freely. Component names are specified in PascalCase — the same form you use when importing.
 
 ```bash frame="none"
 # Add a component (interactive setup on first run)
-npx @lism-css/cli ui add accordion
+npx @lism-css/cli ui add Accordion
 
 # Add multiple components at once
-npx @lism-css/cli ui add accordion modal tabs
-
-# Multi-word components use kebab-case
-npx @lism-css/cli ui add nav-menu shape-divider
+npx @lism-css/cli ui add Accordion Modal Tabs NavMenu
 
 # Add all components
 npx @lism-css/cli ui add --all
 ```
+
+Case, hyphens, and underscores are ignored when resolving names, so `NavMenu` / `navmenu` / `nav-menu` / `nav_menu` all resolve to the same component.
 
 
 ## AI Tool Integration

--- a/apps/docs/src/content/en/installation.mdx
+++ b/apps/docs/src/content/en/installation.mdx
@@ -162,7 +162,7 @@ import { Accordion, Tabs, Button } from '@lism-css/ui/astro';
 
 ### Copy to your project with the CLI
 
-Using `@lism-css/cli`'s `lism ui add`, you can copy UI component source code directly into your project and customize it freely.
+Using `@lism-css/cli`'s `lism ui add`, you can copy UI component source code directly into your project and customize it freely. Component names are specified in kebab-case (e.g. `NavMenu` → `nav-menu`).
 
 ```bash frame="none"
 # Add a component (interactive setup on first run)
@@ -170,6 +170,9 @@ npx @lism-css/cli ui add accordion
 
 # Add multiple components at once
 npx @lism-css/cli ui add accordion modal tabs
+
+# Multi-word components use kebab-case
+npx @lism-css/cli ui add nav-menu shape-divider
 
 # Add all components
 npx @lism-css/cli ui add --all

--- a/apps/docs/src/content/ja/installation.mdx
+++ b/apps/docs/src/content/ja/installation.mdx
@@ -162,21 +162,20 @@ import { Accordion, Tabs, Button } from '@lism-css/ui/astro';
 
 ### CLI でプロジェクトにコピーする
 
-`@lism-css/cli` の `lism ui add` を使うと、UIコンポーネントのソースコードを自分のプロジェクトにコピーし、自由にカスタマイズできます。コンポーネント名は kebab-case で指定します（例: `NavMenu` → `nav-menu`）。
+`@lism-css/cli` の `lism ui add` を使うと、UIコンポーネントのソースコードを自分のプロジェクトにコピーし、自由にカスタマイズできます。コンポーネント名は `import` するときと同じ PascalCase で指定します。
 
 ```bash frame="none"
 # コンポーネントを追加（初回は対話形式でセットアップ）
-npx @lism-css/cli ui add accordion
+npx @lism-css/cli ui add Accordion
 
 # 複数コンポーネントをまとめて追加
-npx @lism-css/cli ui add accordion modal tabs
-
-# 複合語のコンポーネントは kebab-case で
-npx @lism-css/cli ui add nav-menu shape-divider
+npx @lism-css/cli ui add Accordion Modal Tabs NavMenu
 
 # 全コンポーネントを追加
 npx @lism-css/cli ui add --all
 ```
+
+名前は大文字小文字・ハイフン・アンダースコアを無視して解決するため、`NavMenu` / `navmenu` / `nav-menu` / `nav_menu` のいずれでも同じコンポーネントに解決されます。
 
 
 ## AIツール連携

--- a/apps/docs/src/content/ja/installation.mdx
+++ b/apps/docs/src/content/ja/installation.mdx
@@ -162,7 +162,7 @@ import { Accordion, Tabs, Button } from '@lism-css/ui/astro';
 
 ### CLI でプロジェクトにコピーする
 
-`@lism-css/cli` の `lism ui add` を使うと、UIコンポーネントのソースコードを自分のプロジェクトにコピーし、自由にカスタマイズできます。
+`@lism-css/cli` の `lism ui add` を使うと、UIコンポーネントのソースコードを自分のプロジェクトにコピーし、自由にカスタマイズできます。コンポーネント名は kebab-case で指定します（例: `NavMenu` → `nav-menu`）。
 
 ```bash frame="none"
 # コンポーネントを追加（初回は対話形式でセットアップ）
@@ -170,6 +170,9 @@ npx @lism-css/cli ui add accordion
 
 # 複数コンポーネントをまとめて追加
 npx @lism-css/cli ui add accordion modal tabs
+
+# 複合語のコンポーネントは kebab-case で
+npx @lism-css/cli ui add nav-menu shape-divider
 
 # 全コンポーネントを追加
 npx @lism-css/cli ui add --all

--- a/packages/lism-cli/package.json
+++ b/packages/lism-cli/package.json
@@ -22,6 +22,7 @@
     "format": "prettier --write . --ignore-path ../../.prettierignore",
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {

--- a/packages/lism-cli/src/commands/ui/add.ts
+++ b/packages/lism-cli/src/commands/ui/add.ts
@@ -14,6 +14,7 @@ import {
 import { resolveHelperPlaceholder } from '../../transform.js';
 import { runInit } from './init.js';
 import { logger } from '../../logger.js';
+import { normalizeComponentName } from './normalize.js';
 import type { LismCliConfig } from '../../config.js';
 
 interface AddOptions {
@@ -61,12 +62,11 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
 
   // 入力を PascalCase の正規名に解決
   // kebab-case / snake_case / camelCase / PascalCase / lowercase のいずれも受け付ける
-  const normalize = (s: string) => s.replace(/[-_]/g, '').toLowerCase();
   const resolvedNames: string[] = [];
   const notFound: string[] = [];
   for (const input of names) {
-    const normalized = normalize(input);
-    const match = catalog.components.find((c) => normalize(c.name) === normalized);
+    const normalized = normalizeComponentName(input);
+    const match = catalog.components.find((c) => normalizeComponentName(c.name) === normalized);
     if (match) resolvedNames.push(match.name);
     else notFound.push(input);
   }

--- a/packages/lism-cli/src/commands/ui/add.ts
+++ b/packages/lism-cli/src/commands/ui/add.ts
@@ -59,12 +59,14 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
     process.exit(1);
   }
 
-  // 入力を PascalCase の正規名に解決（`navmenu` / `NavMenu` どちらでも受け付ける）
+  // 入力を PascalCase の正規名に解決
+  // kebab-case / snake_case / camelCase / PascalCase / lowercase のいずれも受け付ける
+  const normalize = (s: string) => s.replace(/[-_]/g, '').toLowerCase();
   const resolvedNames: string[] = [];
   const notFound: string[] = [];
   for (const input of names) {
-    const lower = input.toLowerCase();
-    const match = catalog.components.find((c) => c.name.toLowerCase() === lower);
+    const normalized = normalize(input);
+    const match = catalog.components.find((c) => normalize(c.name) === normalized);
     if (match) resolvedNames.push(match.name);
     else notFound.push(input);
   }

--- a/packages/lism-cli/src/commands/ui/list.ts
+++ b/packages/lism-cli/src/commands/ui/list.ts
@@ -22,14 +22,9 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
   logger.log(`\nLism UI v${catalog.version}\n`);
   logger.log('コンポーネント:');
 
-  // PascalCase → kebab-case。複合語のみ `(NavMenu/)` のように実ディレクトリ名を併記
-  const toKebabCase = (s: string) => s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
-
   for (const component of catalog.components) {
-    const kebab = toKebabCase(component.name);
-    const dirLabel = kebab !== component.name.toLowerCase() ? ` (${component.name}/)` : '';
-    const helpers = component.helpers.length > 0 ? ` [helpers: ${component.helpers.join(', ')}]` : '';
-    logger.log(`  - ${kebab}${dirLabel}${helpers}`);
+    const helpers = component.helpers.length > 0 ? ` (helpers: ${component.helpers.join(', ')})` : '';
+    logger.log(`  - ${component.name}${helpers}`);
   }
 
   logger.log(`\n合計: ${catalog.components.length} コンポーネント`);

--- a/packages/lism-cli/src/commands/ui/list.ts
+++ b/packages/lism-cli/src/commands/ui/list.ts
@@ -22,9 +22,14 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
   logger.log(`\nLism UI v${catalog.version}\n`);
   logger.log('コンポーネント:');
 
+  // PascalCase → kebab-case。複合語のみ `(NavMenu/)` のように実ディレクトリ名を併記
+  const toKebabCase = (s: string) => s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+
   for (const component of catalog.components) {
-    const helpers = component.helpers.length > 0 ? ` (helpers: ${component.helpers.join(', ')})` : '';
-    logger.log(`  - ${component.name}${helpers}`);
+    const kebab = toKebabCase(component.name);
+    const dirLabel = kebab !== component.name.toLowerCase() ? ` (${component.name}/)` : '';
+    const helpers = component.helpers.length > 0 ? ` [helpers: ${component.helpers.join(', ')}]` : '';
+    logger.log(`  - ${kebab}${dirLabel}${helpers}`);
   }
 
   logger.log(`\n合計: ${catalog.components.length} コンポーネント`);

--- a/packages/lism-cli/src/commands/ui/normalize.test.ts
+++ b/packages/lism-cli/src/commands/ui/normalize.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeComponentName } from './normalize';
+
+describe('normalizeComponentName', () => {
+  it('kebab-case / snake_case / camelCase / PascalCase / lowercase をすべて同じ正規形に揃える', () => {
+    const expected = 'navmenu';
+    expect(normalizeComponentName('nav-menu')).toBe(expected);
+    expect(normalizeComponentName('nav_menu')).toBe(expected);
+    expect(normalizeComponentName('navMenu')).toBe(expected);
+    expect(normalizeComponentName('NavMenu')).toBe(expected);
+    expect(normalizeComponentName('navmenu')).toBe(expected);
+  });
+});

--- a/packages/lism-cli/src/commands/ui/normalize.ts
+++ b/packages/lism-cli/src/commands/ui/normalize.ts
@@ -1,0 +1,5 @@
+/**
+ * コンポーネント名を比較用の正規形（ハイフン・アンダースコア除去 + 小文字化）に変換する。
+ * `nav-menu` / `nav_menu` / `navMenu` / `NavMenu` / `navmenu` をすべて `navmenu` に揃える。
+ */
+export const normalizeComponentName = (s: string): string => s.replace(/[-_]/g, '').toLowerCase();

--- a/skills/lism-css-guide/components-ui.md
+++ b/skills/lism-css-guide/components-ui.md
@@ -316,13 +316,16 @@ HTML の `details/summary` 要素をラップしたコンポーネント。Accor
 
 `@lism-css/ui` の UI コンポーネントは、CLI コマンドで自分のプロジェクトにソースコードをコピーして使うこともできます。コピーしたファイルは自由にカスタマイズ可能です。
 
+コンポーネント名は kebab-case で指定します（`NavMenu` → `nav-menu`）。
+
 ```bash
 # 初期設定（framework、出力先ディレクトリを対話的に設定）
 npx @lism-css/cli ui init
 
 # コンポーネントを追加
-npx @lism-css/cli ui add Button Modal
-npx @lism-css/cli ui add -a          # 全コンポーネントを追加
+npx @lism-css/cli ui add button modal
+npx @lism-css/cli ui add nav-menu shape-divider
+npx @lism-css/cli ui add --all        # 全コンポーネントを追加
 
 # 利用可能なコンポーネント一覧を表示
 npx @lism-css/cli ui list

--- a/skills/lism-css-guide/components-ui.md
+++ b/skills/lism-css-guide/components-ui.md
@@ -316,15 +316,15 @@ HTML の `details/summary` 要素をラップしたコンポーネント。Accor
 
 `@lism-css/ui` の UI コンポーネントは、CLI コマンドで自分のプロジェクトにソースコードをコピーして使うこともできます。コピーしたファイルは自由にカスタマイズ可能です。
 
-コンポーネント名は kebab-case で指定します（`NavMenu` → `nav-menu`）。
+コンポーネント名は `import` するときと同じ PascalCase で指定します。
 
 ```bash
 # 初期設定（framework、出力先ディレクトリを対話的に設定）
 npx @lism-css/cli ui init
 
 # コンポーネントを追加
-npx @lism-css/cli ui add button modal
-npx @lism-css/cli ui add nav-menu shape-divider
+npx @lism-css/cli ui add Button Modal
+npx @lism-css/cli ui add NavMenu
 npx @lism-css/cli ui add --all        # 全コンポーネントを追加
 
 # 利用可能なコンポーネント一覧を表示


### PR DESCRIPTION
## Summary

`lism ui add` / `lism ui list` のコンポーネント名取り扱いを、shadcn/ui・HeroUI・Park UI 等の事実上の業界標準に合わせて改善します。

従来は `toLowerCase()` のみの比較で、`NavMenu` / `navmenu` / `navMenu` は通るが、**shadcn 系の慣例である kebab-case (`nav-menu`) は受け付けられない** 状態でした。他ライブラリから乗り換えてきたユーザーが直感的に使えるように、ハイフン・アンダースコアを含む表記を正規化ロジックに取り込みます。

Closes #295

## Changes

### CLI
- `packages/lism-cli/src/commands/ui/add.ts`: 入力正規化を `s.replace(/[-_]/g, '').toLowerCase()` に変更。`nav-menu` / `nav_menu` / `navMenu` / `NavMenu` / `navmenu` すべて同じコンポーネントに解決
- `packages/lism-cli/src/commands/ui/list.ts`: 表示を kebab-case ベースに変更。PascalCase 複合語は `(NavMenu/)` で実ディレクトリ名を併記

### Docs / Skill
- `apps/docs/src/content/{ja,en}/installation.mdx`: 本文で「コンポーネント名は kebab-case で指定」と明示し、`nav-menu` / `shape-divider` の例を追加
- `skills/lism-css-guide/components-ui.md`: CLI 例を `Button Modal` → `button modal` に、`-a` → `--all` に統一

### 互換性
- 既存の PascalCase 表記 (`NavMenu`) や連結小文字 (`navmenu`) は引き続き有効。破壊的変更なし
- `-a` 短縮フラグは CLI としては残す（docs/skill では `--all` のみ記載）

## Test plan

- [x] `nr build:cli` 成功
- [x] `nr typecheck` 成功（lism-cli 関連エラーなし）
- [ ] 手動確認: `npx @lism-css/cli ui add nav-menu` が正しく NavMenu を追加する
- [ ] 手動確認: `npx @lism-css/cli ui add NavMenu` も従来通り動作する
- [ ] 手動確認: `npx @lism-css/cli ui list` の表示で `nav-menu (NavMenu/)` のように併記される