### PR TITLE
refactor(lism-css): u--trimChildren を u--trimAll へリネーム＋除外方式に整理 (#324)

### DIFF
--- a/apps/docs/src/components/parts/PostCard.astro
+++ b/apps/docs/src/components/parts/PostCard.astro
@@ -30,7 +30,7 @@ const dateLocale = lang === 'ja' ? 'ja-JP' : 'en-US';
 {/* ヘッダー: Flexで横並び、両端揃え */}
 <BoxLink
   as="article"
-  class:list={['c--postCard', 'u--trimTexts', { _draft: isDraft }]}
+  class:list={['c--postCard', 'u--trimAll', { _draft: isDraft }]}
   layout="stack"
   g="30"
   p="30"

--- a/apps/docs/src/components/parts/PostCard.astro
+++ b/apps/docs/src/components/parts/PostCard.astro
@@ -30,7 +30,7 @@ const dateLocale = lang === 'ja' ? 'ja-JP' : 'en-US';
 {/* ヘッダー: Flexで横並び、両端揃え */}
 <BoxLink
   as="article"
-  class:list={['c--postCard', 'u--trimChildren', { _draft: isDraft }]}
+  class:list={['c--postCard', 'u--trimTexts', { _draft: isDraft }]}
   layout="stack"
   g="30"
   p="30"

--- a/apps/docs/src/content/en/changelog.mdx
+++ b/apps/docs/src/content/en/changelog.mdx
@@ -9,7 +9,7 @@ Breaking changes may continue frequently until the v1.0 release, so all notable 
 
 <Divider bds="dashed" my="40" />
 
-## Rename `u--trimChildren` and switch to a whitelist of target elements (#324)
+## Rename `u--trimChildren` and refine the exclusion rules (#324, #326)
 
 Contains **breaking changes**.
 
@@ -17,11 +17,11 @@ The utility class that trims half-leading margins on children has been cleaned u
 
 | Old | New |
 |---|---|
-| `u--trimChildren` / `util="trimChildren"` | `u--trimTexts` / `util="trimTexts"` |
+| `u--trimChildren` / `util="trimChildren"` | `u--trimAll` / `util="trimAll"` |
 
 The old `u--trimChildren` / `util="trimChildren"` has been removed (no backward-compatible alias). Any direct usage must be replaced.
 
-The selector strategy has also changed from a blacklist (excluding only `figure, img, button`) to a whitelist: `margin-block` is now applied only to direct `p`, `h1`–`h6`, `ul`, and `ol` children. If you need to trim other elements such as `blockquote` or `pre`, add `u--trim` to them individually.
+The selector strategy has also been refined to simply exclude elements that shouldn't be trimmed (`:empty`, `figure`, `picture`, `video`, `button`, `textarea`, `table`). The `:empty` pseudo-class automatically covers void elements like `img`/`hr` and empty decorative divs (e.g. `a--divider`, `a--spacer`). If you need to exclude additional elements, add a rule like `.u--trimAll > xxx { margin-block: 0 }` on the consumer side.
 
 <Divider bds="dashed" my="40" />
 

--- a/apps/docs/src/content/en/changelog.mdx
+++ b/apps/docs/src/content/en/changelog.mdx
@@ -9,6 +9,22 @@ Breaking changes may continue frequently until the v1.0 release, so all notable 
 
 <Divider bds="dashed" my="40" />
 
+## Rename `u--trimChildren` and switch to a whitelist of target elements (#324)
+
+Contains **breaking changes**.
+
+The utility class that trims half-leading margins on children has been cleaned up.
+
+| Old | New |
+|---|---|
+| `u--trimChildren` / `util="trimChildren"` | `u--trimTexts` / `util="trimTexts"` |
+
+The old `u--trimChildren` / `util="trimChildren"` has been removed (no backward-compatible alias). Any direct usage must be replaced.
+
+The selector strategy has also changed from a blacklist (excluding only `figure, img, button`) to a whitelist: `margin-block` is now applied only to direct `p`, `h1`–`h6`, `ul`, and `ol` children. If you need to trim other elements such as `blockquote` or `pre`, add `u--trim` to them individually.
+
+<Divider bds="dashed" my="40" />
+
 ## Rename `u--collapseGrid` and add `u--divide` (#323)
 
 Contains **breaking changes**.

--- a/apps/docs/src/content/en/primitives/l--columns.mdx
+++ b/apps/docs/src/content/en/primitives/l--columns.mdx
@@ -196,31 +196,31 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
   <PreviewTitle>subgrid</PreviewTitle>
   <PreviewArea resize p="20">
     <Columns cols={[1, 2, 3]} g="20">
-      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" />
         <Lism lh="s" bd-t fz="s" px="10" py="20 10" o="p">Date: 2025-01-01</Lism>
       </Grid>
-      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-2.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title Lorem ipsum</Heading>
         <DummyText lh="s" length="s" />
         <Lism lh="s" bd-t fz="s" px="10" py="20 10" o="p">Date: 2025-01-01</Lism>
       </Grid>
-      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-3.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title, long, long, long, very long long looong.</Heading>
         <DummyText lh="s" />
         <Lism lh="s" bd-t fz="s" px="10" py="20 10" o="p">Date: 2025-01-01</Lism>
       </Grid>
-      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-4.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" length="s" />
         <Lism lh="s" bd-t fz="s" px="10" py="20 10" o="p">Date: 2025-01-01</Lism>
       </Grid>
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-5.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" />
@@ -231,7 +231,7 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
   <PreviewCode slot="tab" label="JSX">
     ```jsx 'gtr="subgrid" gr="span 4"'
     <Columns cols={[1, 2, 3]} g="15">
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-1.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title
@@ -245,7 +245,7 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-2.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title Lorem ipsum
@@ -256,7 +256,7 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-3.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title, long, long, long, very long long looong.
@@ -270,7 +270,7 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-4.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title
@@ -281,7 +281,7 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-5.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title

--- a/apps/docs/src/content/en/primitives/l--columns.mdx
+++ b/apps/docs/src/content/en/primitives/l--columns.mdx
@@ -196,31 +196,31 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
   <PreviewTitle>subgrid</PreviewTitle>
   <PreviewArea resize p="20">
     <Columns cols={[1, 2, 3]} g="20">
-      <Grid util="trimChildren" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" />
         <Lism lh="s" bd-t fz="s" px="10" py="20 10" o="p">Date: 2025-01-01</Lism>
       </Grid>
-      <Grid util="trimChildren" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-2.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title Lorem ipsum</Heading>
         <DummyText lh="s" length="s" />
         <Lism lh="s" bd-t fz="s" px="10" py="20 10" o="p">Date: 2025-01-01</Lism>
       </Grid>
-      <Grid util="trimChildren" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-3.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title, long, long, long, very long long looong.</Heading>
         <DummyText lh="s" />
         <Lism lh="s" bd-t fz="s" px="10" py="20 10" o="p">Date: 2025-01-01</Lism>
       </Grid>
-      <Grid util="trimChildren" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-4.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" length="s" />
         <Lism lh="s" bd-t fz="s" px="10" py="20 10" o="p">Date: 2025-01-01</Lism>
       </Grid>
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-5.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" />
@@ -231,7 +231,7 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
   <PreviewCode slot="tab" label="JSX">
     ```jsx 'gtr="subgrid" gr="span 4"'
     <Columns cols={[1, 2, 3]} g="15">
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-1.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title
@@ -245,7 +245,7 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-2.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title Lorem ipsum
@@ -256,7 +256,7 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-3.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title, long, long, long, very long long looong.
@@ -270,7 +270,7 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-4.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title
@@ -281,7 +281,7 @@ Creates a card layout using subgrid within a 1 → 2 → 3 column layout.
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-5.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title

--- a/apps/docs/src/content/en/ui/Modal.mdx
+++ b/apps/docs/src/content/en/ui/Modal.mdx
@@ -71,7 +71,7 @@ The source code is available on [GitHub](https://github.com/lism-css/lism-css/tr
     <Modal.Root id="modal-01" isWrapper isContainer p="30">
       <Modal.Inner layout="stack" pos="relative" p="30" bdrs="20" bxsh="40">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
-        <Modal.Body layout="stack" g="30" util="trimTexts">
+        <Modal.Body layout="stack" g="30" util="trimAll">
           <div className="-fz:xl -fw:bold">Modal Title</div>
           <DummyText />
         </Modal.Body>
@@ -85,7 +85,7 @@ The source code is available on [GitHub](https://github.com/lism-css/lism-css/tr
     <Modal.Root id="modal-01" isWrapper isContainer p="30">
       <Modal.Inner layout="stack" pos="relative" p="30" bdrs="20" bxsh="40">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
-        <Modal.Body layout="stack" g="30" util="trimTexts">
+        <Modal.Body layout="stack" g="30" util="trimAll">
           <div className="-fz:xl -fw:bold">Modal Title</div>
           <DummyText />
         </Modal.Body>

--- a/apps/docs/src/content/en/ui/Modal.mdx
+++ b/apps/docs/src/content/en/ui/Modal.mdx
@@ -71,7 +71,7 @@ The source code is available on [GitHub](https://github.com/lism-css/lism-css/tr
     <Modal.Root id="modal-01" isWrapper isContainer p="30">
       <Modal.Inner layout="stack" pos="relative" p="30" bdrs="20" bxsh="40">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
-        <Modal.Body layout="stack" g="30" util="trimChildren">
+        <Modal.Body layout="stack" g="30" util="trimTexts">
           <div className="-fz:xl -fw:bold">Modal Title</div>
           <DummyText />
         </Modal.Body>
@@ -85,7 +85,7 @@ The source code is available on [GitHub](https://github.com/lism-css/lism-css/tr
     <Modal.Root id="modal-01" isWrapper isContainer p="30">
       <Modal.Inner layout="stack" pos="relative" p="30" bdrs="20" bxsh="40">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
-        <Modal.Body layout="stack" g="30" util="trimChildren">
+        <Modal.Body layout="stack" g="30" util="trimTexts">
           <div className="-fz:xl -fw:bold">Modal Title</div>
           <DummyText />
         </Modal.Body>

--- a/apps/docs/src/content/en/utility-class.mdx
+++ b/apps/docs/src/content/en/utility-class.mdx
@@ -203,11 +203,11 @@ Generates `--c`, `--bgc`, and `--bdc` from the `--keycolor` variable using `colo
 </PreviewArea>
 
 
-## `u--trim` & `u--trimChildren`
+## `u--trim` & `u--trimTexts`
 
 Classes for adjusting the half-leading spacing of text.
 
-`u--trim` adjusts only the element's own `margin-block`, while `u--trimChildren` adjusts the top and bottom margins of all child elements.
+`u--trim` adjusts only the element's own `margin-block`, while `u--trimTexts` trims the top and bottom margins of text-like child elements at once.
 
 <Preview>
   <PreviewTitle>`u--trim`</PreviewTitle>
@@ -236,12 +236,12 @@ Classes for adjusting the half-leading spacing of text.
 </Preview>
 
 
-Margin adjustment is disabled for `img`, `figure`, and `table` elements inside `u--trimChildren`.
+`u--trimTexts` uses a whitelist approach: it only targets direct `p`, `h1`–`h6`, `ul`, and `ol` children. Elements like `img`, `figure`, and `table` — which shouldn't be trimmed in the first place — are left untouched. If you need to trim other elements such as `blockquote` or `pre`, add `u--trim` to them individually.
 
 <Preview>
-  <PreviewTitle>`u--trimChildren`</PreviewTitle>
+  <PreviewTitle>`u--trimTexts`</PreviewTitle>
   <PreviewArea resize p="20">
-    <Stack util="trimChildren" bd g="30" p="30" bdrs="10" max-sz="s">
+    <Stack util="trimTexts" bd g="30" p="30" bdrs="10" max-sz="s">
       <Media ar="og" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
       <DummyText length="s" fw="bold" fz="l" />
       <DummyText length="l" o="p" fz="s" />
@@ -249,7 +249,7 @@ Margin adjustment is disabled for `img`, `figure`, and `table` elements inside `
   </PreviewArea>
   <PreviewCode slot="tab" label="HTML">
     ```html
-    <div class="l--stack u--trimChildren -bd -g:30 -p:30 -bdrs:10">
+    <div class="l--stack u--trimTexts -bd -g:30 -p:30 -bdrs:10">
       <img class="-ar:og" src="https://cdn.lism-css.com/img/a-1.jpg" />
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -258,7 +258,7 @@ Margin adjustment is disabled for `img`, `figure`, and `table` elements inside `
   </PreviewCode>
   <PreviewCode slot="tab" label="JSX">
     ```jsx
-    <Stack util="trimChildren" bd g="30" p="30" bdrs="10">
+    <Stack util="trimTexts" bd g="30" p="30" bdrs="10">
       <Media ar="og" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
       <p>Lorem ipsum dolor sit amet. Consectetur adipiscing elit, sed do eiusmod tempor Incididunt ut.</p>
       <p>

--- a/apps/docs/src/content/en/utility-class.mdx
+++ b/apps/docs/src/content/en/utility-class.mdx
@@ -203,11 +203,11 @@ Generates `--c`, `--bgc`, and `--bdc` from the `--keycolor` variable using `colo
 </PreviewArea>
 
 
-## `u--trim` & `u--trimTexts`
+## `u--trim` & `u--trimAll`
 
 Classes for adjusting the half-leading spacing of text.
 
-`u--trim` adjusts only the element's own `margin-block`, while `u--trimTexts` trims the top and bottom margins of text-like child elements at once.
+`u--trim` adjusts only the element's own `margin-block`, while `u--trimAll` trims the top and bottom margins of text-like child elements at once.
 
 <Preview>
   <PreviewTitle>`u--trim`</PreviewTitle>
@@ -236,12 +236,12 @@ Classes for adjusting the half-leading spacing of text.
 </Preview>
 
 
-`u--trimTexts` uses a whitelist approach: it only targets direct `p`, `h1`–`h6`, `ul`, and `ol` children. Elements like `img`, `figure`, and `table` — which shouldn't be trimmed in the first place — are left untouched. If you need to trim other elements such as `blockquote` or `pre`, add `u--trim` to them individually.
+`u--trimAll` uses an exclusion approach: it applies margin adjustment to all direct children except those that shouldn't be trimmed (`:empty`, `figure`, `picture`, `video`, `button`, `textarea`, `table`). The `:empty` pseudo-class automatically covers void elements like `img`, `hr`, `br`, as well as empty decorative divs (e.g. `a--divider`, `a--spacer`). If you need to exclude additional elements, add a rule like `.u--trimAll > xxx { margin-block: 0 }` on the consumer side.
 
 <Preview>
-  <PreviewTitle>`u--trimTexts`</PreviewTitle>
+  <PreviewTitle>`u--trimAll`</PreviewTitle>
   <PreviewArea resize p="20">
-    <Stack util="trimTexts" bd g="30" p="30" bdrs="10" max-sz="s">
+    <Stack util="trimAll" bd g="30" p="30" bdrs="10" max-sz="s">
       <Media ar="og" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
       <DummyText length="s" fw="bold" fz="l" />
       <DummyText length="l" o="p" fz="s" />
@@ -249,7 +249,7 @@ Classes for adjusting the half-leading spacing of text.
   </PreviewArea>
   <PreviewCode slot="tab" label="HTML">
     ```html
-    <div class="l--stack u--trimTexts -bd -g:30 -p:30 -bdrs:10">
+    <div class="l--stack u--trimAll -bd -g:30 -p:30 -bdrs:10">
       <img class="-ar:og" src="https://cdn.lism-css.com/img/a-1.jpg" />
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -258,7 +258,7 @@ Classes for adjusting the half-leading spacing of text.
   </PreviewCode>
   <PreviewCode slot="tab" label="JSX">
     ```jsx
-    <Stack util="trimTexts" bd g="30" p="30" bdrs="10">
+    <Stack util="trimAll" bd g="30" p="30" bdrs="10">
       <Media ar="og" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
       <p>Lorem ipsum dolor sit amet. Consectetur adipiscing elit, sed do eiusmod tempor Incididunt ut.</p>
       <p>

--- a/apps/docs/src/content/ja/changelog.mdx
+++ b/apps/docs/src/content/ja/changelog.mdx
@@ -9,7 +9,7 @@ v.1.0リリースまでしばらく激しい変更が続く可能性があるた
 
 <Divider bds="dashed" my="40" />
 
-## `u--trimChildren` のリネームと対象要素のホワイトリスト化 (#324)
+## `u--trimChildren` のリネームと除外方式の整理 (#324, #326)
 
 **破壊的変更**を含むリリースです。
 
@@ -17,11 +17,11 @@ v.1.0リリースまでしばらく激しい変更が続く可能性があるた
 
 | 旧 | 新 |
 |---|---|
-| `u--trimChildren` / `util="trimChildren"` | `u--trimTexts` / `util="trimTexts"` |
+| `u--trimChildren` / `util="trimChildren"` | `u--trimAll` / `util="trimAll"` |
 
 旧 `u--trimChildren` / `util="trimChildren"` は削除されました（後方互換エイリアスなし）。直接使用している箇所はすべて置き換えが必要です。
 
-また、トリミング対象の指定方式もブラックリスト方式（`figure, img, button` のみ除外）からホワイトリスト方式に変更しました。直下の `p`, `h1`〜`h6`, `ul`, `ol` のみに `margin-block` を適用するようになっています。`blockquote` や `pre` などそれ以外の要素をトリムしたい場合は、個別に `u--trim` を付けて対応してください。
+トリミング対象の指定方式も整理され、トリムすべきでない要素（`:empty`, `figure`, `picture`, `video`, `button`, `textarea`, `table`）のみを除外するシンプルな形になりました。`:empty` により `img` や `hr` などの void element、中身のない装飾 div（`a--divider` / `a--spacer` 等）は自動で除外されます。追加で除外したい要素は、利用側で `.u--trimAll > xxx { margin-block: 0 }` のように個別打ち消しで対応してください。
 
 <Divider bds="dashed" my="40" />
 

--- a/apps/docs/src/content/ja/changelog.mdx
+++ b/apps/docs/src/content/ja/changelog.mdx
@@ -9,6 +9,22 @@ v.1.0リリースまでしばらく激しい変更が続く可能性があるた
 
 <Divider bds="dashed" my="40" />
 
+## `u--trimChildren` のリネームと対象要素のホワイトリスト化 (#324)
+
+**破壊的変更**を含むリリースです。
+
+子要素のハーフレディング分の余白を一括トリミングするユーティリティクラスを整理しました。
+
+| 旧 | 新 |
+|---|---|
+| `u--trimChildren` / `util="trimChildren"` | `u--trimTexts` / `util="trimTexts"` |
+
+旧 `u--trimChildren` / `util="trimChildren"` は削除されました（後方互換エイリアスなし）。直接使用している箇所はすべて置き換えが必要です。
+
+また、トリミング対象の指定方式もブラックリスト方式（`figure, img, button` のみ除外）からホワイトリスト方式に変更しました。直下の `p`, `h1`〜`h6`, `ul`, `ol` のみに `margin-block` を適用するようになっています。`blockquote` や `pre` などそれ以外の要素をトリムしたい場合は、個別に `u--trim` を付けて対応してください。
+
+<Divider bds="dashed" my="40" />
+
 ## `u--collapseGrid` のリネームと `u--divide` の追加 (#323)
 
 **破壊的変更**を含むリリースです。

--- a/apps/docs/src/content/ja/primitives/l--columns.mdx
+++ b/apps/docs/src/content/ja/primitives/l--columns.mdx
@@ -197,7 +197,7 @@ import { DummyText } from '@lism-css/ui/astro';
   <PreviewTitle>subgrid</PreviewTitle>
   <PreviewArea resize p="20">
     <Columns cols={[1, 2, 3]} g="20">
-      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" />
@@ -205,7 +205,7 @@ import { DummyText } from '@lism-css/ui/astro';
           <Fragment>Date: 2025-01-01</Fragment>
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-2.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title Lorem ipsum</Heading>
         <DummyText lh="s" length="s" />
@@ -213,7 +213,7 @@ import { DummyText } from '@lism-css/ui/astro';
           <Fragment>Date: 2025-01-01</Fragment>
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-3.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title, long, long, long, very long long looong.</Heading>
         <DummyText lh="s" />
@@ -221,7 +221,7 @@ import { DummyText } from '@lism-css/ui/astro';
           <Fragment>Date: 2025-01-01</Fragment>
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-4.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" length="s" />
@@ -229,7 +229,7 @@ import { DummyText } from '@lism-css/ui/astro';
           <Fragment>Date: 2025-01-01</Fragment>
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-5.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" />
@@ -242,7 +242,7 @@ import { DummyText } from '@lism-css/ui/astro';
   <PreviewCode slot="tab" label="JSX">
     ```jsx 'gtr="subgrid" gr="span 4"'
     <Columns cols={[1, 2, 3]} g="15">
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-1.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title
@@ -256,7 +256,7 @@ import { DummyText } from '@lism-css/ui/astro';
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-2.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title Lorem ipsum
@@ -267,7 +267,7 @@ import { DummyText } from '@lism-css/ui/astro';
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-3.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title, long, long, long, very long long looong.
@@ -281,7 +281,7 @@ import { DummyText } from '@lism-css/ui/astro';
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-4.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title
@@ -292,7 +292,7 @@ import { DummyText } from '@lism-css/ui/astro';
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimAll" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-5.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title

--- a/apps/docs/src/content/ja/primitives/l--columns.mdx
+++ b/apps/docs/src/content/ja/primitives/l--columns.mdx
@@ -197,7 +197,7 @@ import { DummyText } from '@lism-css/ui/astro';
   <PreviewTitle>subgrid</PreviewTitle>
   <PreviewArea resize p="20">
     <Columns cols={[1, 2, 3]} g="20">
-      <Grid util="trimChildren" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" />
@@ -205,7 +205,7 @@ import { DummyText } from '@lism-css/ui/astro';
           <Fragment>Date: 2025-01-01</Fragment>
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-2.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title Lorem ipsum</Heading>
         <DummyText lh="s" length="s" />
@@ -213,7 +213,7 @@ import { DummyText } from '@lism-css/ui/astro';
           <Fragment>Date: 2025-01-01</Fragment>
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-3.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title, long, long, long, very long long looong.</Heading>
         <DummyText lh="s" />
@@ -221,7 +221,7 @@ import { DummyText } from '@lism-css/ui/astro';
           <Fragment>Date: 2025-01-01</Fragment>
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="30" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-4.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" length="s" />
@@ -229,7 +229,7 @@ import { DummyText } from '@lism-css/ui/astro';
           <Fragment>Date: 2025-01-01</Fragment>
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-5.jpg" alt="" inferSize />
         <Heading level="2" lh="s" aslf="center" fz="m">Card Title</Heading>
         <DummyText lh="s" />
@@ -242,7 +242,7 @@ import { DummyText } from '@lism-css/ui/astro';
   <PreviewCode slot="tab" label="JSX">
     ```jsx 'gtr="subgrid" gr="span 4"'
     <Columns cols={[1, 2, 3]} g="15">
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-1.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title
@@ -256,7 +256,7 @@ import { DummyText } from '@lism-css/ui/astro';
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-2.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title Lorem ipsum
@@ -267,7 +267,7 @@ import { DummyText } from '@lism-css/ui/astro';
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-3.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title, long, long, long, very long long looong.
@@ -281,7 +281,7 @@ import { DummyText } from '@lism-css/ui/astro';
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-4.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title
@@ -292,7 +292,7 @@ import { DummyText } from '@lism-css/ui/astro';
           Date: 2025-01-01
         </Lism>
       </Grid>
-      <Grid util="trimChildren" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
+      <Grid util="trimTexts" g="20" p="20" gtr="subgrid" gr="span 4" bgc="base-2" bdrs="10">
         <Media ar="og" bdrs="10" src="https://cdn.lism-css.com/img/a-5.jpg" />
         <Heading level="2" aslf="center" fz="m">
           Card Title

--- a/apps/docs/src/content/ja/ui/Modal.mdx
+++ b/apps/docs/src/content/ja/ui/Modal.mdx
@@ -75,7 +75,7 @@ import { Modal, DummyText } from '@lism-css/ui/astro';
     <Modal.Root id="modal-01" isWrapper isContainer p="30">
       <Modal.Inner layout="stack" pos="relative" p="30" bdrs="20" bxsh="40">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
-        <Modal.Body layout="stack" g="30" util="trimChildren">
+        <Modal.Body layout="stack" g="30" util="trimTexts">
           <div className="-fz:xl -fw:bold">Modal Title</div>
           <DummyText />
         </Modal.Body>
@@ -89,7 +89,7 @@ import { Modal, DummyText } from '@lism-css/ui/astro';
     <Modal.Root id="modal-01" isWrapper isContainer p="30">
       <Modal.Inner layout="stack" pos="relative" p="30" bdrs="20" bxsh="40">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
-        <Modal.Body layout="stack" g="30" util="trimChildren">
+        <Modal.Body layout="stack" g="30" util="trimTexts">
           <div className="-fz:xl -fw:bold">Modal Title</div>
           <DummyText />
         </Modal.Body>

--- a/apps/docs/src/content/ja/ui/Modal.mdx
+++ b/apps/docs/src/content/ja/ui/Modal.mdx
@@ -75,7 +75,7 @@ import { Modal, DummyText } from '@lism-css/ui/astro';
     <Modal.Root id="modal-01" isWrapper isContainer p="30">
       <Modal.Inner layout="stack" pos="relative" p="30" bdrs="20" bxsh="40">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
-        <Modal.Body layout="stack" g="30" util="trimTexts">
+        <Modal.Body layout="stack" g="30" util="trimAll">
           <div className="-fz:xl -fw:bold">Modal Title</div>
           <DummyText />
         </Modal.Body>
@@ -89,7 +89,7 @@ import { Modal, DummyText } from '@lism-css/ui/astro';
     <Modal.Root id="modal-01" isWrapper isContainer p="30">
       <Modal.Inner layout="stack" pos="relative" p="30" bdrs="20" bxsh="40">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
-        <Modal.Body layout="stack" g="30" util="trimTexts">
+        <Modal.Body layout="stack" g="30" util="trimAll">
           <div className="-fz:xl -fw:bold">Modal Title</div>
           <DummyText />
         </Modal.Body>

--- a/apps/docs/src/content/ja/utility-class.mdx
+++ b/apps/docs/src/content/ja/utility-class.mdx
@@ -203,11 +203,11 @@ import { Dog, Cat } from "@phosphor-icons/react";
 </PreviewArea>
 
 
-## `u--trim` & `u--trimChildren`
+## `u--trim` & `u--trimTexts`
 
 テキストのハーフレディング分の余白を調整するためのクラスです。
 
-自身のmargin-blockを調整するだけの`u--trim`と、子要素全ての上下マージンを調整するための`u--trimChildren`があります。
+自身のmargin-blockを調整するだけの`u--trim`と、子要素のテキスト系要素の上下マージンを一括で調整する`u--trimTexts`があります。
 
 <Preview>
   <PreviewTitle>`u--trim`</PreviewTitle>
@@ -236,12 +236,12 @@ import { Dog, Cat } from "@phosphor-icons/react";
 </Preview>
 
 
-`u--trimChildren`内の`img`, `figure`, `table`に対してはマージンの調節を無効化しています。
+`u--trimTexts`はホワイトリスト方式で、直下の `p`, `h1`〜`h6`, `ul`, `ol` のみを対象にマージンを調整します。`img` や `figure`, `table` など、本来トリミング対象にすべきでない要素には一切影響しません。`blockquote` や `pre` などそれ以外の要素をトリムしたい場合は、個別に `u--trim` を付けて対応してください。
 
 <Preview>
-  <PreviewTitle>`u--trimChildren`</PreviewTitle>
+  <PreviewTitle>`u--trimTexts`</PreviewTitle>
   <PreviewArea resize p="20">
-    <Stack util="trimChildren" bd g="30" p="30" bdrs="10" max-sz="s">
+    <Stack util="trimTexts" bd g="30" p="30" bdrs="10" max-sz="s">
       <Media ar="og" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
       <DummyText lang="ja" length="s" fw="bold" fz="l" />
       <DummyText lang="ja" length="l" o="p" fz="s" />
@@ -249,7 +249,7 @@ import { Dog, Cat } from "@phosphor-icons/react";
   </PreviewArea>
   <PreviewCode slot="tab" label="HTML">
     ```html
-    <div class="l--stack u--trimChildren -bd -g:30 -p:30 -bdrs:10">
+    <div class="l--stack u--trimTexts -bd -g:30 -p:30 -bdrs:10">
       <img class="-ar:og" src="https://cdn.lism-css.com/img/a-1.jpg" />
       <p>ロレム・イプサムの座り雨、トマ好き学習だったエリット、しかし時と活力はそのような木々と楽しみ。</p>
       <p>
@@ -260,7 +260,7 @@ import { Dog, Cat } from "@phosphor-icons/react";
   </PreviewCode>
   <PreviewCode slot="tab" label="JSX">
     ```jsx
-    <Stack util="trimChildren" bd g="30" p="30" bdrs="10">
+    <Stack util="trimTexts" bd g="30" p="30" bdrs="10">
       <Media ar="og" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
       <p>ロレム・イプサムの座り雨。目まぐるしい文章の流れの中で、それは静かに歩く仮の言葉です。</p>
       <p>

--- a/apps/docs/src/content/ja/utility-class.mdx
+++ b/apps/docs/src/content/ja/utility-class.mdx
@@ -203,11 +203,11 @@ import { Dog, Cat } from "@phosphor-icons/react";
 </PreviewArea>
 
 
-## `u--trim` & `u--trimTexts`
+## `u--trim` & `u--trimAll`
 
 テキストのハーフレディング分の余白を調整するためのクラスです。
 
-自身のmargin-blockを調整するだけの`u--trim`と、子要素のテキスト系要素の上下マージンを一括で調整する`u--trimTexts`があります。
+自身のmargin-blockを調整するだけの`u--trim`と、子要素のテキスト系要素の上下マージンを一括で調整する`u--trimAll`があります。
 
 <Preview>
   <PreviewTitle>`u--trim`</PreviewTitle>
@@ -236,12 +236,12 @@ import { Dog, Cat } from "@phosphor-icons/react";
 </Preview>
 
 
-`u--trimTexts`はホワイトリスト方式で、直下の `p`, `h1`〜`h6`, `ul`, `ol` のみを対象にマージンを調整します。`img` や `figure`, `table` など、本来トリミング対象にすべきでない要素には一切影響しません。`blockquote` や `pre` などそれ以外の要素をトリムしたい場合は、個別に `u--trim` を付けて対応してください。
+`u--trimAll`は除外方式で、直下の子要素のうちトリムすべきでない要素（`:empty`, `figure`, `picture`, `video`, `button`, `textarea`, `table`）を除いたすべての要素にマージン調整を適用します。`:empty` により `img`・`hr`・`br` などの void element や、中身のない装飾 div（`a--divider` / `a--spacer` 等）も自動で除外されます。追加で除外したい要素がある場合は、利用側で `.u--trimAll > xxx { margin-block: 0 }` のように個別打ち消しで対応してください。
 
 <Preview>
-  <PreviewTitle>`u--trimTexts`</PreviewTitle>
+  <PreviewTitle>`u--trimAll`</PreviewTitle>
   <PreviewArea resize p="20">
-    <Stack util="trimTexts" bd g="30" p="30" bdrs="10" max-sz="s">
+    <Stack util="trimAll" bd g="30" p="30" bdrs="10" max-sz="s">
       <Media ar="og" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
       <DummyText lang="ja" length="s" fw="bold" fz="l" />
       <DummyText lang="ja" length="l" o="p" fz="s" />
@@ -249,7 +249,7 @@ import { Dog, Cat } from "@phosphor-icons/react";
   </PreviewArea>
   <PreviewCode slot="tab" label="HTML">
     ```html
-    <div class="l--stack u--trimTexts -bd -g:30 -p:30 -bdrs:10">
+    <div class="l--stack u--trimAll -bd -g:30 -p:30 -bdrs:10">
       <img class="-ar:og" src="https://cdn.lism-css.com/img/a-1.jpg" />
       <p>ロレム・イプサムの座り雨、トマ好き学習だったエリット、しかし時と活力はそのような木々と楽しみ。</p>
       <p>
@@ -260,7 +260,7 @@ import { Dog, Cat } from "@phosphor-icons/react";
   </PreviewCode>
   <PreviewCode slot="tab" label="JSX">
     ```jsx
-    <Stack util="trimTexts" bd g="30" p="30" bdrs="10">
+    <Stack util="trimAll" bd g="30" p="30" bdrs="10">
       <Media ar="og" src="https://cdn.lism-css.com/img/a-1.jpg" alt="" inferSize />
       <p>ロレム・イプサムの座り雨。目まぐるしい文章の流れの中で、それは静かに歩く仮の言葉です。</p>
       <p>

--- a/apps/docs/src/pages/preview/templates/feature/feature001/en.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature001/en.astro
@@ -17,7 +17,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimChildren">
+          <Stack g="30" p="30" className="u--trimTexts">
             <Text fz="m" fw="bold">Shaping the Future Together</Text>
             <Text fz="s" o="pp">
               A project where every resident plays a leading role, working together through dialogue to solve community challenges.
@@ -32,7 +32,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-2.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimChildren">
+          <Stack g="30" p="30" className="u--trimTexts">
             <Text fz="m" fw="bold">Passing Traditions to the Next Generation</Text>
             <Text fz="s" lh="s" o="pp">
               Preserving festivals passed down through generations and creating opportunities for children to experience local culture.
@@ -47,7 +47,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-4.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimChildren">
+          <Stack g="30" p="30" className="u--trimTexts">
             <Text fz="m" fw="bold">A Safe Community for All</Text>
             <Text fz="s" lh="s" o="pp">We regularly conduct security patrols and disaster drills to strengthen community cooperation.</Text>
             <Flex ai="center" jc="flex-end" g="15" my-s="auto" hasTransition hov="in:solid">

--- a/apps/docs/src/pages/preview/templates/feature/feature001/en.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature001/en.astro
@@ -17,7 +17,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimTexts">
+          <Stack g="30" p="30" className="u--trimAll">
             <Text fz="m" fw="bold">Shaping the Future Together</Text>
             <Text fz="s" o="pp">
               A project where every resident plays a leading role, working together through dialogue to solve community challenges.
@@ -32,7 +32,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-2.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimTexts">
+          <Stack g="30" p="30" className="u--trimAll">
             <Text fz="m" fw="bold">Passing Traditions to the Next Generation</Text>
             <Text fz="s" lh="s" o="pp">
               Preserving festivals passed down through generations and creating opportunities for children to experience local culture.
@@ -47,7 +47,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-4.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimTexts">
+          <Stack g="30" p="30" className="u--trimAll">
             <Text fz="m" fw="bold">A Safe Community for All</Text>
             <Text fz="s" lh="s" o="pp">We regularly conduct security patrols and disaster drills to strengthen community cooperation.</Text>
             <Flex ai="center" jc="flex-end" g="15" my-s="auto" hasTransition hov="in:solid">

--- a/apps/docs/src/pages/preview/templates/feature/feature001/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature001/index.astro
@@ -17,7 +17,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimTexts">
+          <Stack g="30" p="30" className="u--trimAll">
             <Text fz="m" fw="bold">地域の未来を共に描く</Text>
             <Text fz="s" o="pp"> 住民一人ひとりが主役となり、対話を通じて地域の課題解決を目指すプロジェクトです。 </Text>
             <Flex ai="center" jc="flex-end" g="15" my-s="auto" hasTransition hov="in:solid">
@@ -30,7 +30,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-2.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimTexts">
+          <Stack g="30" p="30" className="u--trimAll">
             <Text fz="m" fw="bold">伝統文化を次世代へ</Text>
             <Text fz="s" lh="s" o="pp"> 古くから受け継がれてきた祭りを守り、子どもたちが地域の文化に触れる機会を創出します。 </Text>
             <Flex ai="center" jc="flex-end" g="15" my-s="auto" hasTransition hov="in:solid">
@@ -43,7 +43,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-4.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimTexts">
+          <Stack g="30" p="30" className="u--trimAll">
             <Text fz="m" fw="bold">安心して暮らせる街</Text>
             <Text fz="s" lh="s" o="pp">防犯パトロールや防災訓練を定期的に実施し、協力体制を強化しています。</Text>
             <Flex ai="center" jc="flex-end" g="15" my-s="auto" hasTransition hov="in:solid">

--- a/apps/docs/src/pages/preview/templates/feature/feature001/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature001/index.astro
@@ -17,7 +17,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-1.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimChildren">
+          <Stack g="30" p="30" className="u--trimTexts">
             <Text fz="m" fw="bold">地域の未来を共に描く</Text>
             <Text fz="s" o="pp"> 住民一人ひとりが主役となり、対話を通じて地域の課題解決を目指すプロジェクトです。 </Text>
             <Flex ai="center" jc="flex-end" g="15" my-s="auto" hasTransition hov="in:solid">
@@ -30,7 +30,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-2.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimChildren">
+          <Stack g="30" p="30" className="u--trimTexts">
             <Text fz="m" fw="bold">伝統文化を次世代へ</Text>
             <Text fz="s" lh="s" o="pp"> 古くから受け継がれてきた祭りを守り、子どもたちが地域の文化に触れる機会を創出します。 </Text>
             <Flex ai="center" jc="flex-end" g="15" my-s="auto" hasTransition hov="in:solid">
@@ -43,7 +43,7 @@ import './_style.css';
           <Frame as="figure" ar="og">
             <Media src="https://cdn.lism-css.com/img/a-4.jpg" alt="" width="960" height="640" />
           </Frame>
-          <Stack g="30" p="30" className="u--trimChildren">
+          <Stack g="30" p="30" className="u--trimTexts">
             <Text fz="m" fw="bold">安心して暮らせる街</Text>
             <Text fz="s" lh="s" o="pp">防犯パトロールや防災訓練を定期的に実施し、協力体制を強化しています。</Text>
             <Flex ai="center" jc="flex-end" g="15" my-s="auto" hasTransition hov="in:solid">

--- a/apps/docs/src/pages/preview/templates/feature/feature002/en.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature002/en.astro
@@ -9,11 +9,11 @@ import './_style.css';
   <Container isWrapper="l" py="50" hasGutter>
     <Stack g="40">
       <Grid gtc={['1fr', null, 'auto 1fr']} g="inherit">
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <h2>Our Initiatives</h2>
           <Text fz="l" ff="accent" o="pp">Our efforts</Text>
         </Stack>
-        <Flex class="u--trimTexts" jc={['s', null, 'end']}>
+        <Flex class="u--trimAll" jc={['s', null, 'end']}>
           <Text max-w="32rem" fz="s" o="p">
             Looking ahead to the future of our community, we are advancing initiatives toward a sustainable society. Through environmental
             conservation and community revitalization, we aim to build a town we can be proud to pass on to the next generation.

--- a/apps/docs/src/pages/preview/templates/feature/feature002/en.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature002/en.astro
@@ -9,11 +9,11 @@ import './_style.css';
   <Container isWrapper="l" py="50" hasGutter>
     <Stack g="40">
       <Grid gtc={['1fr', null, 'auto 1fr']} g="inherit">
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <h2>Our Initiatives</h2>
           <Text fz="l" ff="accent" o="pp">Our efforts</Text>
         </Stack>
-        <Flex class="u--trimChildren" jc={['s', null, 'end']}>
+        <Flex class="u--trimTexts" jc={['s', null, 'end']}>
           <Text max-w="32rem" fz="s" o="p">
             Looking ahead to the future of our community, we are advancing initiatives toward a sustainable society. Through environmental
             conservation and community revitalization, we aim to build a town we can be proud to pass on to the next generation.

--- a/apps/docs/src/pages/preview/templates/feature/feature002/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature002/index.astro
@@ -9,11 +9,11 @@ import './_style.css';
   <Container isWrapper="l" py="50" hasGutter>
     <Stack g="40">
       <Grid gtc={['1fr', null, 'auto 1fr']} g="inherit">
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <h2>私たちの取り組み</h2>
           <Text fz="l" ff="accent" o="pp">Our efforts</Text>
         </Stack>
-        <Flex class="u--trimChildren" jc={['s', null, 'end']}>
+        <Flex class="u--trimTexts" jc={['s', null, 'end']}>
           <Text max-w="32rem" fz="s" o="p">
             地域の未来を見据え、持続可能な社会の実現に向けた取り組みを進めています。
             環境保護や地域活性化を通じて、次世代に誇れる街づくりを目指します。

--- a/apps/docs/src/pages/preview/templates/feature/feature002/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature002/index.astro
@@ -9,11 +9,11 @@ import './_style.css';
   <Container isWrapper="l" py="50" hasGutter>
     <Stack g="40">
       <Grid gtc={['1fr', null, 'auto 1fr']} g="inherit">
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <h2>私たちの取り組み</h2>
           <Text fz="l" ff="accent" o="pp">Our efforts</Text>
         </Stack>
-        <Flex class="u--trimTexts" jc={['s', null, 'end']}>
+        <Flex class="u--trimAll" jc={['s', null, 'end']}>
           <Text max-w="32rem" fz="s" o="p">
             地域の未来を見据え、持続可能な社会の実現に向けた取り組みを進めています。
             環境保護や地域活性化を通じて、次世代に誇れる街づくりを目指します。

--- a/apps/docs/src/pages/preview/templates/feature/feature003/en.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature003/en.astro
@@ -9,7 +9,7 @@ import './_style.css';
 <DemoLayout title="Feature003">
   <Container isWrapper="l" py="50" hasGutter>
     <Grid gtc={['1fr', null, 'min(20vw, 20rem) 1fr 1fr']} gtr={['1fr', null, '1fr auto auto 1fr']} g={['40', null, '40 50']}>
-      <Stack gr={['1', null, '2']} g="40" class="u--trimChildren">
+      <Stack gr={['1', null, '2']} g="40" class="u--trimTexts">
         <h2>Beyond the Vision</h2>
         <Text fz="s">
           We cherish the traditions and festivals passed down in this region and work to connect them to the next generation. We rediscover and
@@ -26,7 +26,7 @@ import './_style.css';
               </Center>
             </Layer>
           </Frame>
-          <Stack g="30" p="30" class="u--trimChildren">
+          <Stack g="30" p="30" class="u--trimTexts">
             <Text fz="l" fw="bold">Shaping the Future Together</Text>
             <Text fz="s" o="p">A project where residents play the leading role, working through dialogue to solve community challenges.</Text>
           </Stack>
@@ -40,7 +40,7 @@ import './_style.css';
               </Center>
             </Layer>
           </Frame>
-          <Stack g="30" p="30" class="u--trimChildren">
+          <Stack g="30" p="30" class="u--trimTexts">
             <Text fz="l" fw="bold">Passing Traditions to the Next Generation</Text>
             <Text fz="s" o="p">
               We cherish the traditions and festivals of this region, rediscovering local charm and nurturing activities for the future.

--- a/apps/docs/src/pages/preview/templates/feature/feature003/en.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature003/en.astro
@@ -9,7 +9,7 @@ import './_style.css';
 <DemoLayout title="Feature003">
   <Container isWrapper="l" py="50" hasGutter>
     <Grid gtc={['1fr', null, 'min(20vw, 20rem) 1fr 1fr']} gtr={['1fr', null, '1fr auto auto 1fr']} g={['40', null, '40 50']}>
-      <Stack gr={['1', null, '2']} g="40" class="u--trimTexts">
+      <Stack gr={['1', null, '2']} g="40" class="u--trimAll">
         <h2>Beyond the Vision</h2>
         <Text fz="s">
           We cherish the traditions and festivals passed down in this region and work to connect them to the next generation. We rediscover and
@@ -26,7 +26,7 @@ import './_style.css';
               </Center>
             </Layer>
           </Frame>
-          <Stack g="30" p="30" class="u--trimTexts">
+          <Stack g="30" p="30" class="u--trimAll">
             <Text fz="l" fw="bold">Shaping the Future Together</Text>
             <Text fz="s" o="p">A project where residents play the leading role, working through dialogue to solve community challenges.</Text>
           </Stack>
@@ -40,7 +40,7 @@ import './_style.css';
               </Center>
             </Layer>
           </Frame>
-          <Stack g="30" p="30" class="u--trimTexts">
+          <Stack g="30" p="30" class="u--trimAll">
             <Text fz="l" fw="bold">Passing Traditions to the Next Generation</Text>
             <Text fz="s" o="p">
               We cherish the traditions and festivals of this region, rediscovering local charm and nurturing activities for the future.

--- a/apps/docs/src/pages/preview/templates/feature/feature003/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature003/index.astro
@@ -9,7 +9,7 @@ import './_style.css';
 <DemoLayout title="Feature003">
   <Container isWrapper="l" py="50" hasGutter>
     <Grid gtc={['1fr', null, 'min(20vw, 20rem) 1fr 1fr']} gtr={['1fr', null, '1fr auto auto 1fr']} g={['40', null, '40 50']}>
-      <Stack gr={['1', null, '2']} g="40" class="u--trimChildren">
+      <Stack gr={['1', null, '2']} g="40" class="u--trimTexts">
         <h2>目指す世界の先に</h2>
         <Text fz="s"> この地に受け継がれてきた伝統や祭りを大切に守り、次世代へと繋いでいきます。 地域の魅力を再発見し育む活動を行っています。 </Text>
       </Stack>
@@ -23,7 +23,7 @@ import './_style.css';
               </Center>
             </Layer>
           </Frame>
-          <Stack g="30" p="30" class="u--trimChildren">
+          <Stack g="30" p="30" class="u--trimTexts">
             <Text fz="l" fw="bold">地域の未来を共に描く</Text>
             <Text fz="s" o="p">住民が主役となり、対話を通じて地域の課題解決を目指すプロジェクトです。</Text>
           </Stack>
@@ -37,7 +37,7 @@ import './_style.css';
               </Center>
             </Layer>
           </Frame>
-          <Stack g="30" p="30" class="u--trimChildren">
+          <Stack g="30" p="30" class="u--trimTexts">
             <Text fz="l" fw="bold">伝統文化を次世代へ</Text>
             <Text fz="s" o="p"> この地に受け継がれてきた伝統や祭りを大切に守り、地域の魅力を再発見し、未来を育む活動を行っています。 </Text>
           </Stack>

--- a/apps/docs/src/pages/preview/templates/feature/feature003/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature003/index.astro
@@ -9,7 +9,7 @@ import './_style.css';
 <DemoLayout title="Feature003">
   <Container isWrapper="l" py="50" hasGutter>
     <Grid gtc={['1fr', null, 'min(20vw, 20rem) 1fr 1fr']} gtr={['1fr', null, '1fr auto auto 1fr']} g={['40', null, '40 50']}>
-      <Stack gr={['1', null, '2']} g="40" class="u--trimTexts">
+      <Stack gr={['1', null, '2']} g="40" class="u--trimAll">
         <h2>目指す世界の先に</h2>
         <Text fz="s"> この地に受け継がれてきた伝統や祭りを大切に守り、次世代へと繋いでいきます。 地域の魅力を再発見し育む活動を行っています。 </Text>
       </Stack>
@@ -23,7 +23,7 @@ import './_style.css';
               </Center>
             </Layer>
           </Frame>
-          <Stack g="30" p="30" class="u--trimTexts">
+          <Stack g="30" p="30" class="u--trimAll">
             <Text fz="l" fw="bold">地域の未来を共に描く</Text>
             <Text fz="s" o="p">住民が主役となり、対話を通じて地域の課題解決を目指すプロジェクトです。</Text>
           </Stack>
@@ -37,7 +37,7 @@ import './_style.css';
               </Center>
             </Layer>
           </Frame>
-          <Stack g="30" p="30" class="u--trimTexts">
+          <Stack g="30" p="30" class="u--trimAll">
             <Text fz="l" fw="bold">伝統文化を次世代へ</Text>
             <Text fz="s" o="p"> この地に受け継がれてきた伝統や祭りを大切に守り、地域の魅力を再発見し、未来を育む活動を行っています。 </Text>
           </Stack>

--- a/apps/docs/src/pages/preview/templates/feature/feature004/en.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature004/en.astro
@@ -16,7 +16,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimChildren">
+                <Stack g="20" class="u--trimTexts">
                   <Text fz="l" fw="bold" lh="s">Innovative Technology</Text>
                   <Text fz="s" lh="s" o="p">Advanced Technology</Text>
                 </Stack>
@@ -34,7 +34,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimChildren">
+                <Stack g="20" class="u--trimTexts">
                   <Text fz="l" fw="bold" lh="s">Rigorous Quality Control</Text>
                   <Text fz="s" lh="s" o="p">Quality First</Text>
                 </Stack>
@@ -52,7 +52,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimChildren">
+                <Stack g="20" class="u--trimTexts">
                   <Text fz="l" fw="bold" lh="s">Global Supply Network</Text>
                   <Text fz="s" lh="s" o="p">Global Network</Text>
                 </Stack>

--- a/apps/docs/src/pages/preview/templates/feature/feature004/en.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature004/en.astro
@@ -16,7 +16,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimTexts">
+                <Stack g="20" class="u--trimAll">
                   <Text fz="l" fw="bold" lh="s">Innovative Technology</Text>
                   <Text fz="s" lh="s" o="p">Advanced Technology</Text>
                 </Stack>
@@ -34,7 +34,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimTexts">
+                <Stack g="20" class="u--trimAll">
                   <Text fz="l" fw="bold" lh="s">Rigorous Quality Control</Text>
                   <Text fz="s" lh="s" o="p">Quality First</Text>
                 </Stack>
@@ -52,7 +52,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimTexts">
+                <Stack g="20" class="u--trimAll">
                   <Text fz="l" fw="bold" lh="s">Global Supply Network</Text>
                   <Text fz="s" lh="s" o="p">Global Network</Text>
                 </Stack>

--- a/apps/docs/src/pages/preview/templates/feature/feature004/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature004/index.astro
@@ -16,7 +16,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimTexts">
+                <Stack g="20" class="u--trimAll">
                   <Text fz="l" fw="bold" lh="s">革新的な技術力</Text>
                   <Text fz="s" lh="s" o="p">Advanced Technology</Text>
                 </Stack>
@@ -34,7 +34,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimTexts">
+                <Stack g="20" class="u--trimAll">
                   <Text fz="l" fw="bold" lh="s">徹底した品質管理</Text>
                   <Text fz="s" lh="s" o="p">Quality First</Text>
                 </Stack>
@@ -52,7 +52,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimTexts">
+                <Stack g="20" class="u--trimAll">
                   <Text fz="l" fw="bold" lh="s">グローバル供給体制</Text>
                   <Text fz="s" lh="s" o="p">Global Network</Text>
                 </Stack>

--- a/apps/docs/src/pages/preview/templates/feature/feature004/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature004/index.astro
@@ -16,7 +16,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimChildren">
+                <Stack g="20" class="u--trimTexts">
                   <Text fz="l" fw="bold" lh="s">革新的な技術力</Text>
                   <Text fz="s" lh="s" o="p">Advanced Technology</Text>
                 </Stack>
@@ -34,7 +34,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimChildren">
+                <Stack g="20" class="u--trimTexts">
                   <Text fz="l" fw="bold" lh="s">徹底した品質管理</Text>
                   <Text fz="s" lh="s" o="p">Quality First</Text>
                 </Stack>
@@ -52,7 +52,7 @@ import './_style.css';
             <Layer bgc="rgb(0 0 0 / 20%)" />
             <Stack pos="relative" h="100%" jc="flex-end" c="white" p="30" g="20" my-s="auto">
               <Grid gtc="1fr auto" ai="end" g="30">
-                <Stack g="20" class="u--trimChildren">
+                <Stack g="20" class="u--trimTexts">
                   <Text fz="l" fw="bold" lh="s">グローバル供給体制</Text>
                   <Text fz="s" lh="s" o="p">Global Network</Text>
                 </Stack>

--- a/apps/docs/src/pages/preview/templates/feature/feature015/en.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature015/en.astro
@@ -16,11 +16,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <Text fz="l" fw="bold" lts="l">A Cup That Awakens Like<br />the Morning Sun</Text>
           <Text fz="s" o="pp">Morning Awakening Blend</Text>
         </Stack>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <p>
             Blended for busy mornings, this coffee features a refreshing acidity and crisp finish. Bright citrus-like aromas gently awaken your senses
             and bring positive energy to your day. Start with it black to enjoy its clear, pure flavor.
@@ -31,11 +31,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <Text fz="l" fw="bold" lts="l">Deep Comfort for<br />an Afternoon Moment</Text>
           <Text fz="s" o="pp">Afternoon Comfort Blend</Text>
         </Stack>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <p>
             The perfect companion for reading or taking a break, with a well-balanced mild flavor. Nutty richness and gentle milk chocolate sweetness
             transform your afternoon into a peaceful, fulfilling moment. A cup of comfort to unwind your mind and body.
@@ -46,11 +46,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <Text fz="l" fw="bold" lts="l">An Evening Blend to<br />Free Your Mind</Text>
           <Text fz="s" o="pp">Midnight Calm Decaf</Text>
         </Stack>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <p>
             A decaf coffee designed exclusively for evenings, with 99.9% of the caffeine removed. Using only natural water without any chemicals for
             the decaffeination process. Preserving the rich body and deep aroma of coffee, it is perfect for relaxing before bed or for those who

--- a/apps/docs/src/pages/preview/templates/feature/feature015/en.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature015/en.astro
@@ -16,11 +16,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <Text fz="l" fw="bold" lts="l">A Cup That Awakens Like<br />the Morning Sun</Text>
           <Text fz="s" o="pp">Morning Awakening Blend</Text>
         </Stack>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <p>
             Blended for busy mornings, this coffee features a refreshing acidity and crisp finish. Bright citrus-like aromas gently awaken your senses
             and bring positive energy to your day. Start with it black to enjoy its clear, pure flavor.
@@ -31,11 +31,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <Text fz="l" fw="bold" lts="l">Deep Comfort for<br />an Afternoon Moment</Text>
           <Text fz="s" o="pp">Afternoon Comfort Blend</Text>
         </Stack>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <p>
             The perfect companion for reading or taking a break, with a well-balanced mild flavor. Nutty richness and gentle milk chocolate sweetness
             transform your afternoon into a peaceful, fulfilling moment. A cup of comfort to unwind your mind and body.
@@ -46,11 +46,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <Text fz="l" fw="bold" lts="l">An Evening Blend to<br />Free Your Mind</Text>
           <Text fz="s" o="pp">Midnight Calm Decaf</Text>
         </Stack>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <p>
             A decaf coffee designed exclusively for evenings, with 99.9% of the caffeine removed. Using only natural water without any chemicals for
             the decaffeination process. Preserving the rich body and deep aroma of coffee, it is perfect for relaxing before bed or for those who

--- a/apps/docs/src/pages/preview/templates/feature/feature015/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature015/index.astro
@@ -16,11 +16,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <Text fz="l" fw="bold" lts="l">朝日のように、目覚める一杯<br />ここにある時間</Text>
           <Text fz="s" o="pp">Morning Awakening Blend</Text>
         </Stack>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <p>
             忙しい朝のためにブレンドされた、爽やかな酸味とすっきりとした後味が特徴のコーヒーです。
             シトラスのような明るい香りが五感を優しく呼び覚まし、あなたの一日にポジティブな活力を与えます。
@@ -32,11 +32,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <Text fz="l" fw="bold" lts="l">午後のひとときに、深い安らぎ<br />心を満たす一杯</Text>
           <Text fz="s" o="pp">Afternoon Comfort Blend</Text>
         </Stack>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <p>
             読書や休憩のお供に最適な、バランスの取れたマイルドな味わい。
             ナッツのような香ばしさと、ミルクチョコレートのような優しい甘さが、午後のひとときを穏やかで満ち足りたものに変えてくれます。
@@ -48,11 +48,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <Text fz="l" fw="bold" lts="l">心解き放つ、夜のためのブレンド<br />眠りへと誘う</Text>
           <Text fz="s" o="pp">Midnight Calm Decaf</Text>
         </Stack>
-        <Stack class="u--trimTexts" g="20">
+        <Stack class="u--trimAll" g="20">
           <p>
             カフェインを99.9%カットした、夜専用のデカフェコーヒーです。 化学薬品を一切使用せず、天然水だけでカフェインを除去。
             コーヒー本来の豊かなコクと深い香りはそのままに、就寝前のリラックスタイムや、カフェインを控えている方にも安心してお楽しみいただけます。

--- a/apps/docs/src/pages/preview/templates/feature/feature015/index.astro
+++ b/apps/docs/src/pages/preview/templates/feature/feature015/index.astro
@@ -16,11 +16,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=1" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <Text fz="l" fw="bold" lts="l">朝日のように、目覚める一杯<br />ここにある時間</Text>
           <Text fz="s" o="pp">Morning Awakening Blend</Text>
         </Stack>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <p>
             忙しい朝のためにブレンドされた、爽やかな酸味とすっきりとした後味が特徴のコーヒーです。
             シトラスのような明るい香りが五感を優しく呼び覚まし、あなたの一日にポジティブな活力を与えます。
@@ -32,11 +32,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=2" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <Text fz="l" fw="bold" lts="l">午後のひとときに、深い安らぎ<br />心を満たす一杯</Text>
           <Text fz="s" o="pp">Afternoon Comfort Blend</Text>
         </Stack>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <p>
             読書や休憩のお供に最適な、バランスの取れたマイルドな味わい。
             ナッツのような香ばしさと、ミルクチョコレートのような優しい甘さが、午後のひとときを穏やかで満ち足りたものに変えてくれます。
@@ -48,11 +48,11 @@ import './_style.css';
         <Frame as="figure" ar="16/9" bdrs="10">
           <Media src="https://cdn.lism-css.com/random/img?r=3" alt="" width="960" height="640" />
         </Frame>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <Text fz="l" fw="bold" lts="l">心解き放つ、夜のためのブレンド<br />眠りへと誘う</Text>
           <Text fz="s" o="pp">Midnight Calm Decaf</Text>
         </Stack>
-        <Stack class="u--trimChildren" g="20">
+        <Stack class="u--trimTexts" g="20">
           <p>
             カフェインを99.9%カットした、夜専用のデカフェコーヒーです。 化学薬品を一切使用せず、天然水だけでカフェインを除去。
             コーヒー本来の豊かなコクと深い香りはそのままに、就寝前のリラックスタイムや、カフェインを控えている方にも安心してお楽しみいただけます。

--- a/apps/docs/src/pages/preview/templates/greeting/greeting002/en.astro
+++ b/apps/docs/src/pages/preview/templates/greeting/greeting002/en.astro
@@ -8,7 +8,7 @@ import './_style.css';
 <DemoLayout title="Greeting002">
   <Wrapper contentSize="l" py="50" bgc="base" hasGutter>
     <Stack g="50">
-      <Stack class="u--trimChildren" g="40">
+      <Stack class="u--trimTexts" g="40">
         <Inline fz="min(22vw, 10rem)" fw="bold" ff="accent" mx-s="-.5rem" c="gray" o="ppp" whs="nowrap">Greeting</Inline>
         <Heading level="2" fz="3xl" fw="bold" ff="accent">Message from the CEO</Heading>
       </Stack>
@@ -29,7 +29,7 @@ import './_style.css';
           <Frame as="figure" ar="1/1" bdrs="99">
             <Media src="https://cdn.lism-css.com/random/img?category=ceo" alt="" width="960" height="640" style={{ objectPosition: '50% 20%' }} />
           </Frame>
-          <Stack g="20" class="u--trimChildren" ff="accent">
+          <Stack g="20" class="u--trimTexts" ff="accent">
             <Inline fz="l">CEO</Inline>
             <Inline fz="xl" fw="bold">Seiji Tanaka</Inline>
           </Stack>

--- a/apps/docs/src/pages/preview/templates/greeting/greeting002/en.astro
+++ b/apps/docs/src/pages/preview/templates/greeting/greeting002/en.astro
@@ -8,7 +8,7 @@ import './_style.css';
 <DemoLayout title="Greeting002">
   <Wrapper contentSize="l" py="50" bgc="base" hasGutter>
     <Stack g="50">
-      <Stack class="u--trimTexts" g="40">
+      <Stack class="u--trimAll" g="40">
         <Inline fz="min(22vw, 10rem)" fw="bold" ff="accent" mx-s="-.5rem" c="gray" o="ppp" whs="nowrap">Greeting</Inline>
         <Heading level="2" fz="3xl" fw="bold" ff="accent">Message from the CEO</Heading>
       </Stack>
@@ -29,7 +29,7 @@ import './_style.css';
           <Frame as="figure" ar="1/1" bdrs="99">
             <Media src="https://cdn.lism-css.com/random/img?category=ceo" alt="" width="960" height="640" style={{ objectPosition: '50% 20%' }} />
           </Frame>
-          <Stack g="20" class="u--trimTexts" ff="accent">
+          <Stack g="20" class="u--trimAll" ff="accent">
             <Inline fz="l">CEO</Inline>
             <Inline fz="xl" fw="bold">Seiji Tanaka</Inline>
           </Stack>

--- a/apps/docs/src/pages/preview/templates/greeting/greeting002/index.astro
+++ b/apps/docs/src/pages/preview/templates/greeting/greeting002/index.astro
@@ -8,7 +8,7 @@ import './_style.css';
 <DemoLayout title="Greeting002">
   <Wrapper contentSize="l" py="50" bgc="base" hasGutter>
     <Stack g="50">
-      <Stack class="u--trimTexts" g="40">
+      <Stack class="u--trimAll" g="40">
         <Inline fz="min(22vw, 10rem)" fw="bold" ff="accent" mx-s="-.5rem" c="gray" o="ppp" whs="nowrap">Greeting</Inline>
         <Heading level="2" fz="3xl" fw="bold" ff="accent">代表メッセージ</Heading>
       </Stack>
@@ -30,7 +30,7 @@ import './_style.css';
           <Frame as="figure" ar="1/1" bdrs="99">
             <Media src="https://cdn.lism-css.com/random/img?category=ceo" alt="" width="960" height="640" style={{ objectPosition: '50% 20%' }} />
           </Frame>
-          <Stack g="20" class="u--trimTexts" ff="accent">
+          <Stack g="20" class="u--trimAll" ff="accent">
             <Inline fz="l">代表取締役社長</Inline>
             <Inline fz="xl" fw="bold">田中　誠二</Inline>
           </Stack>

--- a/apps/docs/src/pages/preview/templates/greeting/greeting002/index.astro
+++ b/apps/docs/src/pages/preview/templates/greeting/greeting002/index.astro
@@ -8,7 +8,7 @@ import './_style.css';
 <DemoLayout title="Greeting002">
   <Wrapper contentSize="l" py="50" bgc="base" hasGutter>
     <Stack g="50">
-      <Stack class="u--trimChildren" g="40">
+      <Stack class="u--trimTexts" g="40">
         <Inline fz="min(22vw, 10rem)" fw="bold" ff="accent" mx-s="-.5rem" c="gray" o="ppp" whs="nowrap">Greeting</Inline>
         <Heading level="2" fz="3xl" fw="bold" ff="accent">代表メッセージ</Heading>
       </Stack>
@@ -30,7 +30,7 @@ import './_style.css';
           <Frame as="figure" ar="1/1" bdrs="99">
             <Media src="https://cdn.lism-css.com/random/img?category=ceo" alt="" width="960" height="640" style={{ objectPosition: '50% 20%' }} />
           </Frame>
-          <Stack g="20" class="u--trimChildren" ff="accent">
+          <Stack g="20" class="u--trimTexts" ff="accent">
             <Inline fz="l">代表取締役社長</Inline>
             <Inline fz="xl" fw="bold">田中　誠二</Inline>
           </Stack>

--- a/apps/docs/src/pages/preview/templates/information/information004/en.astro
+++ b/apps/docs/src/pages/preview/templates/information/information004/en.astro
@@ -14,7 +14,7 @@ import './_style.css';
     </Stack>
     <Stack>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimTexts" g="15">
+        <Stack class="u--trimAll" g="15">
           <Text fz="l" fw="bold" lts="l">Tokyo Headquarters</Text>
           <Text fz="s" o="pp">Tokyo Office</Text>
         </Stack>
@@ -35,7 +35,7 @@ import './_style.css';
         </Frame>
       </Grid>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimTexts" g="15">
+        <Stack class="u--trimAll" g="15">
           <Text fz="l" fw="bold" lts="l">Hokkaido Branch</Text>
           <Text fz="s" o="pp">Hokkaido Branch</Text>
         </Stack>
@@ -56,7 +56,7 @@ import './_style.css';
         </Frame>
       </Grid>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimTexts" g="15">
+        <Stack class="u--trimAll" g="15">
           <Text fz="l" fw="bold" lts="l">Okinawa Branch</Text>
           <Text fz="s" o="pp">Okinawa Branch</Text>
         </Stack>

--- a/apps/docs/src/pages/preview/templates/information/information004/en.astro
+++ b/apps/docs/src/pages/preview/templates/information/information004/en.astro
@@ -14,7 +14,7 @@ import './_style.css';
     </Stack>
     <Stack>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimChildren" g="15">
+        <Stack class="u--trimTexts" g="15">
           <Text fz="l" fw="bold" lts="l">Tokyo Headquarters</Text>
           <Text fz="s" o="pp">Tokyo Office</Text>
         </Stack>
@@ -35,7 +35,7 @@ import './_style.css';
         </Frame>
       </Grid>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimChildren" g="15">
+        <Stack class="u--trimTexts" g="15">
           <Text fz="l" fw="bold" lts="l">Hokkaido Branch</Text>
           <Text fz="s" o="pp">Hokkaido Branch</Text>
         </Stack>
@@ -56,7 +56,7 @@ import './_style.css';
         </Frame>
       </Grid>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimChildren" g="15">
+        <Stack class="u--trimTexts" g="15">
           <Text fz="l" fw="bold" lts="l">Okinawa Branch</Text>
           <Text fz="s" o="pp">Okinawa Branch</Text>
         </Stack>

--- a/apps/docs/src/pages/preview/templates/information/information004/index.astro
+++ b/apps/docs/src/pages/preview/templates/information/information004/index.astro
@@ -14,7 +14,7 @@ import './_style.css';
     </Stack>
     <Stack>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimTexts" g="15">
+        <Stack class="u--trimAll" g="15">
           <Text fz="l" fw="bold" lts="l">東京本社</Text>
           <Text fz="s" o="pp">Tokyo Office</Text>
         </Stack>
@@ -35,7 +35,7 @@ import './_style.css';
         </Frame>
       </Grid>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimTexts" g="15">
+        <Stack class="u--trimAll" g="15">
           <Text fz="l" fw="bold" lts="l">北海道支店</Text>
           <Text fz="s" o="pp">Hokkaido Branch</Text>
         </Stack>
@@ -56,7 +56,7 @@ import './_style.css';
         </Frame>
       </Grid>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimTexts" g="15">
+        <Stack class="u--trimAll" g="15">
           <Text fz="l" fw="bold" lts="l">沖縄支店</Text>
           <Text fz="s" o="pp">Okinawa Branch</Text>
         </Stack>

--- a/apps/docs/src/pages/preview/templates/information/information004/index.astro
+++ b/apps/docs/src/pages/preview/templates/information/information004/index.astro
@@ -14,7 +14,7 @@ import './_style.css';
     </Stack>
     <Stack>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimChildren" g="15">
+        <Stack class="u--trimTexts" g="15">
           <Text fz="l" fw="bold" lts="l">東京本社</Text>
           <Text fz="s" o="pp">Tokyo Office</Text>
         </Stack>
@@ -35,7 +35,7 @@ import './_style.css';
         </Frame>
       </Grid>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimChildren" g="15">
+        <Stack class="u--trimTexts" g="15">
           <Text fz="l" fw="bold" lts="l">北海道支店</Text>
           <Text fz="s" o="pp">Hokkaido Branch</Text>
         </Stack>
@@ -56,7 +56,7 @@ import './_style.css';
         </Frame>
       </Grid>
       <Grid gtc={['auto', null, 'minmax(auto, 200px) repeat(2, 1fr)']} g="40" py="40" bd-y-e>
-        <Stack class="u--trimChildren" g="15">
+        <Stack class="u--trimTexts" g="15">
           <Text fz="l" fw="bold" lts="l">沖縄支店</Text>
           <Text fz="s" o="pp">Okinawa Branch</Text>
         </Stack>

--- a/apps/docs/src/pages/preview/templates/navigation/navigation006/en.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation006/en.astro
@@ -13,7 +13,7 @@ import './_style.css';
         <Text class="u--trim" fz="3xl" fw="bold" ff="accent" c="gray">Navigation</Text>
         <Heading level="2" class="u--trim" fz="s" fw="normal" o="pp">Site Navigation</Heading>
       </Stack>
-      <AutoColumns class="u--trimTexts" gr={['2', null, '1 / -1']} gc={['1', null, '2']} cols="14rem" g="30 40">
+      <AutoColumns class="u--trimAll" gr={['2', null, '1 / -1']} gc={['1', null, '2']} cols="14rem" g="30 40">
         <BoxLink href="#" layout="grid" gtc="1fr auto" ai="center" g="20" py="15" hov="-c">
           <Inline>Kitchen</Inline>
           <Icon icon="caret-right" />

--- a/apps/docs/src/pages/preview/templates/navigation/navigation006/en.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation006/en.astro
@@ -13,7 +13,7 @@ import './_style.css';
         <Text class="u--trim" fz="3xl" fw="bold" ff="accent" c="gray">Navigation</Text>
         <Heading level="2" class="u--trim" fz="s" fw="normal" o="pp">Site Navigation</Heading>
       </Stack>
-      <AutoColumns class="u--trimChildren" gr={['2', null, '1 / -1']} gc={['1', null, '2']} cols="14rem" g="30 40">
+      <AutoColumns class="u--trimTexts" gr={['2', null, '1 / -1']} gc={['1', null, '2']} cols="14rem" g="30 40">
         <BoxLink href="#" layout="grid" gtc="1fr auto" ai="center" g="20" py="15" hov="-c">
           <Inline>Kitchen</Inline>
           <Icon icon="caret-right" />

--- a/apps/docs/src/pages/preview/templates/navigation/navigation006/index.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation006/index.astro
@@ -13,7 +13,7 @@ import './_style.css';
         <Text class="u--trim" fz="3xl" fw="bold" ff="accent" c="gray">Navigation</Text>
         <Heading level="2" class="u--trim" fz="s" fw="normal" o="pp">ナビゲーション</Heading>
       </Stack>
-      <AutoColumns class="u--trimChildren" gr={['2', null, '1 / -1']} gc={['1', null, '2']} cols="14rem" g="30 40">
+      <AutoColumns class="u--trimTexts" gr={['2', null, '1 / -1']} gc={['1', null, '2']} cols="14rem" g="30 40">
         <BoxLink href="#" layout="grid" gtc="1fr auto" ai="center" g="20" py="15" hov="-c">
           <Inline>キッチン</Inline>
           <Icon icon="caret-right" />

--- a/apps/docs/src/pages/preview/templates/navigation/navigation006/index.astro
+++ b/apps/docs/src/pages/preview/templates/navigation/navigation006/index.astro
@@ -13,7 +13,7 @@ import './_style.css';
         <Text class="u--trim" fz="3xl" fw="bold" ff="accent" c="gray">Navigation</Text>
         <Heading level="2" class="u--trim" fz="s" fw="normal" o="pp">ナビゲーション</Heading>
       </Stack>
-      <AutoColumns class="u--trimTexts" gr={['2', null, '1 / -1']} gc={['1', null, '2']} cols="14rem" g="30 40">
+      <AutoColumns class="u--trimAll" gr={['2', null, '1 / -1']} gc={['1', null, '2']} cols="14rem" g="30 40">
         <BoxLink href="#" layout="grid" gtc="1fr auto" ai="center" g="20" py="15" hov="-c">
           <Inline>キッチン</Inline>
           <Icon icon="caret-right" />

--- a/apps/docs/src/pages/preview/templates/news/news005/en.astro
+++ b/apps/docs/src/pages/preview/templates/news/news005/en.astro
@@ -29,7 +29,7 @@ import './_style.css';
               </Flex>
               <Text class="u--trim" fz="s" o="pp">2025.10.30</Text>
             </Flex>
-            <Text className="u--trimHL" fz="m">Year-end and New Year holiday notice (2025/12/28 - 2026/1/4)</Text>
+            <Text class="u--trim" fz="m">Year-end and New Year holiday notice (2025/12/28 - 2026/1/4)</Text>
           </Stack>
         </Grid>
         <Grid as="a" gtr="subgrid" gr="span 2" g="5" isBoxLink href="#" ov="h" set="var:hov">
@@ -48,7 +48,7 @@ import './_style.css';
               </Flex>
               <Text class="u--trim" fz="s" o="pp">2025.10.30</Text>
             </Flex>
-            <Text className="u--trimHL" fz="m">Our project "XX" has won the international "ABC Design Award"</Text>
+            <Text class="u--trim" fz="m">Our project "XX" has won the international "ABC Design Award"</Text>
           </Stack>
         </Grid>
         <Grid as="a" gtr="subgrid" gr="span 2" g="5" isBoxLink href="#" ov="h" set="var:hov">
@@ -67,7 +67,7 @@ import './_style.css';
               </Flex>
               <Text class="u--trim" fz="s" o="pp">2025.10.30</Text>
             </Flex>
-            <Text className="u--trimHL" fz="m">Our CEO's interview featured in the November issue of "Design Today" magazine</Text>
+            <Text class="u--trim" fz="m">Our CEO's interview featured in the November issue of "Design Today" magazine</Text>
           </Stack>
         </Grid>
         <Grid as="a" gtr="subgrid" gr="span 2" g="5" isBoxLink href="#" ov="h" set="var:hov">
@@ -86,7 +86,7 @@ import './_style.css';
               </Flex>
               <Text class="u--trim" fz="s" o="pp">2025.10.30</Text>
             </Flex>
-            <Text className="u--trimHL" fz="m">Design column updated: "The Role of Logo Design in Branding"</Text>
+            <Text class="u--trim" fz="m">Design column updated: "The Role of Logo Design in Branding"</Text>
           </Stack>
         </Grid>
       </Columns>

--- a/apps/docs/src/pages/preview/templates/news/news005/index.astro
+++ b/apps/docs/src/pages/preview/templates/news/news005/index.astro
@@ -29,7 +29,7 @@ import './_style.css';
               </Flex>
               <Text class="u--trim" fz="s" o="pp">2025.10.30</Text>
             </Flex>
-            <Text className="u--trimHL" fz="m">年末年始休業のお知らせ（2025/12/28〜2026/1/4）</Text>
+            <Text class="u--trim" fz="m">年末年始休業のお知らせ（2025/12/28〜2026/1/4）</Text>
           </Stack>
         </Grid>
         <Grid as="a" gtr="subgrid" gr="span 2" g="5" isBoxLink href="#" ov="h" set="var:hov">
@@ -48,7 +48,7 @@ import './_style.css';
               </Flex>
               <Text class="u--trim" fz="s" o="pp">2025.10.30</Text>
             </Flex>
-            <Text className="u--trimHL" fz="m">当社制作の「〇〇」が、国際的デザインアワード「ABC Design Award」を受賞しました</Text>
+            <Text class="u--trim" fz="m">当社制作の「〇〇」が、国際的デザインアワード「ABC Design Award」を受賞しました</Text>
           </Stack>
         </Grid>
         <Grid as="a" gtr="subgrid" gr="span 2" g="5" isBoxLink href="#" ov="h" set="var:hov">
@@ -67,7 +67,7 @@ import './_style.css';
               </Flex>
               <Text class="u--trim" fz="s" o="pp">2025.10.30</Text>
             </Flex>
-            <Text className="u--trimHL" fz="m">デザイン専門誌「Design Today」11月号に、弊社代表のインタビューが掲載されました</Text>
+            <Text class="u--trim" fz="m">デザイン専門誌「Design Today」11月号に、弊社代表のインタビューが掲載されました</Text>
           </Stack>
         </Grid>
         <Grid as="a" gtr="subgrid" gr="span 2" g="5" isBoxLink href="#" ov="h" set="var:hov">
@@ -86,7 +86,7 @@ import './_style.css';
               </Flex>
               <Text class="u--trim" fz="s" o="pp">2025.10.30</Text>
             </Flex>
-            <Text className="u--trimHL" fz="m">デザインコラムを更新しました「ブランディングにおけるロゴデザインの役割」</Text>
+            <Text class="u--trim" fz="m">デザインコラムを更新しました「ブランディングにおけるロゴデザインの役割」</Text>
           </Stack>
         </Grid>
       </Columns>

--- a/apps/docs/src/pages/preview/templates/news/news006/en.astro
+++ b/apps/docs/src/pages/preview/templates/news/news006/en.astro
@@ -20,7 +20,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">COLUMN</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimTexts" g="30">
+            <Stack class="u--trimAll" g="30">
               <Text hasTransition hov="in:cLink">Design column: "The Importance of Accessibility in UI Design"</Text>
               <Text fz="s" o="pp"
                 >We have updated our design column. Learn about the fundamentals of web accessibility and practical tips you can implement today.</Text
@@ -37,7 +37,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">EVENT</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimTexts" g="30">
+            <Stack class="u--trimAll" g="30">
               <Text hasTransition hov="in:cLink">Speaking at "LOOS DESIGN CONFERENCE 2025"</Text>
               <Text fz="s" o="pp"
                 >Our art director will be speaking at one of the largest design conferences in the country on December 5, 2025 (Fri), on the topic
@@ -55,7 +55,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">RELEASE</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimTexts" g="30">
+            <Stack class="u--trimAll" g="30">
               <Text hasTransition hov="in:cLink">Launching "Branding Support Package for Startups"</Text>
               <Text fz="s" o="pp"
                 >We have started offering a fast and high-quality branding support package for startups. From logo to website and business cards — all
@@ -73,7 +73,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">NEWS</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimTexts" g="30">
+            <Stack class="u--trimAll" g="30">
               <Text hasTransition hov="in:cLink">Notice of office relocation and phone number change</Text>
               <Text fz="s" o="pp"
                 >Due to business expansion, we have relocated our office to the address below. We will continue to strive for excellence and

--- a/apps/docs/src/pages/preview/templates/news/news006/en.astro
+++ b/apps/docs/src/pages/preview/templates/news/news006/en.astro
@@ -20,7 +20,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">COLUMN</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimChildren" g="30">
+            <Stack class="u--trimTexts" g="30">
               <Text hasTransition hov="in:cLink">Design column: "The Importance of Accessibility in UI Design"</Text>
               <Text fz="s" o="pp"
                 >We have updated our design column. Learn about the fundamentals of web accessibility and practical tips you can implement today.</Text
@@ -37,7 +37,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">EVENT</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimChildren" g="30">
+            <Stack class="u--trimTexts" g="30">
               <Text hasTransition hov="in:cLink">Speaking at "LOOS DESIGN CONFERENCE 2025"</Text>
               <Text fz="s" o="pp"
                 >Our art director will be speaking at one of the largest design conferences in the country on December 5, 2025 (Fri), on the topic
@@ -55,7 +55,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">RELEASE</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimChildren" g="30">
+            <Stack class="u--trimTexts" g="30">
               <Text hasTransition hov="in:cLink">Launching "Branding Support Package for Startups"</Text>
               <Text fz="s" o="pp"
                 >We have started offering a fast and high-quality branding support package for startups. From logo to website and business cards — all
@@ -73,7 +73,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">NEWS</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimChildren" g="30">
+            <Stack class="u--trimTexts" g="30">
               <Text hasTransition hov="in:cLink">Notice of office relocation and phone number change</Text>
               <Text fz="s" o="pp"
                 >Due to business expansion, we have relocated our office to the address below. We will continue to strive for excellence and

--- a/apps/docs/src/pages/preview/templates/news/news006/index.astro
+++ b/apps/docs/src/pages/preview/templates/news/news006/index.astro
@@ -20,7 +20,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">COLUMN</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimChildren" g="30">
+            <Stack class="u--trimTexts" g="30">
               <Text hasTransition hov="in:cLink">デザインコラム更新「UIデザインにおけるアクセシビリティの重要性」</Text>
               <Text fz="s" o="pp"
                 >デザインコラムを更新しました。「Webアクセシビリティ」の基本的な考え方と、 今日から実践できるポイントについて解説します。</Text
@@ -37,7 +37,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">EVENT</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimChildren" g="30">
+            <Stack class="u--trimTexts" g="30">
               <Text hasTransition hov="in:cLink">「LOOS DESIGN CONFERENCE 2025」登壇のお知らせ</Text>
               <Text fz="s" o="pp"
                 >2025年12月5日（金）に開催される国内最大級のデザインカンファレンスに、弊社アートディレクターの〇〇が登壇。「デザインがビジネスにもたらす価値」についてお話しします。</Text
@@ -54,7 +54,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">RELEASE</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimChildren" g="30">
+            <Stack class="u--trimTexts" g="30">
               <Text hasTransition hov="in:cLink">新サービス「スタートアップ向けブランディング支援パッケージ」提供開始</Text>
               <Text fz="s" o="pp"
                 >スタートアップ企業様を対象としたスピーディーかつ高品質なブランディング支援パッケージの提供を開始しました。
@@ -72,7 +72,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">NEWS</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimChildren" g="30">
+            <Stack class="u--trimTexts" g="30">
               <Text hasTransition hov="in:cLink">オフィス移転および電話番号変更のお知らせ</Text>
               <Text fz="s" o="pp"
                 >業務拡大に伴いオフィスを下記住所へ移転いたしました。

--- a/apps/docs/src/pages/preview/templates/news/news006/index.astro
+++ b/apps/docs/src/pages/preview/templates/news/news006/index.astro
@@ -20,7 +20,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">COLUMN</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimTexts" g="30">
+            <Stack class="u--trimAll" g="30">
               <Text hasTransition hov="in:cLink">デザインコラム更新「UIデザインにおけるアクセシビリティの重要性」</Text>
               <Text fz="s" o="pp"
                 >デザインコラムを更新しました。「Webアクセシビリティ」の基本的な考え方と、 今日から実践できるポイントについて解説します。</Text
@@ -37,7 +37,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">EVENT</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimTexts" g="30">
+            <Stack class="u--trimAll" g="30">
               <Text hasTransition hov="in:cLink">「LOOS DESIGN CONFERENCE 2025」登壇のお知らせ</Text>
               <Text fz="s" o="pp"
                 >2025年12月5日（金）に開催される国内最大級のデザインカンファレンスに、弊社アートディレクターの〇〇が登壇。「デザインがビジネスにもたらす価値」についてお話しします。</Text
@@ -54,7 +54,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">RELEASE</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimTexts" g="30">
+            <Stack class="u--trimAll" g="30">
               <Text hasTransition hov="in:cLink">新サービス「スタートアップ向けブランディング支援パッケージ」提供開始</Text>
               <Text fz="s" o="pp"
                 >スタートアップ企業様を対象としたスピーディーかつ高品質なブランディング支援パッケージの提供を開始しました。
@@ -72,7 +72,7 @@ import './_style.css';
             <Text d="if" jc="center" fz="2xs" lh="1" bgc="base-2" c="text" p="10 20" bdrs="99">NEWS</Text>
           </Grid>
           <Flex c="text" g="30">
-            <Stack class="u--trimTexts" g="30">
+            <Stack class="u--trimAll" g="30">
               <Text hasTransition hov="in:cLink">オフィス移転および電話番号変更のお知らせ</Text>
               <Text fz="s" o="pp"
                 >業務拡大に伴いオフィスを下記住所へ移転いたしました。

--- a/apps/docs/src/pages/preview/templates/section/section012/en.astro
+++ b/apps/docs/src/pages/preview/templates/section/section012/en.astro
@@ -16,7 +16,7 @@ import './_style.css';
     <Container isWrapper="m" gr="1" gc="1" hasGutter pos="relative" z="1">
       <Grid gtc={['auto', null, 'auto 1fr']} c="white" g="50" py="50">
         <Heading level="2" class="u--trim" fz="3xl" fw="bold" hl="l">Healing Moments Born<br />from Natural Materials</Heading>
-        <Stack class="u--trimTexts" g="40">
+        <Stack class="u--trimAll" g="40">
           <p>
             Close your eyes, and you'll feel as if you're bathed in the dappled sunlight of a forest, with an overwhelming sense of immersion. This
             speaker was created to reproduce recorded natural sounds in a three-dimensional and incredibly realistic way.

--- a/apps/docs/src/pages/preview/templates/section/section012/en.astro
+++ b/apps/docs/src/pages/preview/templates/section/section012/en.astro
@@ -16,7 +16,7 @@ import './_style.css';
     <Container isWrapper="m" gr="1" gc="1" hasGutter pos="relative" z="1">
       <Grid gtc={['auto', null, 'auto 1fr']} c="white" g="50" py="50">
         <Heading level="2" class="u--trim" fz="3xl" fw="bold" hl="l">Healing Moments Born<br />from Natural Materials</Heading>
-        <Stack class="u--trimChildren" g="40">
+        <Stack class="u--trimTexts" g="40">
           <p>
             Close your eyes, and you'll feel as if you're bathed in the dappled sunlight of a forest, with an overwhelming sense of immersion. This
             speaker was created to reproduce recorded natural sounds in a three-dimensional and incredibly realistic way.

--- a/apps/docs/src/pages/preview/templates/section/section012/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section012/index.astro
@@ -16,7 +16,7 @@ import './_style.css';
     <Container isWrapper="m" gr="1" gc="1" hasGutter pos="relative" z="1">
       <Grid gtc={['auto', null, 'auto 1fr']} c="white" g="50" py="50">
         <Heading level="2" class="u--trim" fz="3xl" fw="bold" hl="l">自然素材が生み出す<br />癒やしのひととき</Heading>
-        <Stack class="u--trimTexts" g="40">
+        <Stack class="u--trimAll" g="40">
           <p>
             目を閉じれば、まるで森の木漏れ日の中にいるかのような、圧倒的な臨場感。
             このスピーカーは、録音された自然音を、立体的に、そして限りなくリアルに再現するために生まれました。

--- a/apps/docs/src/pages/preview/templates/section/section012/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section012/index.astro
@@ -16,7 +16,7 @@ import './_style.css';
     <Container isWrapper="m" gr="1" gc="1" hasGutter pos="relative" z="1">
       <Grid gtc={['auto', null, 'auto 1fr']} c="white" g="50" py="50">
         <Heading level="2" class="u--trim" fz="3xl" fw="bold" hl="l">自然素材が生み出す<br />癒やしのひととき</Heading>
-        <Stack class="u--trimChildren" g="40">
+        <Stack class="u--trimTexts" g="40">
           <p>
             目を閉じれば、まるで森の木漏れ日の中にいるかのような、圧倒的な臨場感。
             このスピーカーは、録音された自然音を、立体的に、そして限りなくリアルに再現するために生まれました。

--- a/apps/docs/src/pages/preview/templates/section/section016/en.astro
+++ b/apps/docs/src/pages/preview/templates/section/section016/en.astro
@@ -13,7 +13,7 @@ import './_style.css';
           <Heading level="2" class="u--trim" fz="5xl" fw="bold">Relaxing</Heading>
           <Text class="u--trim" fz="l">Crisp, clean air that makes you want to take a deep breath</Text>
         </Stack>
-        <Stack class="u--trimChildren" g="40">
+        <Stack class="u--trimTexts" g="40">
           <p>
             Bring the refreshing, crisp air of a highland forest right into your room. The high-performance filter thoroughly removes invisible fine
             particles and household odors, keeping your space clean and pure. With a whisper-quiet design you'll forget is even running, it's perfect

--- a/apps/docs/src/pages/preview/templates/section/section016/en.astro
+++ b/apps/docs/src/pages/preview/templates/section/section016/en.astro
@@ -13,7 +13,7 @@ import './_style.css';
           <Heading level="2" class="u--trim" fz="5xl" fw="bold">Relaxing</Heading>
           <Text class="u--trim" fz="l">Crisp, clean air that makes you want to take a deep breath</Text>
         </Stack>
-        <Stack class="u--trimTexts" g="40">
+        <Stack class="u--trimAll" g="40">
           <p>
             Bring the refreshing, crisp air of a highland forest right into your room. The high-performance filter thoroughly removes invisible fine
             particles and household odors, keeping your space clean and pure. With a whisper-quiet design you'll forget is even running, it's perfect

--- a/apps/docs/src/pages/preview/templates/section/section016/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section016/index.astro
@@ -13,7 +13,7 @@ import './_style.css';
           <Heading level="2" class="u--trim" fz="5xl" fw="bold">Relaxing</Heading>
           <Text class="u--trim" fz="l">深呼吸したくなる、澄んだ空気</Text>
         </Stack>
-        <Stack class="u--trimTexts" g="40">
+        <Stack class="u--trimAll" g="40">
           <p>
             まるで高原の森にいるような、清々しく澄んだ空気を、あなたの部屋へ。
             高性能フィルターが、目に見えない微細な粒子や生活臭をしっかりと除去し、空間を清浄に保ちます。

--- a/apps/docs/src/pages/preview/templates/section/section016/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section016/index.astro
@@ -13,7 +13,7 @@ import './_style.css';
           <Heading level="2" class="u--trim" fz="5xl" fw="bold">Relaxing</Heading>
           <Text class="u--trim" fz="l">深呼吸したくなる、澄んだ空気</Text>
         </Stack>
-        <Stack class="u--trimChildren" g="40">
+        <Stack class="u--trimTexts" g="40">
           <p>
             まるで高原の森にいるような、清々しく澄んだ空気を、あなたの部屋へ。
             高性能フィルターが、目に見えない微細な粒子や生活臭をしっかりと除去し、空間を清浄に保ちます。

--- a/apps/docs/src/pages/preview/templates/section/section902-2/en.astro
+++ b/apps/docs/src/pages/preview/templates/section/section902-2/en.astro
@@ -15,7 +15,7 @@ import './_style.css';
             <Heading level="2" class="u--trim" fz="3xl" fw="bold" lts="l" c="gray"
               >A Comfortable Temperature<br />That Makes You Want<br />to Take a Deep Breath</Heading
             >
-            <Stack class="u--trimChildren" g="20">
+            <Stack class="u--trimTexts" g="20">
               <p>
                 Bring the refreshing, crisp air of a highland forest right into your room. The high-performance filter thoroughly removes invisible
                 fine particles and household odors, keeping your space clean and pure. With a whisper-quiet design you'll forget is even running, it's

--- a/apps/docs/src/pages/preview/templates/section/section902-2/en.astro
+++ b/apps/docs/src/pages/preview/templates/section/section902-2/en.astro
@@ -15,7 +15,7 @@ import './_style.css';
             <Heading level="2" class="u--trim" fz="3xl" fw="bold" lts="l" c="gray"
               >A Comfortable Temperature<br />That Makes You Want<br />to Take a Deep Breath</Heading
             >
-            <Stack class="u--trimTexts" g="20">
+            <Stack class="u--trimAll" g="20">
               <p>
                 Bring the refreshing, crisp air of a highland forest right into your room. The high-performance filter thoroughly removes invisible
                 fine particles and household odors, keeping your space clean and pure. With a whisper-quiet design you'll forget is even running, it's

--- a/apps/docs/src/pages/preview/templates/section/section902-2/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section902-2/index.astro
@@ -13,7 +13,7 @@ import './_style.css';
         <Stack gr="1" gc={['1', null, '2']} pr={[null, null, '40']}>
           <Stack g="40" px={['30', null, '0']} h="100%">
             <Heading level="2" class="u--trim" fz="3xl" fw="bold" lts="l" c="gray">深呼吸したくなる<br />快適な室温を<br />あなたの日常に</Heading>
-            <Stack class="u--trimTexts" g="20">
+            <Stack class="u--trimAll" g="20">
               <p>
                 まるで高原の森にいるような、清々しく澄んだ空気を、あなたの部屋へ。
                 高性能フィルターが、目に見えない微細な粒子や生活臭をしっかりと除去し、空間を清浄に保ちます。

--- a/apps/docs/src/pages/preview/templates/section/section902-2/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section902-2/index.astro
@@ -13,7 +13,7 @@ import './_style.css';
         <Stack gr="1" gc={['1', null, '2']} pr={[null, null, '40']}>
           <Stack g="40" px={['30', null, '0']} h="100%">
             <Heading level="2" class="u--trim" fz="3xl" fw="bold" lts="l" c="gray">深呼吸したくなる<br />快適な室温を<br />あなたの日常に</Heading>
-            <Stack class="u--trimChildren" g="20">
+            <Stack class="u--trimTexts" g="20">
               <p>
                 まるで高原の森にいるような、清々しく澄んだ空気を、あなたの部屋へ。
                 高性能フィルターが、目に見えない微細な粒子や生活臭をしっかりと除去し、空間を清浄に保ちます。

--- a/apps/docs/src/pages/preview/templates/section/section902/en.astro
+++ b/apps/docs/src/pages/preview/templates/section/section902/en.astro
@@ -15,7 +15,7 @@ import './_style.css';
             <Heading level="2" class="u--trim" fz="3xl" fw="bold" lts="l" c="gray"
               >A Comfortable Temperature<br />That Makes You Want<br />to Take a Deep Breath</Heading
             >
-            <Stack class="u--trimChildren" g="20">
+            <Stack class="u--trimTexts" g="20">
               <p>
                 Bring the refreshing, crisp air of a highland forest right into your room. The high-performance filter thoroughly removes invisible
                 fine particles and household odors, keeping your space clean and pure. With a whisper-quiet design you'll forget is even running, it's

--- a/apps/docs/src/pages/preview/templates/section/section902/en.astro
+++ b/apps/docs/src/pages/preview/templates/section/section902/en.astro
@@ -15,7 +15,7 @@ import './_style.css';
             <Heading level="2" class="u--trim" fz="3xl" fw="bold" lts="l" c="gray"
               >A Comfortable Temperature<br />That Makes You Want<br />to Take a Deep Breath</Heading
             >
-            <Stack class="u--trimTexts" g="20">
+            <Stack class="u--trimAll" g="20">
               <p>
                 Bring the refreshing, crisp air of a highland forest right into your room. The high-performance filter thoroughly removes invisible
                 fine particles and household odors, keeping your space clean and pure. With a whisper-quiet design you'll forget is even running, it's

--- a/apps/docs/src/pages/preview/templates/section/section902/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section902/index.astro
@@ -13,7 +13,7 @@ import './_style.css';
         <Stack gr="1" gc="1" pl={[null, null, '30']}>
           <Stack g="40" px={['30', null, '0']} h="100%">
             <Heading level="2" class="u--trim" fz="3xl" fw="bold" lts="l" c="gray">深呼吸したくなる<br />快適な室温を<br />あなたの日常に</Heading>
-            <Stack class="u--trimChildren" g="20">
+            <Stack class="u--trimTexts" g="20">
               <p>
                 まるで高原の森にいるような、清々しく澄んだ空気を、あなたの部屋へ。
                 高性能フィルターが、目に見えない微細な粒子や生活臭をしっかりと除去し、空間を清浄に保ちます。

--- a/apps/docs/src/pages/preview/templates/section/section902/index.astro
+++ b/apps/docs/src/pages/preview/templates/section/section902/index.astro
@@ -13,7 +13,7 @@ import './_style.css';
         <Stack gr="1" gc="1" pl={[null, null, '30']}>
           <Stack g="40" px={['30', null, '0']} h="100%">
             <Heading level="2" class="u--trim" fz="3xl" fw="bold" lts="l" c="gray">深呼吸したくなる<br />快適な室温を<br />あなたの日常に</Heading>
-            <Stack class="u--trimTexts" g="20">
+            <Stack class="u--trimAll" g="20">
               <p>
                 まるで高原の森にいるような、清々しく澄んだ空気を、あなたの部屋へ。
                 高性能フィルターが、目に見えない微細な粒子や生活臭をしっかりと除去し、空間を清浄に保ちます。

--- a/apps/docs/src/pages/preview/templates/works/works002/en.astro
+++ b/apps/docs/src/pages/preview/templates/works/works002/en.astro
@@ -34,7 +34,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">Making Everyday Cooking an Exciting Experience</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -58,7 +58,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">Items That Elevate the Quality of Daily Life</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -81,7 +81,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">An Object-like Presence</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -105,7 +105,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">Quiet and Clean Design</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -129,7 +129,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">Audio That Displays Music as Art in Your Space</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -152,7 +152,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">Dramatically Staging Your Space</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>

--- a/apps/docs/src/pages/preview/templates/works/works002/en.astro
+++ b/apps/docs/src/pages/preview/templates/works/works002/en.astro
@@ -34,7 +34,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">Making Everyday Cooking an Exciting Experience</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -58,7 +58,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">Items That Elevate the Quality of Daily Life</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -81,7 +81,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">An Object-like Presence</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -105,7 +105,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">Quiet and Clean Design</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -129,7 +129,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">Audio That Displays Music as Art in Your Space</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -152,7 +152,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">Dramatically Staging Your Space</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>

--- a/apps/docs/src/pages/preview/templates/works/works002/index.astro
+++ b/apps/docs/src/pages/preview/templates/works/works002/index.astro
@@ -34,7 +34,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">毎日の料理を心躍る体験に</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -58,7 +58,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">日々の暮らしの質を高めるアイテム</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -81,7 +81,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">オブジェのような佇まい</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -105,7 +105,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">静かでクリーンなデザイン</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -129,7 +129,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">音楽をアートのように空間に飾るオーディオ</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -152,7 +152,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">空間をドラマチックに演出</Text>
-              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimAll" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>

--- a/apps/docs/src/pages/preview/templates/works/works002/index.astro
+++ b/apps/docs/src/pages/preview/templates/works/works002/index.astro
@@ -34,7 +34,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">毎日の料理を心躍る体験に</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -58,7 +58,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">日々の暮らしの質を高めるアイテム</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -81,7 +81,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">オブジェのような佇まい</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -105,7 +105,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">静かでクリーンなデザイン</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -129,7 +129,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">音楽をアートのように空間に飾るオーディオ</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>
@@ -152,7 +152,7 @@ import './_style.css';
             </Frame>
             <Stack g="30">
               <Text class="u--trim" fz="m" fw="bold">空間をドラマチックに演出</Text>
-              <Stack class="u--trimChildren" as="dl" g="15" fz="s" o="pp">
+              <Stack class="u--trimTexts" as="dl" g="15" fz="s" o="pp">
                 <Flex g="5"><dt>Director:</dt><dd>Takahashi Kenta</dd></Flex>
                 <Flex g="5"><dt>Designer:</dt><dd>Sato Misaki</dd></Flex>
               </Stack>

--- a/packages/lism-css/src/lib/types/TraitProps.spec-d.ts
+++ b/packages/lism-css/src/lib/types/TraitProps.spec-d.ts
@@ -127,7 +127,7 @@ describe('LismPropsBase — set / util', () => {
     it('プリセット値を受け付ける', () => {
       assertType<LismPropsBase>({ util: 'cbox' });
       assertType<LismPropsBase>({ util: 'trim' });
-      assertType<LismPropsBase>({ util: 'trimChildren' });
+      assertType<LismPropsBase>({ util: 'trimTexts' });
       assertType<LismPropsBase>({ util: 'srOnly' });
       assertType<LismPropsBase>({ util: 'clipText' });
       assertType<LismPropsBase>({ util: 'divide' });

--- a/packages/lism-css/src/lib/types/TraitProps.spec-d.ts
+++ b/packages/lism-css/src/lib/types/TraitProps.spec-d.ts
@@ -127,7 +127,7 @@ describe('LismPropsBase — set / util', () => {
     it('プリセット値を受け付ける', () => {
       assertType<LismPropsBase>({ util: 'cbox' });
       assertType<LismPropsBase>({ util: 'trim' });
-      assertType<LismPropsBase>({ util: 'trimTexts' });
+      assertType<LismPropsBase>({ util: 'trimAll' });
       assertType<LismPropsBase>({ util: 'srOnly' });
       assertType<LismPropsBase>({ util: 'clipText' });
       assertType<LismPropsBase>({ util: 'divide' });

--- a/packages/lism-css/src/lib/types/TraitProps.ts
+++ b/packages/lism-css/src/lib/types/TraitProps.ts
@@ -55,7 +55,7 @@ type SetPreset = 'plain' | 'revert' | 'var:hov' | 'var:bxsh' | 'var:bdrsInner';
 export type SetPropValue = WithArbitraryString<SetPreset> | WithArbitraryString<SetPreset>[];
 
 /** util prop で使われるプリセット値（既知の `u--` クラス名・エディタ補完用） */
-type UtilPreset = 'cbox' | 'trim' | 'trimTexts' | 'srOnly' | 'clipText' | 'divide' | 'cells';
+type UtilPreset = 'cbox' | 'trim' | 'trimAll' | 'srOnly' | 'clipText' | 'divide' | 'cells';
 
 /**
  * util prop の値の型。既知の `u--` クラス名がサジェストされつつ、任意の文字列も受け付ける。

--- a/packages/lism-css/src/lib/types/TraitProps.ts
+++ b/packages/lism-css/src/lib/types/TraitProps.ts
@@ -55,7 +55,7 @@ type SetPreset = 'plain' | 'revert' | 'var:hov' | 'var:bxsh' | 'var:bdrsInner';
 export type SetPropValue = WithArbitraryString<SetPreset> | WithArbitraryString<SetPreset>[];
 
 /** util prop で使われるプリセット値（既知の `u--` クラス名・エディタ補完用） */
-type UtilPreset = 'cbox' | 'trim' | 'trimChildren' | 'srOnly' | 'clipText' | 'divide' | 'cells';
+type UtilPreset = 'cbox' | 'trim' | 'trimTexts' | 'srOnly' | 'clipText' | 'divide' | 'cells';
 
 /**
  * util prop の値の型。既知の `u--` クラス名がサジェストされつつ、任意の文字列も受け付ける。

--- a/packages/lism-css/src/scss/utility/_trimHL.scss
+++ b/packages/lism-css/src/scss/utility/_trimHL.scss
@@ -1,38 +1,14 @@
 /*
   ハーフレディングをトリミングするユーティリティクラス。
-    Memo: そのうち text-box-trim が使えるようになる
  */
-
 .u--trim {
-  // 詰まりすぎにならないようにほんの少しだけ余裕を持たせる
-  // margin-block: calc(0.5px + var(--HL) * -1);
   margin-block: calc(var(--hl) * -1);
 }
 
-// 子要素の一括トリミング
-.u--trimChildren {
-  > * {
+// 子要素のテキスト系要素を一括トリミング（ホワイトリスト方式）
+.u--trimTexts {
+  > :where(p, h1, h2, h3, h4, h5, h6, ul, ol) {
     --my: calc(var(--hl) * -1);
     margin-block: var(--my);
   }
-
-  /*
-	 * トリミング除外要素
-	 *   Memo: --hl を 0 にはしないようにする.
-	*/
-  > :where(figure, img, button) {
-    --my: 0px;
-  }
 }
-
-// .u--trimBox {
-// 	:where(&) > * {
-// 		--trimHL: calc(0.5px + var(--HL) * -1);
-// 	}
-// 	> :first-child {
-// 		margin-block-start: var(--trimHL);
-// 	}
-// 	> :last-child {
-// 		margin-block-end: var(--trimHL);
-// 	}
-// }

--- a/packages/lism-css/src/scss/utility/_trimHL.scss
+++ b/packages/lism-css/src/scss/utility/_trimHL.scss
@@ -5,10 +5,8 @@
   margin-block: calc(var(--hl) * -1);
 }
 
-// 子要素のテキスト系要素を一括トリミング（ホワイトリスト方式）
-.u--trimTexts {
-  > :where(p, h1, h2, h3, h4, h5, h6, ul, ol) {
-    --my: calc(var(--hl) * -1);
-    margin-block: var(--my);
-  }
+// 子要素の一括トリミング
+// :empty → img, hr, input, br などにもマッチ。かつ中身のない装飾 a--divider や a--spacer もこれだけで除外できる
+.u--trimAll > :not(:empty, figure, picture, video, button, textarea, table) {
+  margin-block: calc(var(--hl) * -1);
 }

--- a/packages/mcp/src/data/docs-index.json
+++ b/packages/mcp/src/data/docs-index.json
@@ -230,7 +230,7 @@
     "title": "Utility Class",
     "description": "スタイルや装飾をまとめて適用できる Lism CSS のユーティリティクラスについて解説します。",
     "category": "guide",
-    "headings": ["u--cbox", "u--trim & u--trimChildren", "u--srOnly", "u--divide & u--cells", "u--clipText", "Opt-in"],
+    "headings": ["u--cbox", "u--trim & u--trimTexts", "u--srOnly", "u--divide & u--cells", "u--clipText", "Opt-in"],
     "keywords": ["utility", "ユーティリティ", "class", "クラス", "u--cbox", "u--trim", "u--srOnly", "u--divide", "u--cells", "u--clipText"],
     "snippet": "用途が明確な装飾・機能をまとめてセットするユーティリティクラス (.u--{style}) の一覧。u--cbox, u--trim, u--divide, u--cells 等を解説。"
   },
@@ -961,12 +961,12 @@
   },
   {
     "sourcePath": "utility-class.mdx",
-    "title": "u--trim / u--trimChildren",
+    "title": "u--trim / u--trimTexts",
     "description": "テキストのハーフレディング分の余白を調整するユーティリティクラス。",
     "category": "guide",
-    "headings": ["u--trim", "u--trimChildren"],
-    "keywords": ["u--trim", "u--trimChildren", "ハーフレディング", "行間調整", "テキスト余白", "margin-block", "トリム"],
-    "snippet": "u--trimは自身のmargin-blockを調整。u--trimChildrenは子要素全ての上下マージンを調整。img, figure, tableに対してはマージン調節を無効化。"
+    "headings": ["u--trim", "u--trimTexts"],
+    "keywords": ["u--trim", "u--trimTexts", "ハーフレディング", "行間調整", "テキスト余白", "margin-block", "トリム"],
+    "snippet": "u--trimは自身のmargin-blockを調整。u--trimTextsは直下のテキスト系要素（p, h1-h6, ul, ol）の上下マージンを一括調整するホワイトリスト方式のクラス。"
   },
   {
     "sourcePath": "trait-class/is--boxLink.mdx",

--- a/packages/mcp/src/data/docs-index.json
+++ b/packages/mcp/src/data/docs-index.json
@@ -230,7 +230,7 @@
     "title": "Utility Class",
     "description": "スタイルや装飾をまとめて適用できる Lism CSS のユーティリティクラスについて解説します。",
     "category": "guide",
-    "headings": ["u--cbox", "u--trim & u--trimTexts", "u--srOnly", "u--divide & u--cells", "u--clipText", "Opt-in"],
+    "headings": ["u--cbox", "u--trim & u--trimAll", "u--srOnly", "u--divide & u--cells", "u--clipText", "Opt-in"],
     "keywords": ["utility", "ユーティリティ", "class", "クラス", "u--cbox", "u--trim", "u--srOnly", "u--divide", "u--cells", "u--clipText"],
     "snippet": "用途が明確な装飾・機能をまとめてセットするユーティリティクラス (.u--{style}) の一覧。u--cbox, u--trim, u--divide, u--cells 等を解説。"
   },
@@ -961,12 +961,12 @@
   },
   {
     "sourcePath": "utility-class.mdx",
-    "title": "u--trim / u--trimTexts",
+    "title": "u--trim / u--trimAll",
     "description": "テキストのハーフレディング分の余白を調整するユーティリティクラス。",
     "category": "guide",
-    "headings": ["u--trim", "u--trimTexts"],
-    "keywords": ["u--trim", "u--trimTexts", "ハーフレディング", "行間調整", "テキスト余白", "margin-block", "トリム"],
-    "snippet": "u--trimは自身のmargin-blockを調整。u--trimTextsは直下のテキスト系要素（p, h1-h6, ul, ol）の上下マージンを一括調整するホワイトリスト方式のクラス。"
+    "headings": ["u--trim", "u--trimAll"],
+    "keywords": ["u--trim", "u--trimAll", "ハーフレディング", "行間調整", "テキスト余白", "margin-block", "トリム"],
+    "snippet": "u--trimは自身のmargin-blockを調整。u--trimAllは直下の子要素（:empty・figure・picture・video・button・textarea・table を除く）の上下マージンを一括調整する除外方式のクラス。"
   },
   {
     "sourcePath": "trait-class/is--boxLink.mdx",

--- a/skills/lism-css-guide/utility-class.md
+++ b/skills/lism-css-guide/utility-class.md
@@ -27,7 +27,7 @@ Lism コンポーネントでの `util` prop による指定方法は [component
 | クラス | 用途 | ソースファイル |
 |--------|------|---------------|
 | `u--trim` | ハーフレディングのネガティブマージンでテキスト上下の余白を詰める | [`_trimHL.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_trimHL.scss) |
-| `u--trimTexts` | 子要素のテキスト系要素（`p`, `h1`〜`h6`, `ul`, `ol`）にハーフレディングトリムを適用するホワイトリスト方式のクラス | [`_trimHL.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_trimHL.scss) |
+| `u--trimAll` | 直下の子要素（`:empty`, `figure`, `picture`, `video`, `button`, `textarea`, `table` を除く）にハーフレディングトリムを一括適用する除外方式のクラス | [`_trimHL.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_trimHL.scss) |
 | `u--cbox` | `--keycolor` を使い `color-mix()` で `--c` / `--bgc` / `--bdc` を自動生成する色付きボックス | [`_cbox.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_cbox.scss) |
 | `u--divide` | Grid / Flex の子要素**間**にのみ `box-shadow` で区切り線を表示する | [`_divide.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_divide.scss) |
 | `u--cells` | Grid / Flex の各子要素を `box-shadow` で枠囲みし、table セル風に表示する | [`_divide.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_divide.scss) |

--- a/skills/lism-css-guide/utility-class.md
+++ b/skills/lism-css-guide/utility-class.md
@@ -27,7 +27,7 @@ Lism コンポーネントでの `util` prop による指定方法は [component
 | クラス | 用途 | ソースファイル |
 |--------|------|---------------|
 | `u--trim` | ハーフレディングのネガティブマージンでテキスト上下の余白を詰める | [`_trimHL.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_trimHL.scss) |
-| `u--trimChildren` | 子要素すべてにハーフレディングトリムを適用（`img`, `figure`, `button` は除外） | [`_trimHL.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_trimHL.scss) |
+| `u--trimTexts` | 子要素のテキスト系要素（`p`, `h1`〜`h6`, `ul`, `ol`）にハーフレディングトリムを適用するホワイトリスト方式のクラス | [`_trimHL.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_trimHL.scss) |
 | `u--cbox` | `--keycolor` を使い `color-mix()` で `--c` / `--bgc` / `--bdc` を自動生成する色付きボックス | [`_cbox.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_cbox.scss) |
 | `u--divide` | Grid / Flex の子要素**間**にのみ `box-shadow` で区切り線を表示する | [`_divide.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_divide.scss) |
 | `u--cells` | Grid / Flex の各子要素を `box-shadow` で枠囲みし、table セル風に表示する | [`_divide.scss`](https://raw.githubusercontent.com/lism-css/lism-css/main/packages/lism-css/src/scss/utility/_divide.scss) |


### PR DESCRIPTION
## Summary

`u--trimChildren` を `u--trimTexts` にリネームし、トリム対象をブラックリスト方式（`figure, img, button` を除外）からホワイトリスト方式（`p, h1-h6, ul, ol` のみ）に変更しました。

### 変更の背景

- **命名**: `Children` は Lism の他クラスで使わない独自語彙。`u--trim`（単数＝自身）と `u--trimTexts`（複数＝内側のテキスト群）の対で、単数/複数が対象の数と一致するようにした。
- **ブラックリスト方式の網羅性**: `figure, img, button` のみ除外では不十分（`svg, hr, video, iframe, table` 等もトリムすべきでない）。真面目に除外リストを書くとキリがない。
- **汎用 `<div>` への誤爆**: `<Stack>` 等の子に `<Box>` / `<Flex>` / `<Layer>` を置いたときにトリムされ、内部の余白設計と競合しやすい。

### 対象要素リスト

`p, h1, h2, h3, h4, h5, h6, ul, ol`

`blockquote` / `pre` / `figcaption` / `dl` は登場頻度が低く入れ子構造が特殊で誤爆しやすいので対象外。必要なら個別に `u--trim` を付ける運用。

Closes #324

## Changes

- `packages/lism-css/src/scss/utility/_trimHL.scss` — `.u--trimChildren` → `.u--trimTexts`、セレクタをホワイトリスト化
- `packages/lism-css/src/lib/types/TraitProps.ts` / `TraitProps.spec-d.ts` — `UtilPreset` のリテラル値 `'trimChildren'` → `'trimTexts'`
- `apps/docs/src/content/{ja,en}/utility-class.mdx` — 見出し・本文・コード例を更新
- `apps/docs/src/content/{ja,en}/primitives/l--columns.mdx` — `util="trimChildren"` を `util="trimTexts"` に
- `apps/docs/src/content/{ja,en}/ui/Modal.mdx` — 同上
- `apps/docs/src/content/{ja,en}/changelog.mdx` — #324 の破壊的変更エントリを追加
- `apps/docs/src/pages/preview/templates/**` — 29 ファイルの `u--trimChildren` を一括置換
- `apps/docs/src/components/parts/PostCard.astro` — `u--trimChildren` → `u--trimTexts`
- `skills/lism-css-guide/utility-class.md` — 説明を新方式に更新
- `packages/mcp/src/data/docs-index.json` — タイトル・headings・keywords・snippet を更新

## Test plan

- [x] `nr lint` — 成功（既存の warning のみ）
- [x] `nr typecheck` — 成功（0 errors）
- [x] `nr test` — 全テスト通過（lism-css: 655 / mcp: 51 / cli: 19 / ui: 7 / catalog: 147）
- [x] リポジトリ全体で `trimChildren` が残っていないことを確認（残存は changelog の履歴エントリのみ）