### PR TITLE
test: LismPropsData / getMaybeTokenValue のテスト整理

### DIFF
--- a/packages/lism-css/src/lib/LismPropsData.test.ts
+++ b/packages/lism-css/src/lib/LismPropsData.test.ts
@@ -1,6 +1,11 @@
 import { describe, test, expect } from 'vitest';
 import { LismPropsData } from './getLismProps';
 
+// LismPropsData は getLismProps の内部クラス。
+// prop 解析の振る舞いテスト（hov / ブレイクポイント / trait / プリセット・カスタム値分岐 等）は
+// 公開 API である getLismProps.test.ts 側に集約しているため、このファイルでは
+// 「内部バケットの分離」「buildClassName の出力順」「メソッド単位の動作」「attrs/styles の基本」
+// の 4 観点のみを扱う。
 describe('LismPropsData', () => {
   describe('基本動作', () => {
     test('空のpropsでインスタンスが作成される', () => {
@@ -15,16 +20,6 @@ describe('LismPropsData', () => {
       expect(instance.attrs).toEqual({});
     });
 
-    test('classNameが設定される', () => {
-      const instance = new LismPropsData({ className: 'test-class' });
-      expect(instance.className).toContain('test-class');
-    });
-
-    test('Astroのclass属性が処理される', () => {
-      const instance = new LismPropsData({ class: 'astro-class' });
-      expect(instance.className).toContain('astro-class');
-    });
-
     test('className と class が両方指定された場合、両方マージされ重複は除去される', () => {
       const instance = new LismPropsData({
         className: 'c--foo',
@@ -32,357 +27,100 @@ describe('LismPropsData', () => {
       });
       expect(instance.className).toContain('c--foo');
       expect(instance.className).toContain('user-class');
-      // 重複除去されて c--foo は 1 回だけ
       expect(instance.className.match(/c--foo/g)?.length).toBe(1);
     });
   });
 
-  describe('ref処理', () => {
-    test('forwardedRefがattrsに設定される', () => {
-      const mockRef = { current: null };
-      const instance = new LismPropsData({ forwardedRef: mockRef });
-      expect(instance.attrs.ref).toBe(mockRef);
+  describe('バケット分離', () => {
+    test('primitiveClass 入力はそのまま primitiveClass バケットに保持される', () => {
+      const instance = new LismPropsData({ primitiveClass: ['a--divider', 'l--flex'] });
+      expect(instance.primitiveClass).toEqual(['a--divider', 'l--flex']);
     });
-  });
 
-  describe('style処理', () => {
-    test('styleが正しく設定される', () => {
+    test('set は setClasses バケットに入る', () => {
+      const instance = new LismPropsData({ set: 'var:hov' });
+      expect(instance.setClasses).toContain('set--var:hov');
+      expect(instance.propClasses).not.toContain('set--var:hov');
+      expect(instance.uClasses).not.toContain('set--var:hov');
+    });
+
+    test('trait prop (isContainer) は traitClasses バケットに入る', () => {
+      const instance = new LismPropsData({ isContainer: true });
+      expect(instance.traitClasses).toContain('is--container');
+      expect(instance.uClasses).not.toContain('is--container');
+      expect(instance.propClasses).not.toContain('is--container');
+    });
+
+    test('util は uClasses バケットに入る', () => {
+      const instance = new LismPropsData({ util: 'cbox' });
+      expect(instance.uClasses).toContain('u--cbox');
+      expect(instance.propClasses).not.toContain('u--cbox');
+      expect(instance.setClasses).not.toContain('u--cbox');
+    });
+
+    test('Lism prop (p) は propClasses バケットに入る', () => {
+      const instance = new LismPropsData({ p: '20' });
+      expect(instance.propClasses).toContain('-p:20');
+      expect(instance.uClasses).not.toContain('-p:20');
+    });
+
+    test('hov は propClasses バケットに入る', () => {
+      const instance = new LismPropsData({ hov: true });
+      expect(instance.propClasses).toContain('-hov');
+    });
+
+    test('css は styles に流れ、どのクラスバケットにも入らない', () => {
+      const instance = new LismPropsData({
+        css: { margin: '10px', padding: '20px' },
+      });
+      expect(instance.styles.margin).toBe('10px');
+      expect(instance.styles.padding).toBe('20px');
+      expect(instance.primitiveClass).toEqual([]);
+      expect(instance.setClasses).toEqual([]);
+      expect(instance.traitClasses).toEqual([]);
+      expect(instance.uClasses).toEqual([]);
+      expect(instance.propClasses).toEqual([]);
+    });
+
+    test('style は styles バケットに保持される', () => {
       const instance = new LismPropsData({
         style: { color: 'red', fontSize: '16px' },
       });
       expect(instance.styles).toEqual({ color: 'red', fontSize: '16px' });
     });
 
-    test('空のstyleも保持される', () => {
-      const instance = new LismPropsData({ style: {} });
-      expect(instance.styles).toEqual({});
-    });
-  });
-
-  describe('analyzeProps - Lism Props処理', () => {
-    test('fz: トークン値が property class になる', () => {
-      const instance = new LismPropsData({ fz: 'xl' });
-      expect(instance.propClasses).toContain('-fz:xl');
-    });
-
-    test('fz: カスタム値は変数として出力される', () => {
-      const instance = new LismPropsData({ fz: '18px' });
-      expect(instance.propClasses).toContain('-fz');
-      expect(instance.styles['--fz']).toBe('18px');
-    });
-
-    test('w: カスタム値は変数として出力される (bp:1)', () => {
-      const instance = new LismPropsData({ w: '200px' });
-      expect(instance.propClasses).toContain('-w');
-      expect(instance.styles['--w']).toBe('200px');
-    });
-
-    test('c: プリセット値が property class になる', () => {
-      const instance = new LismPropsData({ c: 'base' });
-      expect(instance.propClasses).toContain('-c:base');
-    });
-
-    test('c: カスタム値は変数として出力される', () => {
-      const instance = new LismPropsData({ c: 'blue' });
-      expect(instance.styles['--c']).toBe('var(--blue)');
-    });
-
-    test('p: トークン値が property class になる', () => {
-      const instance = new LismPropsData({ p: '20' });
-      expect(instance.propClasses).toContain('-p:20');
-    });
-
-    test(': プレフィックス付きの値は property class になる', () => {
-      const instance = new LismPropsData({ w: ':fit' });
-      expect(instance.propClasses).toContain('-w:fit');
-      expect(instance.styles.width).toBeUndefined();
-    });
-
-    test('true値は property class のみ出力', () => {
-      const instance = new LismPropsData({ w: true });
-      expect(instance.propClasses).toContain('-w');
-      expect(instance.styles.width).toBeUndefined();
-    });
-  });
-
-  describe('analyzeProps - ブレイクポイント指定', () => {
-    test('オブジェクト形式でブレイクポイント指定 (トークン値)', () => {
-      const instance = new LismPropsData({
-        fz: { base: 'xl', sm: 'l' },
-      });
-      expect(instance.propClasses).toContain('-fz:xl');
-      expect(instance.propClasses).toContain('-fz_sm');
-      expect(instance.styles['--fz_sm']).toBe('var(--fz--l)');
-    });
-
-    test('配列形式でブレイクポイント指定 (トークン値)', () => {
-      const instance = new LismPropsData({
-        fz: ['xl', 'l', 'm'],
-      });
-      expect(instance.propClasses).toContain('-fz:xl');
-      expect(instance.propClasses).toContain('-fz_sm');
-      expect(instance.propClasses).toContain('-fz_md');
-      expect(instance.styles['--fz_sm']).toBe('var(--fz--l)');
-      expect(instance.styles['--fz_md']).toBe('var(--fz--m)');
-    });
-
-    test('カスタム値のブレイクポイント指定', () => {
-      const instance = new LismPropsData({
-        fz: { base: '16px', sm: '18px' },
-      });
-      expect(instance.propClasses).toContain('-fz');
-      expect(instance.propClasses).toContain('-fz_sm');
-      expect(instance.styles['--fz']).toBe('16px');
-      expect(instance.styles['--fz_sm']).toBe('18px');
-    });
-  });
-
-  describe('analyzeTrait - Trait処理', () => {
-    test('isContainer: true でトレイトクラスが追加される', () => {
-      const instance = new LismPropsData({ isContainer: true });
-      expect(instance.traitClasses).toContain('is--container');
-    });
-
-    test('isContainer: false では何も追加されない', () => {
-      const instance = new LismPropsData({ isContainer: false });
-      expect(instance.traitClasses).not.toContain('is--container');
-    });
-
-    test('isWrapper: true でトレイトクラスが追加される', () => {
-      const instance = new LismPropsData({ isWrapper: true });
-      expect(instance.traitClasses).toContain('is--wrapper');
-    });
-
-    test('isWrapper: プリセット値でトレイトとプリセットクラスが追加される', () => {
-      const instance = new LismPropsData({ isWrapper: 's' });
-      expect(instance.traitClasses).toContain('is--wrapper -contentSize:s');
-    });
-
-    test('isWrapper: カスタム値でトレイトクラスと変数が追加される', () => {
-      const instance = new LismPropsData({ isWrapper: '800px' });
-      expect(instance.traitClasses).toContain('is--wrapper');
-      expect(instance.styles['--contentSize']).toBe('800px');
-    });
-
-    test('isLayer: true でトレイトクラスが追加される', () => {
-      const instance = new LismPropsData({ isLayer: true });
-      expect(instance.traitClasses).toContain('is--layer');
-    });
-
-    test('複数のstateが同時に機能する', () => {
-      const instance = new LismPropsData({
-        isContainer: true,
-        isLayer: true,
-      });
-      expect(instance.traitClasses).toContain('is--container');
-      expect(instance.traitClasses).toContain('is--layer');
-    });
-  });
-
-  describe('setHovProps - hov処理', () => {
-    test('hov: true で-hovクラスが追加される', () => {
-      const instance = new LismPropsData({ hov: true });
-      expect(instance.propClasses).toContain('-hov');
-    });
-
-    test('hov: 文字列でhoverクラスが追加される', () => {
-      const instance = new LismPropsData({ hov: 'fade' });
-      expect(instance.propClasses).toContain('-hov:fade');
-    });
-
-    test('hov: カンマ区切りで複数のクラスが追加される', () => {
-      const instance = new LismPropsData({ hov: 'fade,shadow' });
-      expect(instance.propClasses).toContain('-hov:fade');
-      expect(instance.propClasses).toContain('-hov:shadow');
-    });
-
-    test('hov: 文字列はそのまま -hov:{入力} として出力される（自動変換なし）', () => {
-      const instance = new LismPropsData({ hov: 'o' });
-      expect(instance.propClasses).toContain('-hov:o');
-      expect(instance.propClasses).not.toContain('-hov:-o');
-    });
-
-    test('hov: "-" 付きで指定した場合は -hov:-{prop} として出力される', () => {
-      const instance = new LismPropsData({ hov: '-o' });
-      expect(instance.propClasses).toContain('-hov:-o');
-    });
-
-    test('hov: カンマ区切りでもそれぞれそのまま出力される', () => {
-      const instance = new LismPropsData({ hov: '-c,-bxsh,neutral,in:zoom' });
-      expect(instance.propClasses).toContain('-hov:-c');
-      expect(instance.propClasses).toContain('-hov:-bxsh');
-      expect(instance.propClasses).toContain('-hov:neutral');
-      expect(instance.propClasses).toContain('-hov:in:zoom');
-    });
-
-    test('hov: オブジェクト形式で値を指定すると -hov:-{key} + --hov-{key} 変数が出力される', () => {
-      const instance = new LismPropsData({
-        hov: { c: 'red', bgc: 'blue' },
-      });
-      expect(instance.propClasses).toContain('-hov:-c');
-      expect(instance.propClasses).toContain('-hov:-bgc');
-      expect(instance.styles['--hov-c']).toBe('var(--red)');
-      expect(instance.styles['--hov-bgc']).toBe('var(--blue)');
-    });
-
-    test('hov: オブジェクト形式で true の場合はクラスのみ（- は付かない）', () => {
-      const instance = new LismPropsData({
-        hov: { c: true, shadowUp: true },
-      });
-      expect(instance.propClasses).toContain('-hov:c');
-      expect(instance.propClasses).toContain('-hov:shadowUp');
-      expect(instance.propClasses).not.toContain('-hov:-c');
-      expect(instance.styles['--hov-c']).toBeUndefined();
-    });
-  });
-
-  describe('css prop処理', () => {
-    test('cssプロパティがstyleに追加される', () => {
-      const instance = new LismPropsData({
-        css: { margin: '10px', padding: '20px' },
-      });
-      expect(instance.styles.margin).toBe('10px');
-      expect(instance.styles.padding).toBe('20px');
-    });
-  });
-
-  describe('_propConfig処理', () => {
-    test('_propConfigで設定を上書きできる', () => {
-      const instance = new LismPropsData({
-        w: '200px',
-        _propConfig: {
-          w: { isVar: 1 },
-        },
-      });
-      expect(instance.styles['--w']).toBe('200px');
-    });
-  });
-
-  describe('その他のattributes', () => {
-    test('Lism Props以外の属性がattrsに保持される', () => {
+    test('Lism Props 以外の属性は attrs に保持される', () => {
+      const onClick = () => {};
       const instance = new LismPropsData({
         id: 'test-id',
         'data-test': 'value',
         'aria-label': 'test',
+        onClick,
       });
       expect(instance.attrs.id).toBe('test-id');
       expect(instance.attrs['data-test']).toBe('value');
       expect(instance.attrs['aria-label']).toBe('test');
-    });
-
-    test('onClick などのイベントハンドラーが保持される', () => {
-      const onClick = () => {};
-      const instance = new LismPropsData({ onClick });
       expect(instance.attrs.onClick).toBe(onClick);
     });
-  });
 
-  describe('addUtil', () => {
-    test('ユーティリティクラスが追加される', () => {
-      const instance = new LismPropsData({});
-      instance.addUtil('-test:class');
-      expect(instance.uClasses).toContain('-test:class');
-    });
-  });
-
-  describe('addUtils', () => {
-    test('複数のユーティリティクラスが追加される', () => {
-      const instance = new LismPropsData({});
-      instance.addUtils(['-test:class1', '-test:class2']);
-      expect(instance.uClasses).toContain('-test:class1');
-      expect(instance.uClasses).toContain('-test:class2');
-    });
-  });
-
-  describe('addStyle', () => {
-    test('スタイルが追加される', () => {
-      const instance = new LismPropsData({});
-      instance.addStyle('--custom', 'value');
-      expect(instance.styles['--custom']).toBe('value');
-    });
-  });
-
-  describe('addStyles', () => {
-    test('複数のスタイルが追加される', () => {
-      const instance = new LismPropsData({});
-      instance.addStyles({ color: 'red', fontSize: '16px' });
-      expect(instance.styles.color).toBe('red');
-      expect(instance.styles.fontSize).toBe('16px');
+    test('forwardedRef は attrs.ref にマップされる', () => {
+      const mockRef = { current: null };
+      const instance = new LismPropsData({ forwardedRef: mockRef });
+      expect(instance.attrs.ref).toBe(mockRef);
     });
 
-    test('既存のスタイルとマージされる', () => {
-      const instance = new LismPropsData({ style: { margin: '10px' } });
-      instance.addStyles({ padding: '20px' });
-      expect(instance.styles.margin).toBe('10px');
-      expect(instance.styles.padding).toBe('20px');
-    });
-  });
-
-  describe('extractProp', () => {
-    test('プロパティを取得して削除する', () => {
-      const instance = new LismPropsData({ 'data-custom': 'value' });
-      instance.attrs['data-custom'] = 'value';
-      const value = instance.extractProp('data-custom');
-      expect(value).toBe('value');
-      expect(instance.attrs['data-custom']).toBeUndefined();
-    });
-
-    test('存在しないプロパティはnullを返す', () => {
-      const instance = new LismPropsData({});
-      const value = instance.extractProp('nonexistent');
-      expect(value).toBeNull();
-    });
-  });
-
-  describe('extractProps', () => {
-    test('複数のプロパティを取得して削除する', () => {
-      const instance = new LismPropsData({});
-      instance.attrs = {
-        prop1: 'value1',
-        prop2: 'value2',
-        prop3: 'value3',
-      };
-      const extracted = instance.extractProps(['prop1', 'prop2']);
-      expect(extracted).toEqual({ prop1: 'value1', prop2: 'value2' });
-      expect(instance.attrs.prop1).toBeUndefined();
-      expect(instance.attrs.prop2).toBeUndefined();
-      expect(instance.attrs.prop3).toBe('value3');
-    });
-  });
-
-  describe('複雑な組み合わせ', () => {
-    test('複数のプロパティが同時に機能する', () => {
+    test('全バケットに要素が同時に投入されても、それぞれが正しいバケットに振り分けられる', () => {
       const instance = new LismPropsData({
-        className: 'custom c--box',
-        fz: 'xl',
-        c: 'base',
-        p: '20',
+        primitiveClass: ['l--flex'],
+        set: 'var:bxsh',
         isContainer: true,
-        style: { margin: '10px' },
-      });
-
-      expect(instance.className).toContain('custom');
-      expect(instance.className).toContain('c--box');
-      expect(instance.className).toContain('is--container');
-      expect(instance.traitClasses).toContain('is--container');
-      expect(instance.propClasses).toContain('-fz:xl');
-      expect(instance.propClasses).toContain('-c:base');
-      expect(instance.propClasses).toContain('-p:20');
-      expect(instance.styles.margin).toBe('10px');
-    });
-
-    test('null/undefined/空文字/falseの値は無視される', () => {
-      const instance = new LismPropsData({
-        fz: '',
-        c: null,
-        w: undefined,
-        h: false,
+        util: 'cbox',
         p: '20',
       });
-      expect(instance.propClasses).not.toContain('-fz');
-      expect(instance.propClasses).not.toContain('-c');
-      expect(instance.propClasses).not.toContain('-w');
-      expect(instance.propClasses).not.toContain('-h');
+      expect(instance.primitiveClass).toEqual(['l--flex']);
+      expect(instance.setClasses).toContain('set--var:bxsh');
+      expect(instance.traitClasses).toContain('is--container');
+      expect(instance.uClasses).toContain('u--cbox');
       expect(instance.propClasses).toContain('-p:20');
     });
   });
@@ -416,6 +154,80 @@ describe('LismPropsData', () => {
       expect(cls.indexOf('set--var:bxsh')).toBeLessThan(cls.indexOf('has--transition'));
       expect(cls.indexOf('has--transition')).toBeLessThan(cls.indexOf('u--trim'));
       expect(cls.indexOf('u--trim')).toBeLessThan(cls.indexOf('-fz:xl'));
+    });
+  });
+
+  describe('メソッド', () => {
+    describe('addUtil', () => {
+      test('uClasses にユーティリティクラスが追加される', () => {
+        const instance = new LismPropsData({});
+        instance.addUtil('-test:class');
+        expect(instance.uClasses).toContain('-test:class');
+      });
+    });
+
+    describe('addUtils', () => {
+      test('uClasses に複数のユーティリティクラスが追加される', () => {
+        const instance = new LismPropsData({});
+        instance.addUtils(['-a:1', '-b:2']);
+        expect(instance.uClasses).toContain('-a:1');
+        expect(instance.uClasses).toContain('-b:2');
+      });
+    });
+
+    describe('addStyle', () => {
+      test('styles にスタイルが追加される', () => {
+        const instance = new LismPropsData({});
+        instance.addStyle('--custom', 'value');
+        expect(instance.styles['--custom']).toBe('value');
+      });
+    });
+
+    describe('addStyles', () => {
+      test('styles に複数のスタイルが追加される', () => {
+        const instance = new LismPropsData({});
+        instance.addStyles({ color: 'red', fontSize: '16px' });
+        expect(instance.styles.color).toBe('red');
+        expect(instance.styles.fontSize).toBe('16px');
+      });
+
+      test('既存の styles とマージされる', () => {
+        const instance = new LismPropsData({ style: { margin: '10px' } });
+        instance.addStyles({ padding: '20px' });
+        expect(instance.styles.margin).toBe('10px');
+        expect(instance.styles.padding).toBe('20px');
+      });
+    });
+
+    describe('extractProp', () => {
+      test('attrs からプロパティを取得して削除する', () => {
+        const instance = new LismPropsData({});
+        instance.attrs['data-custom'] = 'value';
+        const value = instance.extractProp('data-custom');
+        expect(value).toBe('value');
+        expect(instance.attrs['data-custom']).toBeUndefined();
+      });
+
+      test('存在しないプロパティは null を返す', () => {
+        const instance = new LismPropsData({});
+        expect(instance.extractProp('nonexistent')).toBeNull();
+      });
+    });
+
+    describe('extractProps', () => {
+      test('複数のプロパティを一括で取得して削除する', () => {
+        const instance = new LismPropsData({});
+        instance.attrs = {
+          prop1: 'value1',
+          prop2: 'value2',
+          prop3: 'value3',
+        };
+        const extracted = instance.extractProps(['prop1', 'prop2']);
+        expect(extracted).toEqual({ prop1: 'value1', prop2: 'value2' });
+        expect(instance.attrs.prop1).toBeUndefined();
+        expect(instance.attrs.prop2).toBeUndefined();
+        expect(instance.attrs.prop3).toBe('value3');
+      });
     });
   });
 });

--- a/packages/lism-css/src/lib/getMaybeTokenValue.test.ts
+++ b/packages/lism-css/src/lib/getMaybeTokenValue.test.ts
@@ -33,20 +33,20 @@ describe('getMaybeTokenValue', () => {
       expect(getMaybeTokenValue('size', 20, TOKENS)).toBe('var(--size--20)');
     });
 
-    test('マイナスの値はそのまま変数名の一部になる', () => {
+    test('マイナスの値はそのまま変数名の一部になる（実在する o トークン）', () => {
       const TOKENS = {
-        margin: new Set(['-10', '-20']),
+        o: new Set(['-10', '-20', '-30']),
       };
-      expect(getMaybeTokenValue('margin', '-10', TOKENS)).toBe('var(--margin---10)');
-      expect(getMaybeTokenValue('margin', '-20', TOKENS)).toBe('var(--margin---20)');
+      expect(getMaybeTokenValue('o', '-10', TOKENS)).toBe('var(--o---10)');
+      expect(getMaybeTokenValue('o', '-20', TOKENS)).toBe('var(--o---20)');
     });
 
-    test('マイナスの数値もそのまま変数名の一部になる', () => {
+    test('マイナスの数値もそのまま変数名の一部になる（実在する o トークン）', () => {
       const TOKENS = {
-        margin: new Set(['-10', '-20']),
+        o: new Set(['-10', '-20', '-30']),
       };
-      expect(getMaybeTokenValue('margin', -10, TOKENS)).toBe('var(--margin---10)');
-      expect(getMaybeTokenValue('margin', -20, TOKENS)).toBe('var(--margin---20)');
+      expect(getMaybeTokenValue('o', -10, TOKENS)).toBe('var(--o---10)');
+      expect(getMaybeTokenValue('o', -20, TOKENS)).toBe('var(--o---20)');
     });
   });
 
@@ -74,12 +74,12 @@ describe('getMaybeTokenValue', () => {
       expect(getMaybeTokenValue('size', 20, TOKENS)).toBe('var(--size--20)');
     });
 
-    test('マイナスの値はそのまま変数名の一部になる', () => {
+    test('マイナスの値はそのまま変数名の一部になる（実在する o トークン）', () => {
       const TOKENS = {
-        margin: ['-10', '-20'],
+        o: ['-10', '-20', '-30'],
       };
-      expect(getMaybeTokenValue('margin', '-10', TOKENS)).toBe('var(--margin---10)');
-      expect(getMaybeTokenValue('margin', '-20', TOKENS)).toBe('var(--margin---20)');
+      expect(getMaybeTokenValue('o', '-10', TOKENS)).toBe('var(--o---10)');
+      expect(getMaybeTokenValue('o', '-20', TOKENS)).toBe('var(--o---20)');
     });
   });
 
@@ -251,43 +251,40 @@ describe('getMaybeTokenValue', () => {
   });
 
   describe('実際の使用例', () => {
-    test('スペーストークン', () => {
+    test('space トークン（pre=--s のカスタムプレフィックス形式）', () => {
       const TOKENS = {
-        space: new Set(['0', '10', '20', '30', '40', '50']),
+        space: {
+          pre: '--s',
+          values: new Set(['5', '10', '15', '20', '30', '40', '50', '60', '70', '80']),
+        },
       };
-      expect(getMaybeTokenValue('space', '20', TOKENS)).toBe('var(--space--20)');
+      expect(getMaybeTokenValue('space', '20', TOKENS)).toBe('var(--s20)');
       expect(getMaybeTokenValue('space', '100', TOKENS)).toBe('100');
     });
 
-    test('カラートークン（c と palette の組み合わせ）', () => {
+    test('カラートークン（color は c → palette の順に解決される）', () => {
       const TOKENS = {
-        c: new Set(['black', 'white', 'gray']),
-        palette: new Set(['primary', 'secondary', 'accent']),
+        c: {
+          pre: '--',
+          values: new Set(['base', 'text', 'brand', 'accent']),
+        },
+        palette: {
+          pre: '--',
+          values: new Set(['red', 'blue', 'green', 'keycolor']),
+        },
       };
-      expect(getMaybeTokenValue('color', 'black', TOKENS)).toBe('var(--c--black)');
-      expect(getMaybeTokenValue('color', 'primary', TOKENS)).toBe('var(--palette--primary)');
+      expect(getMaybeTokenValue('color', 'base', TOKENS)).toBe('var(--base)');
+      expect(getMaybeTokenValue('color', 'red', TOKENS)).toBe('var(--red)');
       expect(getMaybeTokenValue('color', 'custom', TOKENS)).toBe('custom');
     });
 
-    test('フォントサイズトークン（負の値を含む）', () => {
+    test('opacity トークン（負の値を含む実在の o トークン）', () => {
       const TOKENS = {
-        fz: new Set(['-2', '-1', '0', '1', '2', '3']),
+        o: new Set(['-10', '-20', '-30']),
       };
-      expect(getMaybeTokenValue('fz', '-2', TOKENS)).toBe('var(--fz---2)');
-      expect(getMaybeTokenValue('fz', '0', TOKENS)).toBe('var(--fz--0)');
-      expect(getMaybeTokenValue('fz', '2', TOKENS)).toBe('var(--fz--2)');
-    });
-
-    test('カスタムプレフィックスを持つトークン', () => {
-      const TOKENS = {
-        radius: {
-          pre: '--radius--',
-          values: new Set(['sm', 'md', 'lg', 'full']),
-        },
-      };
-      expect(getMaybeTokenValue('radius', 'sm', TOKENS)).toBe('var(--radius--sm)');
-      expect(getMaybeTokenValue('radius', 'full', TOKENS)).toBe('var(--radius--full)');
-      expect(getMaybeTokenValue('radius', 'custom', TOKENS)).toBe('custom');
+      expect(getMaybeTokenValue('o', '-10', TOKENS)).toBe('var(--o---10)');
+      expect(getMaybeTokenValue('o', '-20', TOKENS)).toBe('var(--o---20)');
+      expect(getMaybeTokenValue('o', '-30', TOKENS)).toBe('var(--o---30)');
     });
   });
 });


### PR DESCRIPTION
## Summary

テストファイル 2 本を整理。`LismPropsData.test.ts` と `getLismProps.test.ts` の振る舞いテスト重複を解消し（#309）、あわせて `getMaybeTokenValue.test.ts` で使われていた架空トークンを実在トークンに置き換える（#286）。

Closes #309
Closes #286

## Changes

### #309: `LismPropsData.test.ts` の責務を内部専用に絞る

振る舞いテスト（`analyzeProps` / `analyzeTrait` / `setHovProps` / ブレイクポイント / `_propConfig` / css prop 等）は公開 API である `getLismProps.test.ts` 側に既に存在していたため、`LismPropsData.test.ts` からは削除。残す内容を以下 4 観点に絞った：

- **基本動作**: 空 props、`className`/`class` の重複除去マージ
- **バケット分離**: `primitiveClass` / `setClasses` / `traitClasses` / `uClasses` / `propClasses` / `styles` / `attrs` に対応する入力が正しいバケットに振り分けられること
- **`buildClassName` の出力順**: `className → primitive → set → trait → util → prop` の順序保証
- **メソッド単位**: `addUtil` / `addUtils` / `addStyle` / `addStyles` / `extractProp` / `extractProps`

これにより、同じ振る舞いに対する重複検証が解消。`LismPropsData` の内部実装（バケット構造）の正しさはキープしつつ、振る舞いバグは公開 API 側で一箇所だけ直せば済むようになる。

### #286: 架空トークンを実在トークンに置換

- 「Set 形式 / Array 形式」の**マイナスの値**テスト: 架空の `margin` → 実在する `o`（opacity）
- 「実際の使用例」セクション:
  - `space` → 実在の `{ pre: '--s', values: [...] }` 形式に修正（`var(--s20)`）
  - `c` / `palette` → 実在の `{ pre: '--', values: [...] }` 形式に修正（`var(--base)` / `var(--red)`）
  - フォントサイズの負値テスト → opacity トークンの負値テストに置換
  - 架空の `radius` カスタムプレフィックス例 → 上記 `space` と統合し削除

## Test plan

- [x] `pnpm --filter lism-css test -- --run src/lib/{LismPropsData,getLismProps,getMaybeTokenValue}.test.ts` 全パス
- [x] `nr typecheck` エラーなし
- [x] `nr lint` エラーなし
- [x] 全体テスト件数は 683 → 656（重複削除分 27 件減、coverage は維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)