### PR TITLE
fix(docs): templates 個別ページとプレビューを noindex 化し sitemap から除外

### DIFF
--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -64,6 +64,10 @@ export default defineConfig({
       optimize: true,
     }),
     sitemap({
+      // noindex のページは sitemap からも除外する
+      // - /templates/{category}/{id}/ : noindex,follow（一覧トップは index のため除外しない）
+      // - /preview/templates/...      : noindex,nofollow（iframe プレビュー）
+      filter: (page) => !/\/templates\/[^/]+\/[^/]+\/?$/.test(page) && !/\/preview\/templates\//.test(page),
       serialize(item) {
         const lastmod = lastmodMap.get(item.url);
         if (lastmod) {

--- a/apps/docs/src/components/Head.astro
+++ b/apps/docs/src/components/Head.astro
@@ -14,9 +14,10 @@ interface Props {
   description?: string;
   ogImage?: string;
   lang: LangCode;
+  noindex?: boolean; // ページ単位で noindex,follow を出力する（全体 publish フラグとは別軸）
 }
 
-const { title, description, ogImage, lang } = Astro.props;
+const { title, description, ogImage, lang, noindex = false } = Astro.props;
 
 // 開発環境かどうか
 const isDev = import.meta.env.DEV;
@@ -96,7 +97,17 @@ const enableGA = !isDev && siteConfig.publish;
   <title>{titleMetaText}</title>
   {description && <meta name="description" content={description} />}
   <link rel="canonical" href={canonicalUrl} />
-  {siteConfig.publish ? <meta name="robots" content="index, follow, max-image-preview:large" /> : <meta name="robots" content="noindex, nofollow" />}
+  {
+    siteConfig.publish ? (
+      noindex ? (
+        <meta name="robots" content="noindex, follow" />
+      ) : (
+        <meta name="robots" content="index, follow, max-image-preview:large" />
+      )
+    ) : (
+      <meta name="robots" content="noindex, nofollow" />
+    )
+  }
 
   {/* 多言語 hreflang: 検索エンジンに各言語版の存在を通知 */}
   {alternateUrls.map(({ lang: altLang, url }) => <link rel="alternate" hreflang={altLang} href={toAbsoluteUrl(url)} />)}

--- a/apps/docs/src/layouts/BaseLayout.astro
+++ b/apps/docs/src/layouts/BaseLayout.astro
@@ -34,9 +34,20 @@ interface Props {
   schemaType?: SchemaType; // 指定時のみ JSON-LD を出力
   date?: Date; // 公開日（JSON-LD の datePublished に使用）
   excludeFromSearch?: boolean; // 検索対象から除外するかどうか
+  noindex?: boolean; // 検索エンジンにインデックスさせない（noindex,follow を出力）
 }
 
-const { title = siteConfig.name, description, ogImage, toc, lang = getRootLang(), schemaType, date, excludeFromSearch = false } = Astro.props;
+const {
+  title = siteConfig.name,
+  description,
+  ogImage,
+  toc,
+  lang = getRootLang(),
+  schemaType,
+  date,
+  excludeFromSearch = false,
+  noindex = false,
+} = Astro.props;
 
 // 開発環境かどうか（ShareBtns用のURL生成に使用）
 const isDev = import.meta.env.DEV;
@@ -46,7 +57,7 @@ const canonicalUrl = isDev ? Astro.url.toString() : Astro.site ? new URL(Astro.u
 ---
 
 <html lang={lang}>
-  <Head title={title} description={description} ogImage={ogImage} lang={lang}>
+  <Head title={title} description={description} ogImage={ogImage} lang={lang} noindex={noindex}>
     {schemaType && <JsonLd schemaType={schemaType} title={title} description={description} lang={lang} date={date} />}
   </Head>
   <body {...excludeFromSearch && { 'data-pagefind-ignore': 'all' }}>

--- a/apps/docs/src/layouts/SimpleLayout.astro
+++ b/apps/docs/src/layouts/SimpleLayout.astro
@@ -32,13 +32,14 @@ interface Props {
   lang?: LangCode; // 言語コード（省略時はroot言語）
   schemaType?: SchemaType; // 指定時のみ JSON-LD を出力
   excludeFromSearch?: boolean; // 検索対象から除外するかどうか
+  noindex?: boolean; // 検索エンジンにインデックスさせない（noindex,follow を出力）
 }
 
-const { title = siteConfig.name, description, ogImage, lang = getRootLang(), schemaType } = Astro.props;
+const { title = siteConfig.name, description, ogImage, lang = getRootLang(), schemaType, noindex = false } = Astro.props;
 ---
 
 <html lang={lang}>
-  <Head title={title || siteConfig.name} description={description} ogImage={ogImage} lang={lang}>
+  <Head title={title || siteConfig.name} description={description} ogImage={ogImage} lang={lang} noindex={noindex}>
     {schemaType && <JsonLd schemaType={schemaType} title={title || siteConfig.name} description={description} lang={lang} />}
   </Head>
   <body data-pagefind-ignore>

--- a/apps/docs/src/pages/[lang]/templates/[category]/[id].astro
+++ b/apps/docs/src/pages/[lang]/templates/[category]/[id].astro
@@ -58,7 +58,7 @@ const previewUrl = `/preview/templates/${category}/${id}/${lang}/`;
 const templatePath = `src/pages/preview/templates/${category}/${id}`;
 ---
 
-<BaseLayout title={`${template.title} - Templates`} description={template.description[lang]} excludeFromSearch noindex>
+<BaseLayout title={`${template.title} - Templates`} description={template.description[lang]} lang={lang} excludeFromSearch noindex>
   <Flow g="30" class="templatePage">
     <Stack as="header" g="10">
       <Text fz="xs" c="text-2" tt="uppercase" lts="l">

--- a/apps/docs/src/pages/[lang]/templates/[category]/[id].astro
+++ b/apps/docs/src/pages/[lang]/templates/[category]/[id].astro
@@ -58,7 +58,7 @@ const previewUrl = `/preview/templates/${category}/${id}/${lang}/`;
 const templatePath = `src/pages/preview/templates/${category}/${id}`;
 ---
 
-<BaseLayout title={`${template.title} - Templates`} description={template.description[lang]} excludeFromSearch>
+<BaseLayout title={`${template.title} - Templates`} description={template.description[lang]} excludeFromSearch noindex>
   <Flow g="30" class="templatePage">
     <Stack as="header" g="10">
       <Text fz="xs" c="text-2" tt="uppercase" lts="l">

--- a/apps/docs/src/pages/templates/[category]/[id].astro
+++ b/apps/docs/src/pages/templates/[category]/[id].astro
@@ -39,7 +39,7 @@ const previewUrl = `/preview/templates/${category}/${id}/`;
 const templatePath = `src/pages/preview/templates/${category}/${id}`;
 ---
 
-<BaseLayout title={`${template.title} - Templates`} description={template.description.ja} excludeFromSearch>
+<BaseLayout title={`${template.title} - Templates`} description={template.description.ja} excludeFromSearch noindex>
   <Flow g="30" class="templatePage">
     <Stack as="header" g="10">
       <Text fz="xs" c="text-2" tt="uppercase" lts="l">


### PR DESCRIPTION
## Summary

`apps/docs/` の templates 配下の個別ページが多数あり、プレビュー＋コード中心の thin content 寄りであるため、サイト全体の評価分散を避ける目的で個別ページに `noindex, follow` を設定し、sitemap からも除外する。一覧ページ（`/templates/`, `/{lang}/templates/`）は引き続き `index, follow` のまま残す。

`/preview/templates/` 配下（iframe 用プレビュー）は既に `DemoLayout` 経由で `noindex, nofollow` 設定済みであることを確認。今回 sitemap 側からも除外して整合性を取った。

Closes #346

## Changes

- `Head.astro` / `BaseLayout.astro` / `SimpleLayout.astro` に `noindex` prop を追加（既存の `siteConfig.publish` フラグによる全体 noindex とは独立）
- `pages/templates/[category]/[id].astro` および `pages/[lang]/templates/[category]/[id].astro` に `noindex` を適用
- `astro.config.ts` の `@astrojs/sitemap` に `filter` を追加：
  - `/templates/{category}/{id}/` を除外
  - `/preview/templates/` 配下を除外

## Test plan

- [x] `nr build` 成功
- [x] `dist/templates/index.html` の robots = `index, follow, max-image-preview:large`
- [x] `dist/templates/cta/cta001/index.html` の robots = `noindex, follow`
- [x] `dist/en/templates/index.html` の robots = `index, follow, max-image-preview:large`
- [x] `dist/en/templates/cta/cta001/index.html` の robots = `noindex, follow`
- [x] `dist/sitemap-0.xml` から個別 templates URL が除外されている
- [x] `dist/sitemap-0.xml` から `/preview/templates/` URL が除外されている
- [x] `dist/sitemap-0.xml` に `/templates/` および `/en/templates/` 一覧URLが残っている
- [ ] デプロイ後、Search Console で robots/sitemap が想定通りに反映されているか確認