### PR TITLE
fix(docs): /docs/ui/* と /[lang]/docs/ui/* の重複ルート生成を抑止

### DIFF
--- a/apps/docs/src/lib/content.ts
+++ b/apps/docs/src/lib/content.ts
@@ -82,10 +82,19 @@ export async function getAllPosts(includeDraft = import.meta.env.DEV): Promise<
 }
 
 /**
- * root言語の全slugを取得（非root言語のフォールバック用パス生成）
+ * docs セクションの記事一覧を取得（id が ui/ で始まらないもの）
+ * /docs/* および /[lang]/docs/* / OG / Pagefind 等の入力として使用
  */
-export async function getRootLangSlugs(includeDraft = import.meta.env.DEV): Promise<string[]> {
-  const rootLang = getRootLang();
-  const posts = await getPostsByLang(rootLang, includeDraft);
-  return posts.map((post) => post.id);
+export async function getDocsPostsByLang(lang: LangCode, includeDraft = import.meta.env.DEV): Promise<PostEntry[]> {
+  const posts = await getPostsByLang(lang, includeDraft);
+  return posts.filter((post) => !post.id.startsWith('ui/'));
+}
+
+/**
+ * UI セクションの記事一覧を取得（id が ui/ で始まるもの）
+ * /ui/* および /[lang]/ui/* / OG 等の入力として使用
+ */
+export async function getUiPostsByLang(lang: LangCode, includeDraft = import.meta.env.DEV): Promise<PostEntry[]> {
+  const posts = await getPostsByLang(lang, includeDraft);
+  return posts.filter((post) => post.id.startsWith('ui/'));
 }

--- a/apps/docs/src/lib/pageHelpers.ts
+++ b/apps/docs/src/lib/pageHelpers.ts
@@ -241,27 +241,31 @@ export interface OgPath {
 
 /**
  * OG画像用のgetStaticPaths（root言語用）
+ * ui/ プレフィックスは /ui/og/* 専用エンドポイントで処理するため除外する
  */
 export async function getOgPathsForRoot(): Promise<OgPath[]> {
   const rootLang = getRootLang();
   const posts = await getPostsByLang(rootLang);
 
-  return posts.map((post) => ({
-    params: { slug: post.id },
-    props: { lang: rootLang, slug: post.id },
-  }));
+  return posts
+    .filter((post) => !post.id.startsWith('ui/'))
+    .map((post) => ({
+      params: { slug: post.id },
+      props: { lang: rootLang, slug: post.id },
+    }));
 }
 
 /**
  * OG画像用のgetStaticPaths（非root言語用）
+ * ui/ プレフィックスは /[lang]/ui/og/* 専用エンドポイントで処理するため除外する
  */
 export async function getOgPathsForNonRoot(): Promise<OgPath[]> {
   const rootLang = getRootLang();
   const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
 
-  // root言語の全記事を取得してslugリストを作成
+  // root言語の全記事を取得してslugリストを作成（ui/ は除外）
   const rootPosts = await getPostsByLang(rootLang);
-  const rootSlugs = rootPosts.map((post) => post.id);
+  const rootSlugs = rootPosts.filter((post) => !post.id.startsWith('ui/')).map((post) => post.id);
 
   const paths: OgPath[] = [];
 
@@ -270,6 +274,48 @@ export async function getOgPathsForNonRoot(): Promise<OgPath[]> {
       paths.push({
         params: { lang, slug },
         props: { lang, slug },
+      });
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * UIコンポーネントOG画像用のgetStaticPaths（root言語用）
+ * URLは ui/ プレフィックスを除去した形（例: /ui/og/accordion.png）
+ * 内部の generateOgImage には ui/ 付きの id を渡してコンテンツを引く
+ */
+export async function getUiOgPathsForRoot(): Promise<OgPath[]> {
+  const rootLang = getRootLang();
+  const posts = await getPostsByLang(rootLang);
+
+  return posts
+    .filter((post) => post.id.startsWith('ui/'))
+    .map((post) => ({
+      params: { slug: post.id.replace(/^ui\//, '') },
+      props: { lang: rootLang, slug: post.id },
+    }));
+}
+
+/**
+ * UIコンポーネントOG画像用のgetStaticPaths（非root言語用）
+ * URLは ui/ プレフィックスを除去した形（例: /en/ui/og/accordion.png）
+ */
+export async function getUiOgPathsForNonRoot(): Promise<OgPath[]> {
+  const rootLang = getRootLang();
+  const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
+
+  const rootPosts = await getPostsByLang(rootLang);
+  const uiPosts = rootPosts.filter((post) => post.id.startsWith('ui/'));
+
+  const paths: OgPath[] = [];
+
+  for (const lang of nonRootLangs) {
+    for (const post of uiPosts) {
+      paths.push({
+        params: { lang, slug: post.id.replace(/^ui\//, '') },
+        props: { lang, slug: post.id },
       });
     }
   }

--- a/apps/docs/src/lib/pageHelpers.ts
+++ b/apps/docs/src/lib/pageHelpers.ts
@@ -30,25 +30,29 @@ export interface PostPathNonRoot {
 
 /**
  * 記事詳細ページ用のgetStaticPaths（root言語用）
+ * ui/ プレフィックスは /ui/* 専用ルートで処理するため除外する
  */
 export async function getPostPathsForRoot(): Promise<PostPath[]> {
   const rootLang = getRootLang();
   const posts = await getPostsByLang(rootLang);
 
-  return posts.map((entry) => ({
-    params: { slug: entry.id },
-    props: { lang: rootLang, entry },
-  }));
+  return posts
+    .filter((entry) => !entry.id.startsWith('ui/'))
+    .map((entry) => ({
+      params: { slug: entry.id },
+      props: { lang: rootLang, entry },
+    }));
 }
 
 /**
  * 記事詳細ページ用のgetStaticPaths（非root言語用）
+ * ui/ プレフィックスは /[lang]/ui/* 専用ルートで処理するため除外する
  */
 export async function getPostPathsForNonRoot(): Promise<PostPathNonRoot[]> {
   const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
 
   // root言語の全slugを取得（非root言語でも同じslugでアクセス可能にする）
-  const rootSlugs = await getRootLangSlugs();
+  const rootSlugs = (await getRootLangSlugs()).filter((slug) => !slug.startsWith('ui/'));
 
   const paths: PostPathNonRoot[] = [];
 

--- a/apps/docs/src/lib/pageHelpers.ts
+++ b/apps/docs/src/lib/pageHelpers.ts
@@ -3,7 +3,7 @@
  * 各ページコンポーネントから呼び出して使用
  */
 import { siteConfig } from '@/config/site';
-import { getPostsByLang, getPostWithFallback, getRootLangSlugs, type PostEntry } from '@/lib/content';
+import { getPostsByLang, getDocsPostsByLang, getUiPostsByLang, getPostWithFallback, type PostEntry } from '@/lib/content';
 import { getRootLang, isRootLang, type LangCode } from '@/lib/i18n';
 import { createHash } from 'crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
@@ -30,37 +30,34 @@ export interface PostPathNonRoot {
 
 /**
  * 記事詳細ページ用のgetStaticPaths（root言語用）
- * ui/ プレフィックスは /ui/* 専用ルートで処理するため除外する
  */
 export async function getPostPathsForRoot(): Promise<PostPath[]> {
   const rootLang = getRootLang();
-  const posts = await getPostsByLang(rootLang);
+  const posts = await getDocsPostsByLang(rootLang);
 
-  return posts
-    .filter((entry) => !entry.id.startsWith('ui/'))
-    .map((entry) => ({
-      params: { slug: entry.id },
-      props: { lang: rootLang, entry },
-    }));
+  return posts.map((entry) => ({
+    params: { slug: entry.id },
+    props: { lang: rootLang, entry },
+  }));
 }
 
 /**
  * 記事詳細ページ用のgetStaticPaths（非root言語用）
- * ui/ プレフィックスは /[lang]/ui/* 専用ルートで処理するため除外する
  */
 export async function getPostPathsForNonRoot(): Promise<PostPathNonRoot[]> {
+  const rootLang = getRootLang();
   const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
 
   // root言語の全slugを取得（非root言語でも同じslugでアクセス可能にする）
-  const rootSlugs = (await getRootLangSlugs()).filter((slug) => !slug.startsWith('ui/'));
+  const rootPosts = await getDocsPostsByLang(rootLang);
 
   const paths: PostPathNonRoot[] = [];
 
   for (const lang of nonRootLangs) {
-    for (const slug of rootSlugs) {
+    for (const post of rootPosts) {
       paths.push({
-        params: { lang, slug },
-        props: { lang, slug },
+        params: { lang, slug: post.id },
+        props: { lang, slug: post.id },
       });
     }
   }
@@ -241,39 +238,34 @@ export interface OgPath {
 
 /**
  * OG画像用のgetStaticPaths（root言語用）
- * ui/ プレフィックスは /ui/og/* 専用エンドポイントで処理するため除外する
  */
 export async function getOgPathsForRoot(): Promise<OgPath[]> {
   const rootLang = getRootLang();
-  const posts = await getPostsByLang(rootLang);
+  const posts = await getDocsPostsByLang(rootLang);
 
-  return posts
-    .filter((post) => !post.id.startsWith('ui/'))
-    .map((post) => ({
-      params: { slug: post.id },
-      props: { lang: rootLang, slug: post.id },
-    }));
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { lang: rootLang, slug: post.id },
+  }));
 }
 
 /**
  * OG画像用のgetStaticPaths（非root言語用）
- * ui/ プレフィックスは /[lang]/ui/og/* 専用エンドポイントで処理するため除外する
  */
 export async function getOgPathsForNonRoot(): Promise<OgPath[]> {
   const rootLang = getRootLang();
   const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
 
-  // root言語の全記事を取得してslugリストを作成（ui/ は除外）
-  const rootPosts = await getPostsByLang(rootLang);
-  const rootSlugs = rootPosts.filter((post) => !post.id.startsWith('ui/')).map((post) => post.id);
+  // root言語の全記事を取得してslugリストを作成
+  const rootPosts = await getDocsPostsByLang(rootLang);
 
   const paths: OgPath[] = [];
 
   for (const lang of nonRootLangs) {
-    for (const slug of rootSlugs) {
+    for (const post of rootPosts) {
       paths.push({
-        params: { lang, slug },
-        props: { lang, slug },
+        params: { lang, slug: post.id },
+        props: { lang, slug: post.id },
       });
     }
   }
@@ -288,14 +280,12 @@ export async function getOgPathsForNonRoot(): Promise<OgPath[]> {
  */
 export async function getUiOgPathsForRoot(): Promise<OgPath[]> {
   const rootLang = getRootLang();
-  const posts = await getPostsByLang(rootLang);
+  const posts = await getUiPostsByLang(rootLang);
 
-  return posts
-    .filter((post) => post.id.startsWith('ui/'))
-    .map((post) => ({
-      params: { slug: post.id.replace(/^ui\//, '') },
-      props: { lang: rootLang, slug: post.id },
-    }));
+  return posts.map((post) => ({
+    params: { slug: post.id.replace(/^ui\//, '') },
+    props: { lang: rootLang, slug: post.id },
+  }));
 }
 
 /**
@@ -306,8 +296,7 @@ export async function getUiOgPathsForNonRoot(): Promise<OgPath[]> {
   const rootLang = getRootLang();
   const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
 
-  const rootPosts = await getPostsByLang(rootLang);
-  const uiPosts = rootPosts.filter((post) => post.id.startsWith('ui/'));
+  const uiPosts = await getUiPostsByLang(rootLang);
 
   const paths: OgPath[] = [];
 

--- a/apps/docs/src/pages/[lang]/ui/[...slug].astro
+++ b/apps/docs/src/pages/[lang]/ui/[...slug].astro
@@ -11,7 +11,7 @@ import PostNavigation from '@parts/PostNavigation.astro';
 import TranslationNotice from '@/components/TranslationNotice.astro';
 import { siteConfig } from '@/config/site';
 import { isRootLang, isValidLang, getRootLang, type LangCode } from '@/lib/i18n';
-import { getPostsByLang, getPostWithFallback } from '@/lib/content';
+import { getUiPostsByLang, getPostWithFallback } from '@/lib/content';
 import { render } from 'astro:content';
 
 // MDXでグローバルに使用するコンポーネント
@@ -21,10 +21,7 @@ export async function getStaticPaths() {
   const langCodes = Object.keys(siteConfig.langs) as LangCode[];
   const nonRootLangs = langCodes.filter((lang) => !isRootLang(lang));
   const rootLang = getRootLang();
-  const allPosts = await getPostsByLang(rootLang);
-
-  // ui/ で始まるIDのみフィルタリング
-  const uiPosts = allPosts.filter((post) => post.id.startsWith('ui/'));
+  const uiPosts = await getUiPostsByLang(rootLang);
 
   const paths = [];
   for (const lang of nonRootLangs) {

--- a/apps/docs/src/pages/[lang]/ui/[...slug].astro
+++ b/apps/docs/src/pages/[lang]/ui/[...slug].astro
@@ -61,7 +61,7 @@ const { Content, headings } = await render(entry);
 const toc = generateToc(headings);
 
 // OG画像のパス
-const ogImage = `/ui/og/${slug.replace(/^ui\//, '')}.png`;
+const ogImage = `/${lang}/ui/og/${slug.replace(/^ui\//, '')}.png`;
 ---
 
 <BaseLayout

--- a/apps/docs/src/pages/[lang]/ui/index.astro
+++ b/apps/docs/src/pages/[lang]/ui/index.astro
@@ -5,7 +5,7 @@
  */
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import { Stack, AutoColumns, BoxLink, Frame, Lism, Media } from 'lism-css/astro';
-import { getPostsByLang } from '@/lib/content';
+import { getUiPostsByLang } from '@/lib/content';
 import { siteConfig } from '@/config/site';
 import { isRootLang, isValidLang, type LangCode } from '@/lib/i18n';
 import fs from 'node:fs';
@@ -30,20 +30,20 @@ if (!isValidLang(lang)) {
   return Astro.redirect('/404');
 }
 
-// 現在の言語の記事を取得
-const allPosts = await getPostsByLang(lang);
+// 現在の言語の UI 記事を取得
+const allUiPosts = await getUiPostsByLang(lang);
 
-// ui/ 配下の記事のみフィルタリング（examples配下は除く）
-const uiPosts = allPosts
-  .filter((post) => post.id.startsWith('ui/') && !post.id.startsWith('ui/examples/'))
+// examples 配下を除いた UI 記事
+const uiPosts = allUiPosts
+  .filter((post) => !post.id.startsWith('ui/examples/'))
   .sort((a, b) => {
     const orderA = a.data.order ?? 999;
     const orderB = b.data.order ?? 999;
     return orderA - orderB;
   });
 
-// ui/examples/ 配下の記事を別途フィルタリング
-const examplePosts = allPosts
+// ui/examples/ 配下の記事
+const examplePosts = allUiPosts
   .filter((post) => post.id.startsWith('ui/examples/'))
   .sort((a, b) => {
     const orderA = a.data.order ?? 999;

--- a/apps/docs/src/pages/[lang]/ui/og/[...slug].png.ts
+++ b/apps/docs/src/pages/[lang]/ui/og/[...slug].png.ts
@@ -1,0 +1,14 @@
+/**
+ * OG画像生成エンドポイント（UIコンポーネント・非root言語用）
+ * URL例: /en/ui/og/accordion.png
+ */
+import type { APIRoute } from 'astro';
+import { getUiOgPathsForNonRoot, generateOgImage } from '@/lib/pageHelpers';
+import type { LangCode } from '@/lib/i18n';
+
+export const getStaticPaths = getUiOgPathsForNonRoot;
+
+export const GET: APIRoute = async ({ props }) => {
+  const { lang, slug } = props as { lang: LangCode; slug: string };
+  return generateOgImage(lang, slug);
+};

--- a/apps/docs/src/pages/ui/[...slug].astro
+++ b/apps/docs/src/pages/ui/[...slug].astro
@@ -9,7 +9,7 @@ import { generateToc } from '@/lib/generateToc';
 import { Icon, Lism, Flow, Heading } from 'lism-css/astro';
 import PostNavigation from '@parts/PostNavigation.astro';
 import { getRootLang, type LangCode } from '@/lib/i18n';
-import { getPostsByLang, type PostEntry } from '@/lib/content';
+import { getUiPostsByLang, type PostEntry } from '@/lib/content';
 import { render } from 'astro:content';
 
 // MDXでグローバルに使用するコンポーネント
@@ -18,10 +18,7 @@ import * as mdxComponents from '@/components/mdx';
 // /ui/ セクション用のgetStaticPaths
 export async function getStaticPaths() {
   const rootLang = getRootLang();
-  const allPosts = await getPostsByLang(rootLang);
-
-  // ui/ で始まる slug のみをフィルタリング
-  const uiPosts = allPosts.filter((post) => post.id.startsWith('ui/'));
+  const uiPosts = await getUiPostsByLang(rootLang);
 
   return uiPosts.map((entry) => ({
     // slug から ui/ プレフィックスを除去

--- a/apps/docs/src/pages/ui/index.astro
+++ b/apps/docs/src/pages/ui/index.astro
@@ -5,18 +5,18 @@
  */
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import { Stack, AutoColumns, BoxLink, Frame, Lism, Media } from 'lism-css/astro';
-import { getPostsByLang } from '@/lib/content';
+import { getUiPostsByLang } from '@/lib/content';
 import { getRootLang } from '@/lib/i18n';
 import fs from 'node:fs';
 import path from 'node:path';
 
-// 現在の言語の記事を取得
+// 現在の言語の UI 記事を取得
 const currentLang = getRootLang();
-const allPosts = await getPostsByLang(currentLang);
+const allUiPosts = await getUiPostsByLang(currentLang);
 
-// ui/ 配下の記事のみフィルタリング（examples配下は除く）
-const uiPosts = allPosts
-  .filter((post) => post.id.startsWith('ui/') && !post.id.startsWith('ui/examples/'))
+// examples 配下を除いた UI 記事
+const uiPosts = allUiPosts
+  .filter((post) => !post.id.startsWith('ui/examples/'))
   .sort((a, b) => {
     // order順にソート（未指定は999）
     const orderA = a.data.order ?? 999;
@@ -24,8 +24,8 @@ const uiPosts = allPosts
     return orderA - orderB;
   });
 
-// ui/examples/ 配下の記事を別途フィルタリング
-const examplePosts = allPosts
+// ui/examples/ 配下の記事
+const examplePosts = allUiPosts
   .filter((post) => post.id.startsWith('ui/examples/'))
   .sort((a, b) => {
     // order順にソート（未指定は999）

--- a/apps/docs/src/pages/ui/og/[...slug].png.ts
+++ b/apps/docs/src/pages/ui/og/[...slug].png.ts
@@ -1,0 +1,14 @@
+/**
+ * OG画像生成エンドポイント（UIコンポーネント・root言語用）
+ * URL例: /ui/og/accordion.png
+ */
+import type { APIRoute } from 'astro';
+import { getUiOgPathsForRoot, generateOgImage } from '@/lib/pageHelpers';
+import type { LangCode } from '@/lib/i18n';
+
+export const getStaticPaths = getUiOgPathsForRoot;
+
+export const GET: APIRoute = async ({ props }) => {
+  const { lang, slug } = props as { lang: LangCode; slug: string };
+  return generateOgImage(lang, slug);
+};


### PR DESCRIPTION
## Summary

`docs/[...slug].astro` および `[lang]/docs/[...slug].astro` の `getStaticPaths` を提供している `getPostPathsForRoot()` / `getPostPathsForNonRoot()` が、コンテンツコレクションに含まれる `ui/...` の slug までそのまま渡していたため、`/ui/*` 専用ルートで生成されるべき UI ドキュメントが `/docs/ui/*` および `/[lang]/docs/ui/*` でも二重に出力されていました。

修正として、両ヘルパーで `slug.startsWith('ui/')` の entry を除外し、`/docs/**` 配下に `ui/**` が混入しないようにします。これにより HTML ページだけでなく Pagefind の検索インデックスや docs-md の `.md` 出力も自動的に正規化されます。

`templates/` は Astro Content Collection に含まれず、`templates/[category]/[id].astro` 側で独自の `getStaticPaths` を持つため同じ問題は発生していません（修正不要）。

Closes #332

## Changes

- `apps/docs/src/lib/pageHelpers.ts`
  - `getPostPathsForRoot()`: `posts.filter((entry) => !entry.id.startsWith('ui/'))` を追加
  - `getPostPathsForNonRoot()`: `getRootLangSlugs()` の結果から `ui/` 始まりを除外
  - 各関数に意図を説明するコメントを追記

## Test plan

- [ ] `nr build:docs` を実行し、`apps/docs/dist/docs/ui/` および `apps/docs/dist/en/docs/ui/` が出力されないことを確認
- [ ] `apps/docs/dist/ui/accordion/index.html` および `apps/docs/dist/en/ui/accordion/index.html` は引き続き生成されることを確認
- [ ] 既存の docs ページ（例: `/docs/introduction/`, `/en/docs/introduction/`）が従来通り生成されることを確認
- [ ] Pagefind 検索結果に `/docs/ui/...` の重複候補が出ないことを確認