### PR TITLE
feat(cli): 表示言語の自動切替と --lang オプション追加

### DIFF
--- a/packages/create-lism/src/index.ts
+++ b/packages/create-lism/src/index.ts
@@ -1,4 +1,4 @@
-import { runCreate } from '@lism-css/cli';
+import { runCreate, setLang, t } from '@lism-css/cli';
 
 /**
  * `pnpm create lism` / `npm create lism@latest` から呼ばれる薄いラッパー。
@@ -9,6 +9,18 @@ async function main(): Promise<void> {
   let template: string | undefined;
   let targetDir: string | undefined;
   let force = false;
+  let showHelp = false;
+
+  // --help の description や printHelp 表示に言語選択を反映させるため、
+  // まず `--lang` を先に走査してから残りの引数を処理する。
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--lang' && args[i + 1]) {
+      setLang(args[i + 1]);
+    } else if (a.startsWith('--lang=')) {
+      setLang(a.slice('--lang='.length));
+    }
+  }
 
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
@@ -18,12 +30,20 @@ async function main(): Promise<void> {
       template = a.slice('--template='.length);
     } else if (a === '-f' || a === '--force') {
       force = true;
+    } else if (a === '--lang') {
+      i++; // 値を 1 つ飛ばす（上で既に setLang 済み）
+    } else if (a.startsWith('--lang=')) {
+      // 何もしない（上で既に setLang 済み）
     } else if (a === '-h' || a === '--help') {
-      printHelp();
-      return;
+      showHelp = true;
     } else if (!a.startsWith('-')) {
       targetDir ??= a;
     }
+  }
+
+  if (showHelp) {
+    printHelp();
+    return;
   }
 
   await runCreate({ template, targetDir, force });
@@ -35,9 +55,10 @@ function printHelp(): void {
       'Usage: create-lism [targetDir] [options]',
       '',
       'Options:',
-      '  -t, --template <name>   使用するテンプレート（例: astro-minimal）',
-      '  -f, --force             既存ディレクトリを強制上書き',
-      '  -h, --help              ヘルプを表示',
+      `  -t, --template <name>   ${t('cli.create.opt.template')}`,
+      `  -f, --force             ${t('cli.create.opt.force')}`,
+      `      --lang <code>       ${t('cli.opt.lang')}`,
+      `  -h, --help              ${t('create-lism.opt.help')}`,
       '',
     ].join('\n')
   );

--- a/packages/create-lism/src/index.ts
+++ b/packages/create-lism/src/index.ts
@@ -58,7 +58,7 @@ function printHelp(): void {
       `  -t, --template <name>   ${t('cli.create.opt.template')}`,
       `  -f, --force             ${t('cli.create.opt.force')}`,
       `      --lang <code>       ${t('cli.opt.lang')}`,
-      `  -h, --help              ${t('create-lism.opt.help')}`,
+      `  -h, --help              ${t('common.help')}`,
       '',
     ].join('\n')
   );

--- a/packages/lism-cli/src/commands/create.ts
+++ b/packages/lism-cli/src/commands/create.ts
@@ -5,15 +5,27 @@ import { select, input, confirm } from '@inquirer/prompts';
 import { logger } from '../logger.js';
 import { LISM_CSS_VERSION } from '../version.js';
 import { DEFAULT_TEMPLATES_REF, EXAMPLES_PATH, SOURCE_REPO } from '../constants.js';
+import { t, tOf } from '../i18n.js';
+
+interface LocalizedText {
+  ja: string;
+  en: string;
+}
 
 interface TemplateDef {
   name: string;
-  label: string;
-  description: string;
+  label: LocalizedText;
+  description: LocalizedText;
 }
 
 /** 配信対象の examples 一覧（将来は examples ディレクトリから自動生成に置き換え可能） */
-const TEMPLATES: TemplateDef[] = [{ name: 'astro-minimal', label: 'Astro (minimal)', description: 'Astro ベースの最小構成' }];
+const TEMPLATES: TemplateDef[] = [
+  {
+    name: 'astro-minimal',
+    label: { ja: 'Astro (最小構成)', en: 'Astro (minimal)' },
+    description: { ja: 'Astro ベースの最小構成', en: 'Minimal Astro setup' },
+  },
+];
 
 interface CreateOptions {
   template?: string;
@@ -33,17 +45,17 @@ export async function runCreate({ template, targetDir, force = false }: RunCreat
 
   if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0 && !force) {
     const ok = await confirm({
-      message: `${outDir} は既に存在し、空ではありません。上書きしますか？`,
+      message: t('create.confirmOverwrite', { dir: outDir }),
       default: false,
     });
     if (!ok) {
-      logger.warn('中断しました。');
+      logger.warn(t('create.aborted'));
       return;
     }
   }
 
   const ref = DEFAULT_TEMPLATES_REF;
-  logger.info(`テンプレート "${tpl.name}" を取得中（ref: ${ref}）...`);
+  logger.info(t('create.fetching', { name: tpl.name, ref }));
   await downloadTemplate(`github:${SOURCE_REPO}/${EXAMPLES_PATH}/${tpl.name}#${ref}`, {
     dir: outDir,
     force: true,
@@ -53,9 +65,9 @@ export async function runCreate({ template, targetDir, force = false }: RunCreat
   // workspace:* を公開バージョンに書き換える
   rewriteWorkspaceDeps(outDir);
 
-  logger.success(`${outDir} にプロジェクトを生成しました。`);
+  logger.success(t('create.created', { dir: outDir }));
   logger.log('');
-  logger.log('次のコマンドで開発を開始できます:');
+  logger.log(t('create.nextSteps'));
   const rel = path.relative(process.cwd(), outDir) || '.';
   logger.log(`  cd ${rel}`);
   logger.log('  npm install   # or pnpm install / yarn');
@@ -71,21 +83,21 @@ async function resolveTemplate(requested?: string): Promise<TemplateDef> {
   if (requested) {
     const found = TEMPLATES.find((t) => t.name === requested);
     if (!found) {
-      throw new Error(`テンプレート "${requested}" は見つかりません。利用可能: ${TEMPLATES.map((t) => t.name).join(', ')}`);
+      throw new Error(t('create.templateNotFound', { name: requested, list: TEMPLATES.map((x) => x.name).join(', ') }));
     }
     return found;
   }
   const picked = await select<string>({
-    message: 'テンプレートを選択してください:',
-    choices: TEMPLATES.map((t) => ({ name: `${t.label} — ${t.description}`, value: t.name })),
+    message: t('create.promptSelectTemplate'),
+    choices: TEMPLATES.map((tpl) => ({ name: `${tOf(tpl.label)} — ${tOf(tpl.description)}`, value: tpl.name })),
   });
-  return TEMPLATES.find((t) => t.name === picked)!;
+  return TEMPLATES.find((x) => x.name === picked)!;
 }
 
 async function resolveTargetDir(provided: string | undefined, templateName: string): Promise<string> {
   if (provided) return provided;
   return input({
-    message: '出力先ディレクトリ:',
+    message: t('create.promptTargetDir'),
     default: `./${templateName}`,
   });
 }
@@ -117,9 +129,9 @@ function rewriteWorkspaceDeps(projectDir: string): void {
     }
     if (touched) {
       fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
-      logger.log(`  package.json の workspace:* を ^${LISM_CSS_VERSION} に置換しました。`);
+      logger.log(t('create.workspaceReplaced', { version: LISM_CSS_VERSION }));
     }
   } catch (err) {
-    logger.warn(`package.json の書き換えに失敗しました: ${String(err)}`);
+    logger.warn(t('create.workspaceFailed', { reason: String(err) }));
   }
 }

--- a/packages/lism-cli/src/commands/skill/add.ts
+++ b/packages/lism-cli/src/commands/skill/add.ts
@@ -5,6 +5,7 @@ import { logger } from '../../logger.js';
 import { ALL_SKILL_TOOLS, SKILL_PATHS, TOOL_MARKERS, type SkillTool } from './paths.js';
 import { cleanupTempDir, compareSkillDirs, copyDirRecursive, fetchSkillSource, hasDiff } from './skillSource.js';
 import { DEFAULT_SKILL_REF } from '../../constants.js';
+import { t } from '../../i18n.js';
 
 export interface SkillAddOptions {
   all?: boolean;
@@ -40,32 +41,32 @@ export async function skillAddCommand(options: SkillAddOptions): Promise<void> {
   if (targets.length === 0) {
     const detected = autoDetectTools(cwd);
     if (detected.length > 0) {
-      logger.info(`検出した AI ツール: ${detected.join(', ')}`);
+      logger.info(t('skill.add.detected', { list: detected.join(', ') }));
     }
     targets = await checkbox<SkillTool>({
-      message: '配置先のツールを選択してください（スペースで選択、Enter で確定）:',
-      choices: ALL_SKILL_TOOLS.map((t) => ({
-        name: `${t}  →  ${SKILL_PATHS[t]}`,
-        value: t,
-        checked: detected.includes(t),
+      message: t('skill.add.promptTools'),
+      choices: ALL_SKILL_TOOLS.map((tool) => ({
+        name: `${tool}  →  ${SKILL_PATHS[tool]}`,
+        value: tool,
+        checked: detected.includes(tool),
       })),
     });
   }
 
   if (targets.length === 0) {
-    logger.warn('配置先が選択されませんでした。');
+    logger.warn(t('skill.add.noTargets'));
     return;
   }
 
   const ref = options.ref ?? DEFAULT_SKILL_REF;
-  logger.info(`スキルを取得中（ref: ${ref}）...`);
+  logger.info(t('skill.add.fetching', { ref }));
   const { dir: srcDir } = await fetchSkillSource(ref);
 
   try {
     for (const tool of targets) {
       await deploySkillTo(srcDir, tool, options);
     }
-    logger.success('完了しました。');
+    logger.success(t('common.done'));
   } finally {
     cleanupTempDir(srcDir);
   }
@@ -80,30 +81,30 @@ async function deploySkillTo(srcDir: string, tool: SkillTool, options: SkillAddO
     const label = `${tool} (${SKILL_PATHS[tool]})`;
 
     if (!hasDiff(diff)) {
-      logger.log(`  スキップ（差分なし）: ${label}`);
+      logger.log(t('skill.add.skippedSame', { label }));
       return;
     }
 
     logger.log('');
-    logger.log(`  ${label} に差分があります:`);
-    if (diff.modified.length > 0) logger.log(`    変更: ${diff.modified.length} ファイル`);
-    if (diff.added.length > 0) logger.log(`    追加: ${diff.added.length} ファイル`);
+    logger.log(t('skill.add.hasDiff', { label }));
+    if (diff.modified.length > 0) logger.log(t('skill.add.modifiedFiles', { count: diff.modified.length }));
+    if (diff.added.length > 0) logger.log(t('skill.add.addedFiles', { count: diff.added.length }));
     if (diff.localOnly.length > 0) {
-      logger.log(`    削除: ${diff.localOnly.length} ファイル（ローカルのみに存在、上書き時に削除されます）`);
+      logger.log(t('skill.add.localOnlyFiles', { count: diff.localOnly.length }));
       for (const rel of diff.localOnly) logger.log(`      - ${rel}`);
     }
 
     const go = await confirm({
-      message: `${SKILL_PATHS[tool]} を上書きしますか？`,
+      message: t('skill.add.confirmOverwrite', { path: SKILL_PATHS[tool] }),
       default: false,
     });
     if (!go) {
-      logger.log(`  スキップ: ${tool}`);
+      logger.log(t('skill.add.skippedTool', { tool }));
       return;
     }
   }
 
   if (existing) fs.rmSync(destDir, { recursive: true, force: true });
   copyDirRecursive(srcDir, destDir);
-  logger.log(`  配置: ${tool} → ${path.relative(process.cwd(), destDir)}`);
+  logger.log(t('skill.add.deployed', { tool, path: path.relative(process.cwd(), destDir) }));
 }

--- a/packages/lism-cli/src/commands/skill/check.ts
+++ b/packages/lism-cli/src/commands/skill/check.ts
@@ -4,6 +4,7 @@ import { logger } from '../../logger.js';
 import { ALL_SKILL_TOOLS, SKILL_PATHS } from './paths.js';
 import { cleanupTempDir, compareSkillDirs, fetchSkillSource, hasDiff, type SkillDiff } from './skillSource.js';
 import { DEFAULT_SKILL_REF } from '../../constants.js';
+import { t } from '../../i18n.js';
 
 export interface SkillCheckOptions {
   ref?: string;
@@ -15,12 +16,12 @@ export async function skillCheckCommand(options: SkillCheckOptions = {}): Promis
   const installed = ALL_SKILL_TOOLS.filter((tool) => fs.existsSync(path.join(cwd, SKILL_PATHS[tool], 'SKILL.md')));
 
   if (installed.length === 0) {
-    logger.info('インストール済みのスキルは見つかりませんでした。`lism skill add` で配置できます。');
+    logger.info(t('skill.check.noneInstalled'));
     return;
   }
 
   const ref = options.ref ?? DEFAULT_SKILL_REF;
-  logger.info(`リモートスキルを取得中（ref: ${ref}）...`);
+  logger.info(t('skill.check.fetching', { ref }));
   const { dir: remoteDir } = await fetchSkillSource(ref);
 
   try {
@@ -31,7 +32,7 @@ export async function skillCheckCommand(options: SkillCheckOptions = {}): Promis
       const label = `${tool.padEnd(9)} ${SKILL_PATHS[tool]}`;
 
       if (!hasDiff(diff)) {
-        logger.log(`  ✓ ${label}  (最新)`);
+        logger.log(t('skill.check.upToDate', { label }));
         continue;
       }
 
@@ -43,9 +44,9 @@ export async function skillCheckCommand(options: SkillCheckOptions = {}): Promis
 
     logger.log('');
     if (outdatedCount === 0) {
-      logger.success('すべてのスキルが最新です。');
+      logger.success(t('skill.check.allLatest'));
     } else {
-      logger.info(`${outdatedCount} 件のツールに差分があります。\`lism skill update\` で最新に更新できます。`);
+      logger.info(t('skill.check.outdated', { count: outdatedCount }));
     }
   } finally {
     cleanupTempDir(remoteDir);
@@ -54,9 +55,9 @@ export async function skillCheckCommand(options: SkillCheckOptions = {}): Promis
 
 function formatDiffSummary(diff: SkillDiff): string {
   const parts: string[] = [];
-  if (diff.modified.length > 0) parts.push(`変更 ${diff.modified.length}`);
-  if (diff.added.length > 0) parts.push(`追加 ${diff.added.length}`);
-  if (diff.localOnly.length > 0) parts.push(`削除 ${diff.localOnly.length}`);
+  if (diff.modified.length > 0) parts.push(t('skill.check.diffModified', { count: diff.modified.length }));
+  if (diff.added.length > 0) parts.push(t('skill.check.diffAdded', { count: diff.added.length }));
+  if (diff.localOnly.length > 0) parts.push(t('skill.check.diffDeleted', { count: diff.localOnly.length }));
   return `      ${parts.join(' / ')}`;
 }
 

--- a/packages/lism-cli/src/commands/skill/index.ts
+++ b/packages/lism-cli/src/commands/skill/index.ts
@@ -2,44 +2,45 @@ import { Command } from 'commander';
 import { skillAddCommand } from './add.js';
 import { skillCheckCommand } from './check.js';
 import { skillUpdateCommand } from './update.js';
+import { SKILL_PATHS } from './paths.js';
+import { t } from '../../i18n.js';
 
 /** `lism skill` サブコマンドツリー */
 export function createSkillCommand(): Command {
-  const skill = new Command('skill').description('AI エージェント向けスキル（SKILL.md）の配置と管理');
+  const skill = new Command('skill').description(t('cli.skill.description'));
+
+  const toolOptDescription = (tool: keyof typeof SKILL_PATHS): string => t('cli.skill.opt.toolPath', { path: SKILL_PATHS[tool] });
 
   const toolFlags = (cmd: Command) =>
     cmd
-      .option('--all', '全ツールに配置')
-      .option('--claude', '.claude/skills/ に配置')
-      .option('--codex', '.agents/skills/ に配置')
-      .option('--cursor', '.cursor/skills/ に配置')
-      .option('--windsurf', '.windsurf/skills/ に配置')
-      .option('--cline', '.cline/skills/ に配置')
-      .option('--copilot', '.github/skills/ に配置')
-      .option('--gemini', '.gemini/skills/ に配置')
-      .option('--junie', '.junie/skills/ に配置');
+      .option('--all', t('cli.skill.opt.all'))
+      .option('--claude', toolOptDescription('claude'))
+      .option('--codex', toolOptDescription('codex'))
+      .option('--cursor', toolOptDescription('cursor'))
+      .option('--windsurf', toolOptDescription('windsurf'))
+      .option('--cline', toolOptDescription('cline'))
+      .option('--copilot', toolOptDescription('copilot'))
+      .option('--gemini', toolOptDescription('gemini'))
+      .option('--junie', toolOptDescription('junie'));
 
   toolFlags(
     skill
       .command('add')
-      .description('スキルを配置する')
-      .option('-o, --overwrite', '確認なしで上書き', false)
-      .option('--ref <ref>', 'GitHub の取得元 ref（ブランチ／タグ／コミット）')
+      .description(t('cli.skill.add.description'))
+      .option('-o, --overwrite', t('cli.skill.add.opt.overwrite'), false)
+      .option('--ref <ref>', t('cli.skill.opt.ref'))
   ).action(skillAddCommand);
 
   skill
     .command('check')
-    .description('配置済みスキルとリモートの差分を確認する')
-    .option('--ref <ref>', 'GitHub の取得元 ref（ブランチ／タグ／コミット）')
-    .option('-v, --verbose', 'ファイル単位の差分を表示')
+    .description(t('cli.skill.check.description'))
+    .option('--ref <ref>', t('cli.skill.opt.ref'))
+    .option('-v, --verbose', t('cli.skill.check.opt.verbose'))
     .action(skillCheckCommand);
 
-  toolFlags(
-    skill
-      .command('update')
-      .description('配置済みスキルを最新版で上書きする（--overwrite 同等）')
-      .option('--ref <ref>', 'GitHub の取得元 ref（ブランチ／タグ／コミット）')
-  ).action(skillUpdateCommand);
+  toolFlags(skill.command('update').description(t('cli.skill.update.description')).option('--ref <ref>', t('cli.skill.opt.ref'))).action(
+    skillUpdateCommand
+  );
 
   return skill;
 }

--- a/packages/lism-cli/src/commands/ui/add.ts
+++ b/packages/lism-cli/src/commands/ui/add.ts
@@ -47,7 +47,7 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
   } catch (err) {
     const refInfo = options.ref ? ` (ref: ${options.ref})` : '';
     const reason = err instanceof Error ? err.message : String(err);
-    logger.error(t('ui.add.catalogFailed', { refInfo, reason }));
+    logger.error(t('ui.catalogFailed', { refInfo, reason }));
     process.exit(1);
   }
 

--- a/packages/lism-cli/src/commands/ui/add.ts
+++ b/packages/lism-cli/src/commands/ui/add.ts
@@ -16,6 +16,7 @@ import { runInit } from './init.js';
 import { logger } from '../../logger.js';
 import { normalizeComponentName } from './normalize.js';
 import type { LismCliConfig } from '../../config.js';
+import { t } from '../../i18n.js';
 
 interface AddOptions {
   overwrite: boolean;
@@ -32,7 +33,7 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
   if (configExists()) {
     config = await readConfig();
   } else {
-    logger.info('lism.config.js が見つかりません。セットアップを開始します...\n');
+    logger.info(t('ui.add.noConfig'));
     config = await runInit();
     console.log();
   }
@@ -46,17 +47,17 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
   } catch (err) {
     const refInfo = options.ref ? ` (ref: ${options.ref})` : '';
     const reason = err instanceof Error ? err.message : String(err);
-    logger.error(`カタログの取得に失敗しました${refInfo}: ${reason}`);
+    logger.error(t('ui.add.catalogFailed', { refInfo, reason }));
     process.exit(1);
   }
 
   if (options.all) {
     names = catalog.components.map((c) => c.name);
-    logger.info(`全 ${names.length} コンポーネントを追加します...`);
+    logger.info(t('ui.add.addingAll', { count: names.length }));
   }
 
   if (names.length === 0) {
-    logger.error('追加するコンポーネント名を指定してください。');
+    logger.error(t('ui.add.specifyName'));
     process.exit(1);
   }
 
@@ -71,7 +72,7 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
     else notFound.push(input);
   }
   if (notFound.length > 0) {
-    logger.error(`見つからないコンポーネント: ${notFound.join(', ')}`);
+    logger.error(t('ui.add.notFound', { list: notFound.join(', ') }));
     process.exit(1);
   }
 
@@ -94,7 +95,7 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
   for (let i = 0; i < resolvedNames.length; i++) {
     const result = results[i];
     if (result.status === 'rejected') {
-      logger.error(`"${resolvedNames[i]}" の取得に失敗しました: ${String(result.reason)}`);
+      logger.error(t('ui.add.componentFetchFailed', { name: resolvedNames[i], reason: String(result.reason) }));
       hasFailure = true;
       continue;
     }
@@ -103,20 +104,20 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
   }
 
   if (hasFailure) {
-    logger.error('一部のコンポーネント / helper の追加に失敗しました。');
+    logger.error(t('ui.add.someFailed'));
     process.exit(1);
   }
 
-  logger.success('完了しました。');
+  logger.success(t('common.done'));
 }
 
 async function askOverwritePolicy(): Promise<OverwritePolicy> {
   return select<OverwritePolicy>({
-    message: '既存ファイルの上書き方針を選択してください:',
+    message: t('ui.add.promptOverwritePolicy'),
     choices: [
-      { name: '全て上書き', value: 'all' },
-      { name: '全てスキップ', value: 'none' },
-      { name: 'コンポーネントごとに確認', value: 'per-component' },
+      { name: t('ui.add.policyAll'), value: 'all' },
+      { name: t('ui.add.policyNone'), value: 'none' },
+      { name: t('ui.add.policyPerComponent'), value: 'per-component' },
     ],
   });
 }
@@ -125,7 +126,7 @@ async function askOverwritePolicy(): Promise<OverwritePolicy> {
 function writeFile(filePath: string, content: string): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, content);
-  logger.log(`  作成: ${path.relative(process.cwd(), filePath)}`);
+  logger.log(t('ui.add.created', { path: path.relative(process.cwd(), filePath) }));
 }
 
 /** コンポーネントディレクトリ内に既存ファイルがあるか */
@@ -141,7 +142,7 @@ async function writeComponent(
   installedHelpers: Set<string>,
   fetchOpts: FetchOptions
 ): Promise<boolean> {
-  logger.info(`${component.name} を展開中...`);
+  logger.info(t('ui.add.deploying', { name: component.name }));
 
   const filesToWrite = [...component.files.shared, ...component.files[config.framework]];
 
@@ -163,7 +164,7 @@ async function writeComponent(
     shouldWrite = false;
   } else if (policy === 'per-component') {
     shouldWrite = await confirm({
-      message: `${componentDirName} は既に存在します。上書きしますか？`,
+      message: t('ui.add.confirmOverwriteComponent', { name: componentDirName }),
       default: false,
     });
   } else {
@@ -171,7 +172,7 @@ async function writeComponent(
   }
 
   if (!shouldWrite) {
-    logger.log(`  スキップ: ${componentDirName}`);
+    logger.log(t('ui.add.skippedComponent', { name: componentDirName }));
   } else {
     for (const file of filesToWrite) {
       const filePath = path.join(componentDir, file.path);
@@ -192,7 +193,7 @@ async function writeComponent(
     for (let i = 0; i < helpersToInstall.length; i++) {
       const result = helperResults[i];
       if (result.status === 'rejected') {
-        logger.error(`  helper "${helpersToInstall[i]}" の取得に失敗しました: ${String(result.reason)}`);
+        logger.error(t('ui.add.helperFetchFailed', { name: helpersToInstall[i], reason: String(result.reason) }));
         helperFailed = true;
         continue;
       }
@@ -202,16 +203,16 @@ async function writeComponent(
 
         if (fs.existsSync(filePath) && !overwriteAll) {
           if (policy === 'none') {
-            logger.log(`  スキップ: ${file.path}`);
+            logger.log(t('ui.add.skippedFile', { path: file.path }));
             continue;
           }
           if (policy === 'per-component') {
             const shouldOverwrite = await confirm({
-              message: `${path.relative(process.cwd(), filePath)} は既に存在します。上書きしますか？`,
+              message: t('ui.add.confirmOverwriteFile', { path: path.relative(process.cwd(), filePath) }),
               default: false,
             });
             if (!shouldOverwrite) {
-              logger.log(`  スキップ: ${file.path}`);
+              logger.log(t('ui.add.skippedFile', { path: file.path }));
               continue;
             }
           }

--- a/packages/lism-cli/src/commands/ui/index.ts
+++ b/packages/lism-cli/src/commands/ui/index.ts
@@ -2,31 +2,29 @@ import { Command, Option } from 'commander';
 import { addCommand } from './add.js';
 import { initCommand } from './init.js';
 import { listCommand } from './list.js';
+import { t } from '../../i18n.js';
 
 /** `lism ui` サブコマンドツリーを構築して返す */
 export function createUiCommand(): Command {
-  const ui = new Command('ui').description('Lism UI コンポーネントの追加・管理');
+  const ui = new Command('ui').description(t('cli.ui.description'));
 
   ui.command('init')
-    .description('lism.config.js の cli セクションを生成する')
-    .addOption(new Option('--framework <name>', 'フレームワーク').choices(['react', 'astro']))
-    .option('--components-dir <path>', 'コンポーネントの出力先ディレクトリ')
-    .option('--helper-dir <path>', 'helper の出力先ディレクトリ')
-    .option('-f, --force', '既存の cli セクションを上書き', false)
+    .description(t('cli.ui.init.description'))
+    .addOption(new Option('--framework <name>', t('cli.ui.init.opt.framework')).choices(['react', 'astro']))
+    .option('--components-dir <path>', t('cli.ui.init.opt.componentsDir'))
+    .option('--helper-dir <path>', t('cli.ui.init.opt.helperDir'))
+    .option('-f, --force', t('cli.ui.init.opt.force'), false)
     .action(initCommand);
 
   ui.command('add')
-    .description('コンポーネントを追加する')
-    .argument('[names...]', '追加するコンポーネント名')
-    .option('-o, --overwrite', '既存ファイルを確認なしで上書き', false)
-    .option('-a, --all', '全コンポーネントを追加', false)
-    .option('--ref <ref>', '取得元の Git ref（ブランチ / タグ / コミット）')
+    .description(t('cli.ui.add.description'))
+    .argument('[names...]', t('cli.ui.add.arg.names'))
+    .option('-o, --overwrite', t('cli.ui.add.opt.overwrite'), false)
+    .option('-a, --all', t('cli.ui.add.opt.all'), false)
+    .option('--ref <ref>', t('cli.ui.opt.ref'))
     .action(addCommand);
 
-  ui.command('list')
-    .description('利用可能なコンポーネント一覧を表示する')
-    .option('--ref <ref>', '取得元の Git ref（ブランチ / タグ / コミット）')
-    .action(listCommand);
+  ui.command('list').description(t('cli.ui.list.description')).option('--ref <ref>', t('cli.ui.opt.ref')).action(listCommand);
 
   return ui;
 }

--- a/packages/lism-cli/src/commands/ui/init.ts
+++ b/packages/lism-cli/src/commands/ui/init.ts
@@ -1,6 +1,7 @@
 import { select, input } from '@inquirer/prompts';
 import { findConfigFile, hasCliSection, patchConfigWithCli, writeFreshConfig } from '../../config.js';
 import { logger } from '../../logger.js';
+import { t } from '../../i18n.js';
 import type { LismCliConfig } from '../../config.js';
 
 export interface InitOptions {
@@ -23,7 +24,7 @@ export async function runInit(options: InitOptions = {}): Promise<LismCliConfig>
   const framework =
     options.framework ??
     (await select<LismCliConfig['framework']>({
-      message: 'フレームワークを選択してください:',
+      message: t('ui.init.promptFramework'),
       choices: [
         { name: 'React', value: 'react' },
         { name: 'Astro', value: 'astro' },
@@ -33,14 +34,14 @@ export async function runInit(options: InitOptions = {}): Promise<LismCliConfig>
   const componentsDir =
     options.componentsDir ??
     (await input({
-      message: 'コンポーネントの出力先ディレクトリ:',
+      message: t('ui.init.promptComponentsDir'),
       default: 'src/components/ui',
     }));
 
   const helperDir =
     options.helperDir ??
     (await input({
-      message: 'helper の出力先ディレクトリ:',
+      message: t('ui.init.promptHelperDir'),
       default: `${componentsDir}/_helper`,
     }));
 
@@ -54,14 +55,14 @@ export async function runInit(options: InitOptions = {}): Promise<LismCliConfig>
       existingCli: options.existingCli,
     });
     if (patched) {
-      logger.success(`${outPath} に cli セクションを${options.force ? '更新' : '追記'}しました。`);
+      logger.success(t(options.force ? 'ui.init.patchedUpdate' : 'ui.init.patchedAdd', { path: outPath }));
     } else {
-      logger.warn(`${outPath} に既に cli セクションが含まれているか、export default が検出できませんでした。手動で追記してください。`);
+      logger.warn(t('ui.init.notPatched', { path: outPath }));
     }
   } else {
     // found が null、または legacy-json（別途 initCommand で warning 済み）
     const outPath = writeFreshConfig(config);
-    logger.success(`${outPath} を作成しました。`);
+    logger.success(t('ui.init.created', { path: outPath }));
   }
 
   return config;
@@ -72,7 +73,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
   let existingCli = false;
   if (found?.kind === 'legacy-json') {
-    logger.warn(`${found.filename} を検出しました。lism.config.js へ移行します。古いファイルは後で削除してください。`);
+    logger.warn(t('ui.init.legacyDetected', { filename: found.filename }));
   } else if (found?.kind === 'module') {
     // ユーザーの lism.config.* に構文エラーがあると jiti が throw するため、
     // スタックトレース付きで uncaught にならないよう logger.error で握って終了する。
@@ -84,10 +85,10 @@ export async function initCommand(options: InitOptions): Promise<void> {
     }
     if (existingCli) {
       if (!options.force) {
-        logger.warn(`${found.filename} には既に cli セクションが設定されています。上書きするには --force を指定してください。`);
+        logger.warn(t('ui.init.alreadyExists', { filename: found.filename }));
         return;
       }
-      logger.warn(`${found.filename} の既存の cli セクションを上書きします。`);
+      logger.warn(t('ui.init.willOverwrite', { filename: found.filename }));
     }
   }
 

--- a/packages/lism-cli/src/commands/ui/list.ts
+++ b/packages/lism-cli/src/commands/ui/list.ts
@@ -16,7 +16,7 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
   } catch (err) {
     const refInfo = options.ref ? ` (ref: ${options.ref})` : '';
     const reason = err instanceof Error ? err.message : String(err);
-    logger.error(t('ui.add.catalogFailed', { refInfo, reason }));
+    logger.error(t('ui.catalogFailed', { refInfo, reason }));
     process.exit(1);
   }
 

--- a/packages/lism-cli/src/commands/ui/list.ts
+++ b/packages/lism-cli/src/commands/ui/list.ts
@@ -1,12 +1,13 @@
 import { fetchCatalog, type FetchOptions, type RegistryCatalog } from './fetcher.js';
 import { logger } from '../../logger.js';
+import { t } from '../../i18n.js';
 
 interface ListOptions {
   ref?: string;
 }
 
 export async function listCommand(options: ListOptions = {}): Promise<void> {
-  logger.info('コンポーネント一覧を取得中...');
+  logger.info(t('ui.list.fetching'));
 
   const fetchOpts: FetchOptions = { ref: options.ref };
   let catalog: RegistryCatalog;
@@ -15,17 +16,17 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
   } catch (err) {
     const refInfo = options.ref ? ` (ref: ${options.ref})` : '';
     const reason = err instanceof Error ? err.message : String(err);
-    logger.error(`カタログの取得に失敗しました${refInfo}: ${reason}`);
+    logger.error(t('ui.add.catalogFailed', { refInfo, reason }));
     process.exit(1);
   }
 
   logger.log(`\nLism UI v${catalog.version}\n`);
-  logger.log('コンポーネント:');
+  logger.log(t('ui.list.header'));
 
   for (const component of catalog.components) {
     const helpers = component.helpers.length > 0 ? ` (helpers: ${component.helpers.join(', ')})` : '';
     logger.log(`  - ${component.name}${helpers}`);
   }
 
-  logger.log(`\n合計: ${catalog.components.length} コンポーネント`);
+  logger.log(`\n${t('ui.list.total', { count: catalog.components.length })}`);
 }

--- a/packages/lism-cli/src/config.ts
+++ b/packages/lism-cli/src/config.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createJiti } from 'jiti';
 import { logger } from './logger.js';
+import { t } from './i18n.js';
 
 const LEGACY_CONFIG_FILE = 'lism-ui.json';
 const CONFIG_SEARCH = ['lism.config.js', 'lism.config.mjs'] as const;
@@ -54,11 +55,11 @@ export function getDefaultConfigPath(): string {
 export async function readConfig(): Promise<LismCliConfig> {
   const found = findConfigFile();
   if (!found) {
-    throw new Error('lism.config.js / lism.config.mjs / lism-ui.json のいずれも見つかりません。');
+    throw new Error(t('config.notFound'));
   }
 
   if (found.kind === 'legacy-json') {
-    logger.warn(`[deprecated] ${LEGACY_CONFIG_FILE} は廃止予定です。"lism ui init" で lism.config.js へ移行してください。`);
+    logger.warn(t('config.legacyWarning', { filename: LEGACY_CONFIG_FILE }));
     const raw = fs.readFileSync(found.path, 'utf-8');
     const parsed = JSON.parse(raw) as LismCliConfig;
     return parsed;
@@ -70,7 +71,7 @@ export async function readConfig(): Promise<LismCliConfig> {
   // `cli` サブキーがあればそれを優先、なければモジュール全体を CLI 設定として扱う（後方互換）
   const cli = (mod as LismConfigFile | undefined)?.cli ?? (mod as LismCliConfig | undefined);
   if (!cli || typeof cli !== 'object') {
-    throw new Error(`${found.filename} から CLI 設定（cli キー）を読み込めませんでした。`);
+    throw new Error(t('config.cliSectionMissing', { filename: found.filename }));
   }
   validateCliConfig(cli);
   return cli;
@@ -79,13 +80,13 @@ export async function readConfig(): Promise<LismCliConfig> {
 function validateCliConfig(cli: unknown): asserts cli is LismCliConfig {
   const c = cli as Partial<LismCliConfig>;
   if (c.framework !== 'react' && c.framework !== 'astro') {
-    throw new Error(`cli.framework は "react" または "astro" を指定してください。`);
+    throw new Error(t('config.invalidFramework'));
   }
   if (typeof c.componentsDir !== 'string' || !c.componentsDir) {
-    throw new Error('cli.componentsDir は文字列で指定してください。');
+    throw new Error(t('config.invalidComponentsDir'));
   }
   if (typeof c.helperDir !== 'string' || !c.helperDir) {
-    throw new Error('cli.helperDir は文字列で指定してください。');
+    throw new Error(t('config.invalidHelperDir'));
   }
 }
 
@@ -108,7 +109,7 @@ export async function hasCliSection(filePath: string): Promise<boolean> {
     const mod = await jiti.import(filePath);
     return !!(mod as LismConfigFile | undefined)?.cli;
   } catch (err) {
-    throw new Error(`${filePath} を読み込めませんでした（構文エラー等）。修正してから再実行してください: ${String(err)}`);
+    throw new Error(t('config.loadFailed', { path: filePath, reason: String(err) }));
   }
 }
 

--- a/packages/lism-cli/src/createProgram.ts
+++ b/packages/lism-cli/src/createProgram.ts
@@ -3,18 +3,27 @@ import { createUiCommand } from './commands/ui/index.js';
 import { createSkillCommand } from './commands/skill/index.js';
 import { createCommand } from './commands/create.js';
 import { CLI_VERSION } from './version.js';
+import { setLang, t } from './i18n.js';
 
 /** `lism` エントリの CLI プログラムを構築して返す（parse は呼ばない）。 */
 export function createLismProgram(): Command {
   const program = new Command();
-  program.name('lism').description('Lism CSS / UI 向け CLI').version(CLI_VERSION);
+  program.name('lism').description(t('cli.description')).version(CLI_VERSION).option('--lang <code>', t('cli.opt.lang'));
+
+  // `--lang` が指定されたら各コマンド実行直前に言語を切り替える。
+  // commander は --lang をルートプログラムで解釈するため、サブコマンドからも opts() で取れる。
+  program.hook('preAction', (thisCommand) => {
+    const opts: Record<string, unknown> = thisCommand.optsWithGlobals();
+    const lang = opts.lang;
+    if (typeof lang === 'string') setLang(lang);
+  });
 
   program
     .command('create')
-    .description('examples テンプレートから新規プロジェクトを生成する')
-    .argument('[targetDir]', '出力先ディレクトリ')
-    .option('-t, --template <name>', '使用するテンプレート名（例: astro-minimal）')
-    .option('-f, --force', '既存ディレクトリを強制上書き', false)
+    .description(t('cli.create.description'))
+    .argument('[targetDir]', t('cli.create.arg.targetDir'))
+    .option('-t, --template <name>', t('cli.create.opt.template'))
+    .option('-f, --force', t('cli.create.opt.force'), false)
     .action(createCommand);
 
   program.addCommand(createUiCommand());

--- a/packages/lism-cli/src/i18n.test.ts
+++ b/packages/lism-cli/src/i18n.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { detectLang, getLang, setLang, preScanLang, t, tOf } from './i18n';
+import type { MessageKey } from './messages';
+
+describe('detectLang', () => {
+  beforeEach(() => {
+    vi.stubEnv('LC_ALL', '');
+    vi.stubEnv('LANG', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('override が "ja" のときはそのまま返す', () => {
+    expect(detectLang('ja')).toBe('ja');
+  });
+
+  it('override が "en" のときはそのまま返す', () => {
+    expect(detectLang('en')).toBe('en');
+  });
+
+  it('無効な override は無視し、環境変数を見る', () => {
+    vi.stubEnv('LANG', 'ja_JP.UTF-8');
+    expect(detectLang('xx')).toBe('ja');
+  });
+
+  it('LC_ALL が ja* のときは ja', () => {
+    vi.stubEnv('LC_ALL', 'ja_JP.UTF-8');
+    expect(detectLang()).toBe('ja');
+  });
+
+  it('LANG が ja* のときは ja', () => {
+    vi.stubEnv('LANG', 'ja');
+    expect(detectLang()).toBe('ja');
+  });
+
+  it('LC_ALL / LANG が英語でも Intl が ja* ならフォールバックで ja', () => {
+    vi.stubEnv('LC_ALL', 'en_US.UTF-8');
+    const spy = vi
+      .spyOn(Intl, 'DateTimeFormat')
+      .mockImplementation(() => ({ resolvedOptions: () => ({ locale: 'ja-JP' }) }) as unknown as Intl.DateTimeFormat);
+    try {
+      expect(detectLang()).toBe('ja');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('どこからも ja が引けない場合は en', () => {
+    vi.stubEnv('LC_ALL', 'en_US.UTF-8');
+    const spy = vi
+      .spyOn(Intl, 'DateTimeFormat')
+      .mockImplementation(() => ({ resolvedOptions: () => ({ locale: 'en-US' }) }) as unknown as Intl.DateTimeFormat);
+    try {
+      expect(detectLang()).toBe('en');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('preScanLang', () => {
+  beforeEach(() => {
+    setLang('en');
+  });
+
+  it('--lang ja で ja に切り替わる', () => {
+    preScanLang(['node', 'lism', '--lang', 'ja']);
+    expect(getLang()).toBe('ja');
+  });
+
+  it('--lang=ja で ja に切り替わる', () => {
+    preScanLang(['--lang=ja']);
+    expect(getLang()).toBe('ja');
+  });
+
+  it('--lang のあとが別オプション（-- で始まる）の場合は無視', () => {
+    preScanLang(['--lang', '--force']);
+    expect(getLang()).toBe('en');
+  });
+
+  it('--lang のあとに値がない場合は無視', () => {
+    preScanLang(['--lang']);
+    expect(getLang()).toBe('en');
+  });
+
+  it('無効値（ja/en 以外）は setLang 側で無視される', () => {
+    preScanLang(['--lang', 'zh']);
+    expect(getLang()).toBe('en');
+  });
+
+  it('--lang 関連の引数がない場合は状態が保たれる', () => {
+    setLang('ja');
+    preScanLang(['create', 'my-app', '--template', 'astro-minimal']);
+    expect(getLang()).toBe('ja');
+  });
+});
+
+describe('t()', () => {
+  beforeEach(() => {
+    setLang('en');
+  });
+
+  it('現在の言語に応じたメッセージを返す', () => {
+    setLang('en');
+    expect(t('common.done')).toBe('Done.');
+    setLang('ja');
+    expect(t('common.done')).toBe('完了しました。');
+  });
+
+  it('{name} プレースホルダを vars で置換する', () => {
+    setLang('ja');
+    expect(t('create.created', { dir: '/tmp/foo' })).toBe('/tmp/foo にプロジェクトを生成しました。');
+  });
+
+  it('vars で渡されなかったプレースホルダは {name} のまま残す', () => {
+    setLang('ja');
+    expect(t('create.created')).toBe('{dir} にプロジェクトを生成しました。');
+  });
+
+  it('未知のキーはキー名をそのまま返す', () => {
+    expect(t('nonexistent.key' as MessageKey)).toBe('nonexistent.key');
+  });
+});
+
+describe('tOf()', () => {
+  it('現在の言語に応じた値を返す', () => {
+    setLang('ja');
+    expect(tOf({ ja: 'あ', en: 'A' })).toBe('あ');
+    setLang('en');
+    expect(tOf({ ja: 'あ', en: 'A' })).toBe('A');
+  });
+});

--- a/packages/lism-cli/src/i18n.ts
+++ b/packages/lism-cli/src/i18n.ts
@@ -48,7 +48,11 @@ export function preScanLang(argv: string[]): void {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--lang') {
-      setLang(argv[i + 1]);
+      const next = argv[i + 1];
+      // 次トークンが別オプション（例: --force）の場合は値とみなさない
+      if (next !== undefined && !next.startsWith('-')) {
+        setLang(next);
+      }
       return;
     }
     if (a.startsWith('--lang=')) {

--- a/packages/lism-cli/src/i18n.ts
+++ b/packages/lism-cli/src/i18n.ts
@@ -1,0 +1,84 @@
+/**
+ * CLI の i18n（多言語化）基盤。
+ *
+ * - 既定は英語（`en`）。環境ロケールが `ja*` のときのみ日本語（`ja`）に切り替わる。
+ * - `--lang <code>` オプションで明示上書き可能。
+ * - メッセージ辞書は `messages.ts` に集約。
+ */
+import { messages, type MessageKey } from './messages.js';
+
+export type Lang = 'ja' | 'en';
+
+/**
+ * 環境変数 / Intl から現在のロケールを検出する。
+ * `override` に `ja` / `en` が渡された場合はそれを優先。
+ */
+export function detectLang(override?: string): Lang {
+  if (override === 'ja' || override === 'en') return override;
+  const raw = (process.env.LC_ALL || process.env.LANG || '').toLowerCase();
+  if (raw.startsWith('ja')) return 'ja';
+  try {
+    const locale = Intl.DateTimeFormat().resolvedOptions().locale.toLowerCase();
+    if (locale.startsWith('ja')) return 'ja';
+  } catch {
+    // Intl が使えない環境ではフォールバック（en）に倒す
+  }
+  return 'en';
+}
+
+let currentLang: Lang = detectLang();
+
+/** 現在の言語を取得する */
+export function getLang(): Lang {
+  return currentLang;
+}
+
+/** 現在の言語を設定する（未知の値は無視） */
+export function setLang(lang: string | undefined): void {
+  if (lang === 'ja' || lang === 'en') {
+    currentLang = lang;
+  }
+}
+
+/**
+ * commander の parse より前に、argv から `--lang` / `--lang=` / `-L` を抽出して言語を設定する。
+ * `--help` の description 表示や各コマンド description のキャプチャに間に合わせるのが目的。
+ */
+export function preScanLang(argv: string[]): void {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--lang') {
+      setLang(argv[i + 1]);
+      return;
+    }
+    if (a.startsWith('--lang=')) {
+      setLang(a.slice('--lang='.length));
+      return;
+    }
+  }
+}
+
+/**
+ * メッセージキーから現在の言語の文字列を取得し、必要に応じて `{name}` プレースホルダーを置換する。
+ */
+export function t(key: MessageKey, vars?: Record<string, string | number>): string {
+  const entry = messages[key];
+  if (!entry) return key;
+  const template = entry[currentLang] ?? entry.en;
+  return vars ? interpolate(template, vars) : template;
+}
+
+/**
+ * ロケール非依存の 2 言語オブジェクトから現在の言語の値を返す。
+ * TEMPLATES の label/description や、辞書化しにくい一時的な二択文字列で使う。
+ */
+export function tOf<T>(pair: { ja: T; en: T }): T {
+  return pair[currentLang];
+}
+
+function interpolate(template: string, vars: Record<string, string | number>): string {
+  return template.replace(/\{(\w+)\}/g, (_, name: string) => {
+    const v = vars[name];
+    return v === undefined ? `{${name}}` : String(v);
+  });
+}

--- a/packages/lism-cli/src/index.ts
+++ b/packages/lism-cli/src/index.ts
@@ -1,4 +1,8 @@
 import { createLismProgram } from './createProgram.js';
+import { preScanLang } from './i18n.js';
 
+// --help 出力や description の評価は parse 前に確定するため、
+// argv から --lang を先に抽出して言語を設定してから CLI を構築する。
+preScanLang(process.argv.slice(2));
 const program = createLismProgram();
 program.parse();

--- a/packages/lism-cli/src/lib.ts
+++ b/packages/lism-cli/src/lib.ts
@@ -4,5 +4,5 @@
  */
 export { runCreate } from './commands/create.js';
 export type { RunCreateArgs } from './commands/create.js';
-export { setLang, t } from './i18n.js';
+export { setLang, t, tOf } from './i18n.js';
 export type { Lang } from './i18n.js';

--- a/packages/lism-cli/src/lib.ts
+++ b/packages/lism-cli/src/lib.ts
@@ -4,3 +4,5 @@
  */
 export { runCreate } from './commands/create.js';
 export type { RunCreateArgs } from './commands/create.js';
+export { setLang, t } from './i18n.js';
+export type { Lang } from './i18n.js';

--- a/packages/lism-cli/src/messages.ts
+++ b/packages/lism-cli/src/messages.ts
@@ -1,0 +1,448 @@
+/**
+ * CLI 表示用のメッセージ辞書（ja / en）。
+ *
+ * 命名規則:
+ *   - `cli.*`    … commander の description / argument / option
+ *   - `create.*` … `lism create` サブコマンド
+ *   - `ui.*`     … `lism ui` 配下
+ *   - `skill.*`  … `lism skill` 配下
+ *   - `config.*` … lism.config.* まわりのエラー・警告
+ *   - `common.*` … 汎用
+ *
+ * プレースホルダは `{name}` 形式（`t()` の `vars` で置換）。
+ */
+
+interface MessageEntry {
+  ja: string;
+  en: string;
+}
+
+export const messages = {
+  // ---------------------------------------------------------------------------
+  // Commander description / arguments / options
+  // ---------------------------------------------------------------------------
+  'cli.description': {
+    ja: 'Lism CSS / UI 向け CLI',
+    en: 'CLI for Lism CSS / UI',
+  },
+  'cli.opt.lang': {
+    ja: 'CLI の表示言語を指定（ja | en）',
+    en: 'Display language for the CLI (ja | en)',
+  },
+  'create-lism.opt.help': {
+    ja: 'ヘルプを表示',
+    en: 'Show help',
+  },
+
+  // create
+  'cli.create.description': {
+    ja: 'examples テンプレートから新規プロジェクトを生成する',
+    en: 'Create a new project from an examples template',
+  },
+  'cli.create.arg.targetDir': {
+    ja: '出力先ディレクトリ',
+    en: 'Target directory',
+  },
+  'cli.create.opt.template': {
+    ja: '使用するテンプレート名（例: astro-minimal）',
+    en: 'Template name to use (e.g. astro-minimal)',
+  },
+  'cli.create.opt.force': {
+    ja: '既存ディレクトリを強制上書き',
+    en: 'Overwrite existing directory',
+  },
+
+  // ui
+  'cli.ui.description': {
+    ja: 'Lism UI コンポーネントの追加・管理',
+    en: 'Manage Lism UI components',
+  },
+  'cli.ui.init.description': {
+    ja: 'lism.config.js の cli セクションを生成する',
+    en: 'Generate the cli section of lism.config.js',
+  },
+  'cli.ui.init.opt.framework': {
+    ja: 'フレームワーク',
+    en: 'Framework',
+  },
+  'cli.ui.init.opt.componentsDir': {
+    ja: 'コンポーネントの出力先ディレクトリ',
+    en: 'Output directory for components',
+  },
+  'cli.ui.init.opt.helperDir': {
+    ja: 'helper の出力先ディレクトリ',
+    en: 'Output directory for helpers',
+  },
+  'cli.ui.init.opt.force': {
+    ja: '既存の cli セクションを上書き',
+    en: 'Overwrite the existing cli section',
+  },
+  'cli.ui.add.description': {
+    ja: 'コンポーネントを追加する',
+    en: 'Add components',
+  },
+  'cli.ui.add.arg.names': {
+    ja: '追加するコンポーネント名',
+    en: 'Component names to add',
+  },
+  'cli.ui.add.opt.overwrite': {
+    ja: '既存ファイルを確認なしで上書き',
+    en: 'Overwrite existing files without confirmation',
+  },
+  'cli.ui.add.opt.all': {
+    ja: '全コンポーネントを追加',
+    en: 'Add all components',
+  },
+  'cli.ui.list.description': {
+    ja: '利用可能なコンポーネント一覧を表示する',
+    en: 'List available components',
+  },
+  'cli.ui.opt.ref': {
+    ja: '取得元の Git ref（ブランチ / タグ / コミット）',
+    en: 'Git ref to fetch from (branch / tag / commit)',
+  },
+
+  // skill
+  'cli.skill.description': {
+    ja: 'AI エージェント向けスキル（SKILL.md）の配置と管理',
+    en: 'Manage SKILL.md files for AI agents',
+  },
+  'cli.skill.add.description': {
+    ja: 'スキルを配置する',
+    en: 'Deploy skills',
+  },
+  'cli.skill.add.opt.overwrite': {
+    ja: '確認なしで上書き',
+    en: 'Overwrite without confirmation',
+  },
+  'cli.skill.check.description': {
+    ja: '配置済みスキルとリモートの差分を確認する',
+    en: 'Show the diff between installed skills and the remote',
+  },
+  'cli.skill.check.opt.verbose': {
+    ja: 'ファイル単位の差分を表示',
+    en: 'Show per-file diffs',
+  },
+  'cli.skill.update.description': {
+    ja: '配置済みスキルを最新版で上書きする（--overwrite 同等）',
+    en: 'Overwrite installed skills with the latest version (same as --overwrite)',
+  },
+  'cli.skill.opt.ref': {
+    ja: 'GitHub の取得元 ref（ブランチ／タグ／コミット）',
+    en: 'Git ref to fetch from on GitHub (branch / tag / commit)',
+  },
+  'cli.skill.opt.all': {
+    ja: '全ツールに配置',
+    en: 'Deploy to all tools',
+  },
+  'cli.skill.opt.toolPath': {
+    ja: '{path} に配置',
+    en: 'Deploy to {path}',
+  },
+
+  // ---------------------------------------------------------------------------
+  // create
+  // ---------------------------------------------------------------------------
+  'create.templateNotFound': {
+    ja: 'テンプレート "{name}" は見つかりません。利用可能: {list}',
+    en: 'Template "{name}" not found. Available: {list}',
+  },
+  'create.promptSelectTemplate': {
+    ja: 'テンプレートを選択してください:',
+    en: 'Select a template:',
+  },
+  'create.promptTargetDir': {
+    ja: '出力先ディレクトリ:',
+    en: 'Target directory:',
+  },
+  'create.confirmOverwrite': {
+    ja: '{dir} は既に存在し、空ではありません。上書きしますか？',
+    en: '{dir} already exists and is not empty. Overwrite?',
+  },
+  'create.aborted': {
+    ja: '中断しました。',
+    en: 'Aborted.',
+  },
+  'create.fetching': {
+    ja: 'テンプレート "{name}" を取得中（ref: {ref}）...',
+    en: 'Fetching template "{name}" (ref: {ref})...',
+  },
+  'create.created': {
+    ja: '{dir} にプロジェクトを生成しました。',
+    en: 'Generated project at {dir}.',
+  },
+  'create.nextSteps': {
+    ja: '次のコマンドで開発を開始できます:',
+    en: 'Next steps:',
+  },
+  'create.workspaceReplaced': {
+    ja: '  package.json の workspace:* を ^{version} に置換しました。',
+    en: '  Replaced workspace:* in package.json with ^{version}.',
+  },
+  'create.workspaceFailed': {
+    ja: 'package.json の書き換えに失敗しました: {reason}',
+    en: 'Failed to rewrite package.json: {reason}',
+  },
+
+  // ---------------------------------------------------------------------------
+  // ui
+  // ---------------------------------------------------------------------------
+  // ui add
+  'ui.add.noConfig': {
+    ja: 'lism.config.js が見つかりません。セットアップを開始します...\n',
+    en: 'lism.config.js not found. Starting setup...\n',
+  },
+  'ui.add.catalogFailed': {
+    ja: 'カタログの取得に失敗しました{refInfo}: {reason}',
+    en: 'Failed to fetch catalog{refInfo}: {reason}',
+  },
+  'ui.add.addingAll': {
+    ja: '全 {count} コンポーネントを追加します...',
+    en: 'Adding all {count} components...',
+  },
+  'ui.add.specifyName': {
+    ja: '追加するコンポーネント名を指定してください。',
+    en: 'Specify component names to add.',
+  },
+  'ui.add.notFound': {
+    ja: '見つからないコンポーネント: {list}',
+    en: 'Components not found: {list}',
+  },
+  'ui.add.componentFetchFailed': {
+    ja: '"{name}" の取得に失敗しました: {reason}',
+    en: 'Failed to fetch "{name}": {reason}',
+  },
+  'ui.add.someFailed': {
+    ja: '一部のコンポーネント / helper の追加に失敗しました。',
+    en: 'Some components / helpers failed to be added.',
+  },
+  'ui.add.promptOverwritePolicy': {
+    ja: '既存ファイルの上書き方針を選択してください:',
+    en: 'Select overwrite policy for existing files:',
+  },
+  'ui.add.policyAll': {
+    ja: '全て上書き',
+    en: 'Overwrite all',
+  },
+  'ui.add.policyNone': {
+    ja: '全てスキップ',
+    en: 'Skip all',
+  },
+  'ui.add.policyPerComponent': {
+    ja: 'コンポーネントごとに確認',
+    en: 'Ask per component',
+  },
+  'ui.add.created': {
+    ja: '  作成: {path}',
+    en: '  Created: {path}',
+  },
+  'ui.add.deploying': {
+    ja: '{name} を展開中...',
+    en: 'Deploying {name}...',
+  },
+  'ui.add.confirmOverwriteComponent': {
+    ja: '{name} は既に存在します。上書きしますか？',
+    en: '{name} already exists. Overwrite?',
+  },
+  'ui.add.skippedComponent': {
+    ja: '  スキップ: {name}',
+    en: '  Skipped: {name}',
+  },
+  'ui.add.helperFetchFailed': {
+    ja: '  helper "{name}" の取得に失敗しました: {reason}',
+    en: '  Failed to fetch helper "{name}": {reason}',
+  },
+  'ui.add.confirmOverwriteFile': {
+    ja: '{path} は既に存在します。上書きしますか？',
+    en: '{path} already exists. Overwrite?',
+  },
+  'ui.add.skippedFile': {
+    ja: '  スキップ: {path}',
+    en: '  Skipped: {path}',
+  },
+
+  // ui init
+  'ui.init.promptFramework': {
+    ja: 'フレームワークを選択してください:',
+    en: 'Select a framework:',
+  },
+  'ui.init.promptComponentsDir': {
+    ja: 'コンポーネントの出力先ディレクトリ:',
+    en: 'Output directory for components:',
+  },
+  'ui.init.promptHelperDir': {
+    ja: 'helper の出力先ディレクトリ:',
+    en: 'Output directory for helpers:',
+  },
+  'ui.init.patchedUpdate': {
+    ja: '{path} に cli セクションを更新しました。',
+    en: 'Updated the cli section in {path}.',
+  },
+  'ui.init.patchedAdd': {
+    ja: '{path} に cli セクションを追記しました。',
+    en: 'Added the cli section to {path}.',
+  },
+  'ui.init.notPatched': {
+    ja: '{path} に既に cli セクションが含まれているか、export default が検出できませんでした。手動で追記してください。',
+    en: 'Either {path} already contains a cli section or no export default was detected. Please add it manually.',
+  },
+  'ui.init.created': {
+    ja: '{path} を作成しました。',
+    en: 'Created {path}.',
+  },
+  'ui.init.legacyDetected': {
+    ja: '{filename} を検出しました。lism.config.js へ移行します。古いファイルは後で削除してください。',
+    en: 'Detected {filename}. Migrating to lism.config.js. Please remove the old file afterwards.',
+  },
+  'ui.init.alreadyExists': {
+    ja: '{filename} には既に cli セクションが設定されています。上書きするには --force を指定してください。',
+    en: '{filename} already has a cli section. Use --force to overwrite.',
+  },
+  'ui.init.willOverwrite': {
+    ja: '{filename} の既存の cli セクションを上書きします。',
+    en: 'Overwriting the existing cli section in {filename}.',
+  },
+
+  // ui list
+  'ui.list.fetching': {
+    ja: 'コンポーネント一覧を取得中...',
+    en: 'Fetching components list...',
+  },
+  'ui.list.header': {
+    ja: 'コンポーネント:',
+    en: 'Components:',
+  },
+  'ui.list.total': {
+    ja: '合計: {count} コンポーネント',
+    en: 'Total: {count} components',
+  },
+
+  // ---------------------------------------------------------------------------
+  // skill
+  // ---------------------------------------------------------------------------
+  // skill add
+  'skill.add.detected': {
+    ja: '検出した AI ツール: {list}',
+    en: 'Detected AI tools: {list}',
+  },
+  'skill.add.promptTools': {
+    ja: '配置先のツールを選択してください（スペースで選択、Enter で確定）:',
+    en: 'Select target tools (Space to select, Enter to confirm):',
+  },
+  'skill.add.noTargets': {
+    ja: '配置先が選択されませんでした。',
+    en: 'No target tools were selected.',
+  },
+  'skill.add.fetching': {
+    ja: 'スキルを取得中（ref: {ref}）...',
+    en: 'Fetching skills (ref: {ref})...',
+  },
+  'skill.add.skippedSame': {
+    ja: '  スキップ（差分なし）: {label}',
+    en: '  Skipped (no changes): {label}',
+  },
+  'skill.add.hasDiff': {
+    ja: '  {label} に差分があります:',
+    en: '  {label} has changes:',
+  },
+  'skill.add.modifiedFiles': {
+    ja: '    変更: {count} ファイル',
+    en: '    Modified: {count} files',
+  },
+  'skill.add.addedFiles': {
+    ja: '    追加: {count} ファイル',
+    en: '    Added: {count} files',
+  },
+  'skill.add.localOnlyFiles': {
+    ja: '    削除: {count} ファイル（ローカルのみに存在、上書き時に削除されます）',
+    en: '    Deleted: {count} files (local-only, will be removed on overwrite)',
+  },
+  'skill.add.confirmOverwrite': {
+    ja: '{path} を上書きしますか？',
+    en: 'Overwrite {path}?',
+  },
+  'skill.add.skippedTool': {
+    ja: '  スキップ: {tool}',
+    en: '  Skipped: {tool}',
+  },
+  'skill.add.deployed': {
+    ja: '  配置: {tool} → {path}',
+    en: '  Deployed: {tool} → {path}',
+  },
+
+  // skill check
+  'skill.check.noneInstalled': {
+    ja: 'インストール済みのスキルは見つかりませんでした。`lism skill add` で配置できます。',
+    en: 'No installed skills found. Run `lism skill add` to deploy them.',
+  },
+  'skill.check.fetching': {
+    ja: 'リモートスキルを取得中（ref: {ref}）...',
+    en: 'Fetching remote skills (ref: {ref})...',
+  },
+  'skill.check.upToDate': {
+    ja: '  ✓ {label}  (最新)',
+    en: '  ✓ {label}  (up to date)',
+  },
+  'skill.check.allLatest': {
+    ja: 'すべてのスキルが最新です。',
+    en: 'All skills are up to date.',
+  },
+  'skill.check.outdated': {
+    ja: '{count} 件のツールに差分があります。`lism skill update` で最新に更新できます。',
+    en: '{count} tools have changes. Run `lism skill update` to update them.',
+  },
+  'skill.check.diffModified': {
+    ja: '変更 {count}',
+    en: 'modified {count}',
+  },
+  'skill.check.diffAdded': {
+    ja: '追加 {count}',
+    en: 'added {count}',
+  },
+  'skill.check.diffDeleted': {
+    ja: '削除 {count}',
+    en: 'deleted {count}',
+  },
+
+  // ---------------------------------------------------------------------------
+  // config
+  // ---------------------------------------------------------------------------
+  'config.legacyWarning': {
+    ja: '[deprecated] {filename} は廃止予定です。"lism ui init" で lism.config.js へ移行してください。',
+    en: '[deprecated] {filename} is deprecated. Run "lism ui init" to migrate to lism.config.js.',
+  },
+  'config.notFound': {
+    ja: 'lism.config.js / lism.config.mjs / lism-ui.json のいずれも見つかりません。',
+    en: 'None of lism.config.js / lism.config.mjs / lism-ui.json were found.',
+  },
+  'config.cliSectionMissing': {
+    ja: '{filename} から CLI 設定（cli キー）を読み込めませんでした。',
+    en: 'Failed to read the CLI config (cli key) from {filename}.',
+  },
+  'config.invalidFramework': {
+    ja: 'cli.framework は "react" または "astro" を指定してください。',
+    en: 'cli.framework must be "react" or "astro".',
+  },
+  'config.invalidComponentsDir': {
+    ja: 'cli.componentsDir は文字列で指定してください。',
+    en: 'cli.componentsDir must be a string.',
+  },
+  'config.invalidHelperDir': {
+    ja: 'cli.helperDir は文字列で指定してください。',
+    en: 'cli.helperDir must be a string.',
+  },
+  'config.loadFailed': {
+    ja: '{path} を読み込めませんでした（構文エラー等）。修正してから再実行してください: {reason}',
+    en: 'Failed to load {path} (syntax error, etc). Please fix it and retry: {reason}',
+  },
+
+  // ---------------------------------------------------------------------------
+  // common
+  // ---------------------------------------------------------------------------
+  'common.done': {
+    ja: '完了しました。',
+    en: 'Done.',
+  },
+} as const satisfies Record<string, MessageEntry>;
+
+export type MessageKey = keyof typeof messages;

--- a/packages/lism-cli/src/messages.ts
+++ b/packages/lism-cli/src/messages.ts
@@ -29,10 +29,6 @@ export const messages = {
     ja: 'CLI の表示言語を指定（ja | en）',
     en: 'Display language for the CLI (ja | en)',
   },
-  'create-lism.opt.help': {
-    ja: 'ヘルプを表示',
-    en: 'Show help',
-  },
 
   // create
   'cli.create.description': {
@@ -187,14 +183,16 @@ export const messages = {
   // ---------------------------------------------------------------------------
   // ui
   // ---------------------------------------------------------------------------
+  // ui 共通（add / list で共有）
+  'ui.catalogFailed': {
+    ja: 'カタログの取得に失敗しました{refInfo}: {reason}',
+    en: 'Failed to fetch catalog{refInfo}: {reason}',
+  },
+
   // ui add
   'ui.add.noConfig': {
     ja: 'lism.config.js が見つかりません。セットアップを開始します...\n',
     en: 'lism.config.js not found. Starting setup...\n',
-  },
-  'ui.add.catalogFailed': {
-    ja: 'カタログの取得に失敗しました{refInfo}: {reason}',
-    en: 'Failed to fetch catalog{refInfo}: {reason}',
   },
   'ui.add.addingAll': {
     ja: '全 {count} コンポーネントを追加します...',
@@ -442,6 +440,10 @@ export const messages = {
   'common.done': {
     ja: '完了しました。',
     en: 'Done.',
+  },
+  'common.help': {
+    ja: 'ヘルプを表示',
+    en: 'Show help',
   },
 } as const satisfies Record<string, MessageEntry>;
 


### PR DESCRIPTION
## Summary
- CLI 表示言語の自動検出（LC_ALL / LANG / Intl から判定、既定は `en`、`ja*` のみ `ja`）と `--lang <ja|en>` オプション上書きを追加
- commander description・argument・option、inquirer プロンプト、logger 出力、`throw new Error` の文言をすべて `src/messages.ts` に集約し `t(key, vars)` 経由で取得
- `@lism-css/cli` 公開 API に `setLang` / `t` / `Lang` を追加し、`create-lism` ラッパー側でも `--lang` を forward
- `lism create` の TEMPLATES の label/description も ja/en の両対応に

## Test plan
- [x] `nr build:cli` が成功
- [x] `pnpm --filter @lism-css/cli test` が成功
- [x] `eslint packages/lism-cli/src packages/create-lism/src` がエラーなし
- [x] `LANG=ja_JP.UTF-8 lism --help` / `LANG=en_US.UTF-8 lism --help` で日本語 / 英語が切り替わる
- [x] `--lang en` / `--lang ja` による明示上書きが動作
- [x] サブコマンド（`ui`, `skill`, `create`）の `--help` も同様に切り替わる
- [x] `create-lism --help` も同様に切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)