### PR TITLE
feat(docs): UI 一覧ページ用 .md (/ui.md, /en/ui.md) を生成

### DIFF
--- a/apps/docs/src/integrations/docs-md/build-llms-txt.test.ts
+++ b/apps/docs/src/integrations/docs-md/build-llms-txt.test.ts
@@ -59,14 +59,14 @@ describe('classify', () => {
     expect(classify('skills.mdx')).toBe('Getting Started');
   });
 
-  it('ui/examples と ui/DummyText と property-class は Optional', () => {
+  it('ui/examples と property-class は Optional', () => {
     expect(classify('ui/examples/Foo.mdx')).toBe('Optional');
-    expect(classify('ui/DummyText.mdx')).toBe('Optional');
     expect(classify('property-class/color.mdx')).toBe('Optional');
   });
 
-  it('それ以外の ui/* は UI Components', () => {
+  it('それ以外の ui/* は UI Components（DummyText も含む）', () => {
     expect(classify('ui/Accordion.mdx')).toBe('UI Components');
+    expect(classify('ui/DummyText.mdx')).toBe('UI Components');
   });
 
   it('上記いずれにも該当しなければ Documentation', () => {

--- a/apps/docs/src/integrations/docs-md/build-llms-txt.ts
+++ b/apps/docs/src/integrations/docs-md/build-llms-txt.ts
@@ -4,8 +4,8 @@
  *
  * セクション分類:
  * - Getting Started: トップレベルの overview/installation/changelog/features/mcp/skills
- * - UI Components:   ui/Xxx.mdx（examples 配下と DummyText を除く）
- * - Optional:        ui/examples/*, ui/DummyText, property-class/*
+ * - UI Components:   ui/Xxx.mdx（examples 配下を除く）
+ * - Optional:        ui/examples/*, property-class/*
  * - Documentation:   それ以外すべて
  *
  * `_demo/` と `test.mdx`、`draft: true` のファイルは除外する。
@@ -13,6 +13,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { toContentSlug } from '../../lib/contentSlug';
+import { walkMdx } from './util';
 
 type FrontMatter = { title?: string; description?: string; draft?: boolean };
 type Entry = { title: string; description: string; url: string; rel: string };
@@ -62,7 +63,6 @@ export function classify(rel: string): Section | null {
   if (rel.startsWith('_demo/') || rel === 'test.mdx') return null;
   const slug = rel.replace(/\.mdx$/, '');
   if (rel.startsWith('ui/examples/')) return 'Optional';
-  if (slug === 'ui/DummyText') return 'Optional';
   if (rel.startsWith('property-class/')) return 'Optional';
   if (rel.startsWith('ui/')) return 'UI Components';
   if (GS_SLUGS.has(slug)) return 'Getting Started';
@@ -80,20 +80,6 @@ export function toUrl(rel: string, siteUrl: string): string {
   return `${base}/en/docs/${slug}.md`;
 }
 
-async function listMdxFiles(dir: string): Promise<string[]> {
-  const result: string[] = [];
-  const walk = async (cur: string) => {
-    const entries = await fs.readdir(cur, { withFileTypes: true });
-    for (const e of entries) {
-      const full = path.join(cur, e.name);
-      if (e.isDirectory()) await walk(full);
-      else if (e.name.endsWith('.mdx')) result.push(full);
-    }
-  };
-  await walk(dir);
-  return result;
-}
-
 function sortEntries(section: Section, entries: Entry[]): Entry[] {
   if (section === 'Getting Started') {
     const order = new Map(GS_ORDER.map((slug, i) => [slug, i] as const));
@@ -108,15 +94,15 @@ function sortEntries(section: Section, entries: Entry[]): Entry[] {
 
 export async function buildLlmsTxt(opts: { contentDir: string; outputPath: string; siteUrl: string; logger: Logger }): Promise<void> {
   const { contentDir, outputPath, siteUrl, logger } = opts;
-  const files = await listMdxFiles(contentDir);
+  const files = await walkMdx(contentDir);
   const grouped = new Map<Section, Entry[]>();
   let count = 0;
 
-  for (const abs of files) {
-    const rel = path.relative(contentDir, abs).replace(/\\/g, '/');
+  for (const rel of files) {
     const section = classify(rel);
     if (!section) continue;
 
+    const abs = path.join(contentDir, rel);
     const content = await fs.readFile(abs, 'utf8');
     const fm = parseFrontmatter(content);
     if (fm.draft) continue;

--- a/apps/docs/src/integrations/docs-md/build-ui-index-md.ts
+++ b/apps/docs/src/integrations/docs-md/build-ui-index-md.ts
@@ -1,0 +1,123 @@
+/**
+ * UI コンポーネント一覧ページ (`/ui/` および `/en/ui/`) 用の `.md` を生成する。
+ *
+ * これらのインデックスページは `excludeFromSearch` で `data-pagefind-body` を持たないため、
+ * 通常の HTML→MD 変換パイプライン (`convert-html-to-md`) では skip される。
+ * AI ツールから一覧として参照できるよう、本モジュールが代替ルートとして
+ * content collection を走査して簡素なリンクリスト形式の `.md` を出力する。
+ *
+ * - frontmatter (title / description / url) は dist 側 index.html から抽出して同期を保つ
+ * - 本文は content/{lang}/ui/ 配下の `.mdx` から組み立てる（`_` 始まり / `draft: true` は除外）
+ * - リンクは個別ページの `.md`（`convert-html-to-md` が生成済み）を指す
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { unified } from 'unified';
+import rehypeParse from 'rehype-parse';
+import type { Root as HastRoot } from 'hast';
+import { extractDocMetaFromTree, type DocMeta } from './rehype-extract-meta';
+import { yamlString } from './convert-html-to-md';
+import { parseFrontmatter } from './build-llms-txt';
+import { toContentSlug } from '../../lib/contentSlug';
+
+type Logger = { warn: (msg: string) => void; info: (msg: string) => void };
+
+type Entry = { title: string; description: string; slug: string };
+
+async function extractHtmlMeta(htmlPath: string): Promise<DocMeta> {
+  const html = await fs.readFile(htmlPath, 'utf8');
+  // compiler 無しで parse のみ行うため `.parse()` を直接使う（`.process()` だと未指定エラー）
+  const tree = unified().use(rehypeParse).parse(html);
+  return extractDocMetaFromTree(tree);
+}
+
+async function listUiMdx(uiDir: string): Promise<string[]> {
+  const out: string[] = [];
+  const walk = async (cur: string, prefix: string) => {
+    const entries = await fs.readdir(cur, { withFileTypes: true });
+    for (const e of entries) {
+      // _opt-in / _demo など、`_` 始まりは公開対象外
+      if (e.name.startsWith('_')) continue;
+      const full = path.join(cur, e.name);
+      const rel = prefix ? `${prefix}/${e.name}` : e.name;
+      if (e.isDirectory()) await walk(full, rel);
+      else if (e.name.endsWith('.mdx')) out.push(rel);
+    }
+  };
+  await walk(uiDir, '');
+  return out;
+}
+
+function formatEntry(e: Entry, urlPrefix: string): string {
+  const url = `${urlPrefix}${e.slug}.md`;
+  return e.description ? `- [${e.title}](${url}): ${e.description}` : `- [${e.title}](${url})`;
+}
+
+export async function buildUiIndexMd(opts: {
+  htmlPath: string;
+  outputPath: string;
+  uiContentDir: string;
+  uiUrlPrefix: string;
+  logger: Logger;
+}): Promise<void> {
+  const { htmlPath, outputPath, uiContentDir, uiUrlPrefix, logger } = opts;
+
+  const meta = await extractHtmlMeta(htmlPath);
+  if (!meta.title) {
+    logger.warn(`ui index md skipped: no <title> in ${htmlPath}`);
+    return;
+  }
+
+  const files = await listUiMdx(uiContentDir);
+  const components: Entry[] = [];
+  const examples: Entry[] = [];
+
+  for (const rel of files) {
+    const abs = path.join(uiContentDir, rel);
+    const content = await fs.readFile(abs, 'utf8');
+    const fm = parseFrontmatter(content);
+    if (fm.draft) continue;
+    if (!fm.title) {
+      logger.warn(`ui index md: missing title in ui/${rel}`);
+      continue;
+    }
+    // toContentSlug は ui/ プレフィックスを含む形で受けて、url 用 slug 部分（ui/ 以下）を返す
+    const fullSlug = toContentSlug(`ui/${rel.replace(/\.mdx$/, '')}`);
+    const slug = fullSlug.replace(/^ui\//, '');
+    const entry: Entry = {
+      title: fm.title,
+      description: fm.description ?? '',
+      slug,
+    };
+    if (rel.startsWith('examples/')) examples.push(entry);
+    else components.push(entry);
+  }
+
+  const sortByTitle = (a: Entry, b: Entry) => a.title.localeCompare(b.title);
+  components.sort(sortByTitle);
+  examples.sort(sortByTitle);
+
+  const lines: string[] = ['---', `title: ${yamlString(meta.title)}`];
+  if (meta.description) lines.push(`description: ${yamlString(meta.description)}`);
+  if (meta.url) lines.push(`url: ${meta.url}`);
+  lines.push('---', '');
+  lines.push(`# ${meta.title}`, '');
+  if (meta.description) {
+    lines.push(meta.description, '');
+  }
+
+  if (components.length > 0) {
+    lines.push('## Components', '');
+    for (const e of components) lines.push(formatEntry(e, uiUrlPrefix));
+    lines.push('');
+  }
+  if (examples.length > 0) {
+    lines.push('## Examples', '');
+    for (const e of examples) lines.push(formatEntry(e, uiUrlPrefix));
+    lines.push('');
+  }
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, lines.join('\n'));
+  logger.info(`generated ${path.basename(outputPath)} (${components.length} components, ${examples.length} examples)`);
+}

--- a/apps/docs/src/integrations/docs-md/build-ui-index-md.ts
+++ b/apps/docs/src/integrations/docs-md/build-ui-index-md.ts
@@ -14,10 +14,10 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { unified } from 'unified';
 import rehypeParse from 'rehype-parse';
-import type { Root as HastRoot } from 'hast';
 import { extractDocMetaFromTree, type DocMeta } from './rehype-extract-meta';
 import { yamlString } from './convert-html-to-md';
 import { parseFrontmatter } from './build-llms-txt';
+import { walkMdx } from './util';
 import { toContentSlug } from '../../lib/contentSlug';
 
 type Logger = { warn: (msg: string) => void; info: (msg: string) => void };
@@ -29,23 +29,6 @@ async function extractHtmlMeta(htmlPath: string): Promise<DocMeta> {
   // compiler 無しで parse のみ行うため `.parse()` を直接使う（`.process()` だと未指定エラー）
   const tree = unified().use(rehypeParse).parse(html);
   return extractDocMetaFromTree(tree);
-}
-
-async function listUiMdx(uiDir: string): Promise<string[]> {
-  const out: string[] = [];
-  const walk = async (cur: string, prefix: string) => {
-    const entries = await fs.readdir(cur, { withFileTypes: true });
-    for (const e of entries) {
-      // _opt-in / _demo など、`_` 始まりは公開対象外
-      if (e.name.startsWith('_')) continue;
-      const full = path.join(cur, e.name);
-      const rel = prefix ? `${prefix}/${e.name}` : e.name;
-      if (e.isDirectory()) await walk(full, rel);
-      else if (e.name.endsWith('.mdx')) out.push(rel);
-    }
-  };
-  await walk(uiDir, '');
-  return out;
 }
 
 function formatEntry(e: Entry, urlPrefix: string): string {
@@ -68,7 +51,8 @@ export async function buildUiIndexMd(opts: {
     return;
   }
 
-  const files = await listUiMdx(uiContentDir);
+  // _opt-in / _demo など `_` 始まりは公開対象外なので走査時に除外
+  const files = await walkMdx(uiContentDir, { skipUnderscore: true });
   const components: Entry[] = [];
   const examples: Entry[] = [];
 

--- a/apps/docs/src/integrations/docs-md/index.ts
+++ b/apps/docs/src/integrations/docs-md/index.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import type { AstroIntegration } from 'astro';
 import { ArticleNotFoundError, convertHtmlToMd } from './convert-html-to-md';
 import { buildLlmsTxt } from './build-llms-txt';
+import { buildUiIndexMd } from './build-ui-index-md';
 
 // 変換対象のパスプレフィックス。templates / demo / preview / page-layout / og 等は対象外
 const INCLUDE_PREFIXES = ['docs/', 'ui/', 'en/docs/', 'en/ui/'];
@@ -32,6 +33,7 @@ function pageToPaths(pathname: string, distDir: string): { html: string; md: str
 export default function docsMd(): AstroIntegration {
   let siteUrl = '';
   let contentEnDir = '';
+  let contentJaDir = '';
   return {
     name: 'docs-md',
     hooks: {
@@ -42,7 +44,9 @@ export default function docsMd(): AstroIntegration {
           throw new Error('docs-md integration requires `site` to be set in astro.config');
         }
         siteUrl = config.site;
-        contentEnDir = path.join(fileURLToPath(config.srcDir), 'content/en');
+        const srcDir = fileURLToPath(config.srcDir);
+        contentEnDir = path.join(srcDir, 'content/en');
+        contentJaDir = path.join(srcDir, 'content/ja');
       },
       'astro:build:done': async ({ dir, pages, logger }) => {
         const distDir = fileURLToPath(dir);
@@ -70,6 +74,24 @@ export default function docsMd(): AstroIntegration {
           })
         );
         logger.info(`generated ${success} markdown files (${skipped} skipped)`);
+
+        // /ui/ と /en/ui/ の一覧ページは `data-pagefind-body` を持たないため上の変換では skip される。
+        // 個別 UI 詳細ページ (.md) へのリンク集として独立して生成する。
+        const baseUrl = siteUrl.replace(/\/$/, '');
+        await buildUiIndexMd({
+          htmlPath: path.join(distDir, 'ui/index.html'),
+          outputPath: path.join(distDir, 'ui.md'),
+          uiContentDir: path.join(contentJaDir, 'ui'),
+          uiUrlPrefix: `${baseUrl}/ui/`,
+          logger,
+        });
+        await buildUiIndexMd({
+          htmlPath: path.join(distDir, 'en/ui/index.html'),
+          outputPath: path.join(distDir, 'en/ui.md'),
+          uiContentDir: path.join(contentEnDir, 'ui'),
+          uiUrlPrefix: `${baseUrl}/en/ui/`,
+          logger,
+        });
 
         await buildLlmsTxt({
           contentDir: contentEnDir,

--- a/apps/docs/src/integrations/docs-md/rehype-extract-meta.ts
+++ b/apps/docs/src/integrations/docs-md/rehype-extract-meta.ts
@@ -17,33 +17,42 @@ const TITLE_SUFFIX = /\s*[-–—]\s*Lism CSS\s*$/;
 
 export const META_DATA_KEY = 'docsMdMeta';
 
+/**
+ * HAST ツリーから <title> / <meta name="description"> / <link rel="canonical"> を抽出する。
+ * rehype プラグインからも、外部の単発呼び出し（コンパイラ無しの parse() 結果）からも使えるよう
+ * 副作用無しの純粋関数として独立させている。
+ */
+export function extractDocMetaFromTree(tree: Root): DocMeta {
+  const meta: DocMeta = {};
+
+  visit(tree, 'element', (node: Element) => {
+    if (node.tagName === 'title') {
+      const child = node.children[0];
+      if (child?.type === 'text') {
+        meta.title = child.value.replace(TITLE_SUFFIX, '').trim();
+      }
+      return;
+    }
+    if (node.tagName === 'meta' && node.properties?.name === 'description') {
+      const content = node.properties.content;
+      if (typeof content === 'string') meta.description = content;
+      return;
+    }
+    if (node.tagName === 'link') {
+      const rel = node.properties?.rel;
+      const isCanonical = Array.isArray(rel) ? rel.includes('canonical') : rel === 'canonical';
+      if (isCanonical) {
+        const href = node.properties?.href;
+        if (typeof href === 'string') meta.url = href;
+      }
+    }
+  });
+
+  return meta;
+}
+
 export function rehypeExtractMeta() {
   return (tree: Root, file: { data: Record<string, unknown> }) => {
-    const meta: DocMeta = {};
-
-    visit(tree, 'element', (node: Element) => {
-      if (node.tagName === 'title') {
-        const child = node.children[0];
-        if (child?.type === 'text') {
-          meta.title = child.value.replace(TITLE_SUFFIX, '').trim();
-        }
-        return;
-      }
-      if (node.tagName === 'meta' && node.properties?.name === 'description') {
-        const content = node.properties.content;
-        if (typeof content === 'string') meta.description = content;
-        return;
-      }
-      if (node.tagName === 'link') {
-        const rel = node.properties?.rel;
-        const isCanonical = Array.isArray(rel) ? rel.includes('canonical') : rel === 'canonical';
-        if (isCanonical) {
-          const href = node.properties?.href;
-          if (typeof href === 'string') meta.url = href;
-        }
-      }
-    });
-
-    file.data[META_DATA_KEY] = meta;
+    file.data[META_DATA_KEY] = extractDocMetaFromTree(tree);
   };
 }

--- a/apps/docs/src/integrations/docs-md/util.ts
+++ b/apps/docs/src/integrations/docs-md/util.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import type { Element } from 'hast';
 
 /**
@@ -9,4 +11,25 @@ export function hasClass(node: Element, cls: string): boolean {
   if (Array.isArray(c)) return c.includes(cls);
   if (typeof c === 'string') return c.split(/\s+/).includes(cls);
   return false;
+}
+
+/**
+ * 指定ディレクトリ配下の `.mdx` ファイルを再帰的に列挙する。
+ * 返り値は `dir` からの相対 path（POSIX 区切り）。
+ * `skipUnderscore: true` の時、`_` 始まりのエントリ（ファイル/ディレクトリ）を除外する。
+ */
+export async function walkMdx(dir: string, opts: { skipUnderscore?: boolean } = {}): Promise<string[]> {
+  const out: string[] = [];
+  const walk = async (cur: string, prefix: string) => {
+    const entries = await fs.readdir(cur, { withFileTypes: true });
+    for (const e of entries) {
+      if (opts.skipUnderscore && e.name.startsWith('_')) continue;
+      const full = path.join(cur, e.name);
+      const rel = prefix ? `${prefix}/${e.name}` : e.name;
+      if (e.isDirectory()) await walk(full, rel);
+      else if (e.name.endsWith('.mdx')) out.push(rel);
+    }
+  };
+  await walk(dir, '');
+  return out;
 }


### PR DESCRIPTION
## Summary

- `/ui/` および `/en/ui/` のインデックスページに対応する `.md`（`dist/ui.md` / `dist/en/ui.md`）を生成
- これらのインデックスは `excludeFromSearch` で `data-pagefind-body` を持たないため、PR #331 で導入した HTML→MD 変換パイプラインでは skip されていた
- AI ツール等から「UI コンポーネント一覧」として参照できるようにする目的

## 変更内容

### 1. `build-ui-index-md.ts`（新規）

UI インデックス専用のジェネレータ。

- frontmatter (`title` / `description` / `url`) は dist 側 `index.html` の `<head>` から抽出して同期を保つ
- 本文は `content/{lang}/ui/` 配下の `.mdx` から組み立て
  - `_opt-in/` / `_demo/` などの `_` 始まりディレクトリは除外
  - `draft: true` は除外
  - タイトル昇順ソート
  - `examples/` 配下は `## Examples` セクション、それ以外は `## Components` セクション
- リンクは個別 UI ページの `.md`（`convert-html-to-md` 生成済み）を指すため 404 にならない

### 2. `rehype-extract-meta.ts` リファクタ

メタ抽出ロジックを `extractDocMetaFromTree(tree: Root): DocMeta` という純粋関数として export。
既存の `rehypeExtractMeta` プラグインも内部でこれを呼ぶようリファクタ（挙動互換）。

これにより、unified の compiler を持たない単発呼び出し（`.parse()` のみ）からも同じロジックを再利用できる。

### 3. `index.ts`

`astro:build:done` 内で `buildLlmsTxt` の前に `buildUiIndexMd` を ja / en 各 1 回呼び出す追記。

## 出力例（抜粋）

````md
---
title: "Lism UI"
description: "UI components based on Lism CSS — @lism-css/ui"
url: https://lism-css.com/en/ui/
---

# Lism UI

UI components based on Lism CSS — @lism-css/ui

## Components

- [Accordion](https://lism-css.com/en/ui/accordion.md): Documentation for the Accordion component provided by @lism-css/ui.
- [Alert](https://lism-css.com/en/ui/alert.md): ...
...

## Examples

- [Banner](https://lism-css.com/en/ui/examples/banner.md): ...
...
````

## 補足: `vercel.ts` ヘッダー設定

PR #331 で追加された `*.md` 用ヘッダー（`X-Robots-Tag: noindex` / `Content-Type: text/markdown`）は `source: '/:path*.md'` パターンのため、新規生成の `/ui.md` / `/en/ui.md` にも自動で適用される想定（要 Vercel プレビュー検証）。

## llms.txt（別件）

llms.txt の `## UI Components` セクション先頭に `/en/ui.md` エントリを追加する話は本 PR では未対応。必要に応じて別 PR で対応する。

## Test plan

- [x] `pnpm --filter lism-docs run typecheck` が 0 errors
- [x] `pnpm --filter lism-docs exec vitest run` が pass（既存 46 件）
- [x] `pnpm --filter lism-docs run build` が完走し `dist/ui.md` / `dist/en/ui.md` が生成される
- [x] frontmatter (`title` / `description` / `url`) が想定どおり付与される
- [x] `## Components` / `## Examples` セクションがタイトル昇順で出力される
- [x] リンク先 `.md` ファイル（例: `dist/ui/accordion.md`）が実在する
- [ ] Vercel プレビュー上で `/ui.md` レスポンスに `X-Robots-Tag: noindex` および `Content-Type: text/markdown` が付与されていること

Refs: #283 #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
