### PR TITLE
add Templates LP001-003: Templatesに新規テンプレートLP001〜003を追加

### DIFF
--- a/apps/docs/src/config/templates.ts
+++ b/apps/docs/src/config/templates.ts
@@ -27,6 +27,7 @@ const templates = {
     label: 'LP',
     items: [
       {
+        draft: true,
         id: 'lp001',
         title: 'LP001: Minimal LP',
         description: {
@@ -35,6 +36,7 @@ const templates = {
         },
       },
       {
+        draft: true,
         id: 'lp002',
         title: 'LP002: Simple Natural LP',
         description: {
@@ -43,6 +45,7 @@ const templates = {
         },
       },
       {
+        draft: true,
         id: 'lp003',
         title: 'LP003: Japanese Ryokan LP',
         description: {

--- a/apps/docs/src/config/templates.ts
+++ b/apps/docs/src/config/templates.ts
@@ -23,6 +23,35 @@ export interface TemplateCategory {
 
 // テンプレートデータ（satisfiesでカテゴリ追加時に型定義の更新が不要になる）
 const templates = {
+  lp: {
+    label: 'LP',
+    items: [
+      {
+        id: 'lp001',
+        title: 'LP001: Minimal LP',
+        description: {
+          ja: 'ミニマルなデザインと控えめなスクロール駆動アニメーションが特徴のLPテンプレートです。',
+          en: '',
+        },
+      },
+      {
+        id: 'lp002',
+        title: 'LP002: Simple Natural LP',
+        description: {
+          ja: 'シンプルでナチュラルな印象のLPテンプレートです。Lism CSSのプリミティブやトークンを活かした汎用的なレイアウトを多く採用しています。',
+          en: '',
+        },
+      },
+      {
+        id: 'lp003',
+        title: 'LP003: Japanese Ryokan LP',
+        description: {
+          ja: '日本の伝統的な旅館をイメージしたLPテンプレートです。Lism CSSのプリミティブやトークンを活かしつつ、変則的なレイアウトは独自クラスを定義して実現しています。',
+          en: '',
+        },
+      },
+    ],
+  },
   cta: {
     label: 'CTA',
     items: [

--- a/apps/docs/src/pages/preview/templates/lp/lp001/_style.css
+++ b/apps/docs/src/pages/preview/templates/lp/lp001/_style.css
@@ -1,0 +1,1 @@
+/* LP001: Minimal LP */

--- a/apps/docs/src/pages/preview/templates/lp/lp001/index.astro
+++ b/apps/docs/src/pages/preview/templates/lp/lp001/index.astro
@@ -22,7 +22,9 @@ import {
   Text,
   Wrapper,
 } from 'lism-css/astro';
-import { Accordion, Button, Modal } from '@lism-css/ui/astro';
+import { Accordion } from '@lism-css/ui/astro/Accordion';
+import { Button } from '@lism-css/ui/astro/Button';
+import { Modal } from '@lism-css/ui/astro/Modal';
 
 export const title = 'LP001: Minimal LP';
 

--- a/apps/docs/src/pages/preview/templates/lp/lp001/index.astro
+++ b/apps/docs/src/pages/preview/templates/lp/lp001/index.astro
@@ -1,0 +1,1379 @@
+---
+import DemoLayout from '@/layouts/DemoLayout.astro';
+import {
+  AutoColumns,
+  Box,
+  BoxLink,
+  Center,
+  Cluster,
+  Container,
+  Flex,
+  Flow,
+  Frame,
+  Grid,
+  Heading,
+  Icon,
+  Inline,
+  Layer,
+  Link,
+  Lism,
+  ListItem,
+  Stack,
+  Text,
+  Wrapper,
+} from 'lism-css/astro';
+import { Accordion, Button, Modal } from '@lism-css/ui/astro';
+
+export const title = 'LP001: Minimal LP';
+
+/** メインナビ（デスクトップ・ドロワー先頭） */
+const headerNavItems = [
+  { href: '#about', ja: 'About', en: 'About' },
+  { href: '#feature', ja: 'Feature', en: 'Feature' },
+  { href: '#works', ja: 'Works', en: 'Works' },
+  { href: '#news', ja: 'News', en: 'News' },
+] as const;
+
+/** Others サブメニュー／ドロワー内 Accordion */
+const headerOthersNavItems = [
+  { href: '#faq', ja: 'FAQ', en: 'FAQ' },
+  { href: '#testimonials', ja: 'Testimonials', en: 'Testimonials' },
+  { href: '#information', ja: 'Information', en: 'Information' },
+  { href: '#contact', ja: 'Contact', en: 'Contact' },
+] as const;
+
+const mvImage = {
+  src: 'https://cdn.lism-css.com/img/u-WFUSqJTxVc.jpg',
+  alt: 'Beautiful Landscape',
+  width: 1920,
+  height: 1080,
+};
+
+const aboutPhotos = [
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=1',
+    alt: 'Beautiful Landscape',
+    width: 800,
+    height: 600,
+  },
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=2',
+    alt: 'Beautiful Landscape',
+    width: 800,
+    height: 600,
+  },
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=3',
+    alt: 'Beautiful Landscape',
+    width: 800,
+    height: 600,
+  },
+] as const;
+
+/** Feature セクションと同じオーバーレイ（filter + hsl、背後の写真に程よく色が残る） */
+const aboutPhotoOverlay = {
+  filter: 'grayscale(1)',
+  backgroundColor: 'hsl(224 4% 99% / 0.85)',
+};
+
+const featureHero = {
+  src: 'https://cdn.lism-css.com/img/random-2510?r=service',
+  alt: 'Beautiful Landscape',
+  width: 960,
+  height: 640,
+};
+
+const featureDefaultCardImageMeta = {
+  alt: 'Beautiful Landscape',
+  width: 960,
+  height: 540,
+} as const;
+
+/** 2列（md+）: 奇数カード [画像|テキスト]、偶数 [テキスト|画像]（gta+ga。参考: l--grid） */
+type FeatureCard = {
+  src: string;
+  title: string;
+  body: string;
+};
+
+const featureCards: FeatureCard[] = [
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=service1',
+    title: 'レイアウト設計サポート',
+    body: 'ワイヤーフレーム作成がしやすい、レイアウトファーストなプリミティブ（Stack や Flex、Grid など）を、ドキュメントに沿った組み方で扱います。骨組みを先に揃え、画面幅の切り替えに耐えるマークアップを意識した設計です。',
+  },
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=service2',
+    title: 'デザイントークン整備',
+    body: 'ハーモニックモジュラースケールに基づくタイポやスペースなど、柔軟でレスポンシブに切り替えやすいCSS変数の設計が前提です。単一プロパティに相当する Property Class でも、同じ考え方を短い表記に落とし込めます。',
+  },
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=service3',
+    title: 'AI連携ワークフロー',
+    body: 'AIコーディング向けの Skills や、@lism-css/mcp（MCPサーバー）がエコシステムに含まれ、公式ドキュメントの参照と組み合わせやすい導線として案内されています。設計上の用語は「概要」や各章で揃いやすいよう整理されています。',
+  },
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=service4',
+    title: 'UIキット／テンプレート導入',
+    body: '公式のエコシステム表では、@lism-css/ui にアコーディオンやタブ、ボタン等のUIコンポーネント、lism-cli に UI をプロジェクトへコピーしてカスタマイズする CLI が並んでいます。React やAstro 向けの専用コンポーネント利用も、同じ概要で「より快適に」と紹介されている導入です。',
+  },
+];
+
+const worksDefaultImage = {
+  alt: 'Beautiful Landscape',
+  width: 960,
+  height: 540,
+} as const;
+
+const worksItems = [
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=works1',
+    title: 'ドキュメントサイト刷新',
+    body: '「概要」で紹介されているゼロビルド導入やWhy Lismの流れを、冒頭で噛み砕けるよう再配置する想定の自作案件。プリミティブとトークンの章へ辿れる導線だけ、先に固めています。',
+  },
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=works2',
+    title: 'デザインシステムLP',
+    body: '公式の訴求（軽量CSS一つ、レイアウトと変数、React／Astroの快適さ）をそのまま見出しに沿わせたLP案。デモのため、スクロール演出はこのページのローカルCSSに閉じています。',
+  },
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=works3',
+    title: 'ブログテンプレート適用',
+    body: 'テンプレート配布の話に寄せ、記事レイアウトをStackで積む前提の骨格だけ先に作る制作物。画像は遅延読み込みにし、本文はProperty Classの例示に使いやすい幅に留めています。',
+  },
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=works4',
+    title: 'UIコンポーネントギャラリー',
+    body: '@lism-css/ui のアコーディオンやモーダルなどを、ドキュメントの説明と同じ語彙で並べるギャラリー案。実装はサンプル閲覧用で、納品物の挙動を保証するものではありません。',
+  },
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=works5',
+    title: 'コーポレートサイト再構築',
+    body: 'エコシステム表（lism-css、@lism-css/ui、lism-cli、@lism-css/mcp）を紹介する帯を、StackとGridで折り返しやすい幅に設計。色はセマンティックトークンに寄せたまま差し替えています。',
+  },
+  {
+    src: 'https://cdn.lism-css.com/img/random-2510?r=works6',
+    title: '開発者向けオンボーディング',
+    body: 'SkillsとMCPの案内ページを想定し、公式のインストール・Skills・MCPの章へ飛ぶリンク集を1枚に集約。命名と@layerの説明は、必ずドキュメントを正とする前提のメモ付きです。',
+  },
+];
+
+const newsBg = {
+  src: 'https://cdn.lism-css.com/img/random-2510?r=news',
+  alt: '',
+  width: 960,
+  height: 640,
+};
+
+const newsRows = [
+  {
+    date: '2026.03.18',
+    title: 'エコシステム紹介：@lism-css/uiの位置づけ',
+    summary:
+      '公式のエコシステム表では、@lism-css/ui にアコーディオン・タブ等のUIコンポーネント集が掲げられており、React・Astro向けに快適、という点も同じ章で補足されています。',
+    long: true,
+  },
+  {
+    date: '2026.02.04',
+    title: 'エコシステム紹介：@lism-css/mcp',
+    summary:
+      '同表では@lism-css/mcpをAIコーディング向けMCPサーバーとして案内しており、Skillsやエディタ支援の導線は公式のはじめに・MCP等の文脈を参照する形が前提です。',
+    long: false,
+  },
+  {
+    date: '2026.01.22',
+    title: '概要：ゼロビルドと拡張の導入',
+    summary:
+      'ゼロビルドでCSSを1つ読み込むだけ、という説明のあと、npmのlism-cssや@lism-css/ui、lism-cli、SCSS上書きやlism.config.js などの話が、概要で順に紹介されています。',
+    long: true,
+  },
+  {
+    date: '2025.12.10',
+    title: '「Why Lism CSS?」の要点のおさらい',
+    summary:
+      '命名規則・デザイントークン・層（@layer）やユーティリティなど、サイト全体のCSS設計をまとめて扱う、という主張は、公式の「Why Lism CSS?」等で繰り返し述べられています。',
+    long: false,
+  },
+];
+
+/** 各項目は質問・回答とも別テキストを想定 */
+const faqItems: { question: string; answer: string }[] = [
+  {
+    question: 'Lism CSSとは何ですか？',
+    answer:
+      'Webサイトの骨組みをテンポ良く美しく作るための、軽量なCSS設計フレームワークです。タイポグラフィ、レイアウト向けのプリミティブ、CSS変数を活かしたユーティリティを一体で扱います。一つのCSSを読み込むだけ、という導入も可能です。',
+  },
+  {
+    question: '他のCSSフレームワークとの違いは？',
+    answer:
+      'Every Layout やTailwind、Chakra UIやMUIなどからインスピレーションを得た、独自のCSS設計です。公式の「Inspirations」に述べるとおり、レイアウトプリミティブやハーモニックモジュラースケーリング、プロパティ単位のユーティリティ方針が整理されています。',
+  },
+  {
+    question: 'ReactやAstroでも使えますか？',
+    answer:
+      'はい。lism-css パッケージに、React やAstro 向けの専用コンポーネントが含まれ、概要ページの訴求どおり扱いやすい導入が案内されています。@lism-css/ui のアコーディオン等も併用できます。',
+  },
+  {
+    question: '商用プロジェクトで利用できますか？',
+    answer:
+      '表記どおり、パッケージ群はすべて無料でオープンソース（MIT）で開発されています。利用条件の詳細は各リポジトリのライセンス表記に従ってください。',
+  },
+  {
+    question: 'カスタマイズや独自スタイルはどこに書けばよいですか？',
+    answer:
+      'SCSS 設定の上書きや lism.config.js の導入で、より柔軟にカスタマイズできる、と公式の「概要」で述べられています。自前のスタイル方針の詳細は、Customize など当該ドキュメントの章に従うのが確実です。',
+  },
+  {
+    question: '不具合や要望はどこに報告すればよいですか？',
+    answer:
+      '各OSSリポジトリ（GitHub 等）の案内に従い、Issue 等に報告する形が一般的です。本ページのデモはショーケース用のため、宛先の取り違いにご注意ください。',
+  },
+];
+
+const testimonialsDefaultAvatar = {
+  width: 256,
+  height: 256,
+  alt: '',
+} as const;
+
+const testimonialsAvatars = [
+  {
+    title: 'レビュー観点が揃い、差分が小さくなった',
+    meta: '東京都 / 30代 / フロントエンドエンジニア',
+    src: 'https://cdn.lism-css.com/img/random-2510?category=avatar&r=testimonials1',
+    body: '公式の「Why Lism」に近い言い方で、命名と@layerの話を1本道にしやすくなりました。ドキュメントの用語に寄せると、レビューでの咀嚼が少なくて済みます。',
+  },
+  {
+    title: 'デザインと実装の言語が一致した',
+    meta: '大阪府 / 40代 / デザイナー（UI）',
+    src: 'https://cdn.lism-css.com/img/random-2510?category=avatar&r=testimonials2',
+    body: 'タイポとスペースのトークン、Property Class の往復が分かりやすく、補足文のトーン合わせが速いです。余白の指示がブレにくいのが助かります。',
+  },
+  {
+    title: 'MCPで仕様確認がループしなくなった',
+    meta: '福岡県 / 20代 / 個人開発者',
+    src: 'https://cdn.lism-css.com/img/random-2510?category=avatar&r=testimonials3',
+    body: 'エコシステム紹介に載る@lism-css/mcp や Skills の話に沿って、用語の当たりを会話で揃えやすいです。まず「一つのCSS」から、という導入の流れに共感しています。',
+  },
+  {
+    title: 'テンプレから最短で公開まで持っていけた',
+    meta: '愛知県 / 30代 / マークアップエンジニア',
+    src: 'https://cdn.lism-css.com/img/random-2510?category=avatar&r=testimonials4',
+    body: 'Inspirations の Every Layout やTailwind への言及をフックに、レイアウト方針の説明を会議で混ぜやすくなりました。プリミティブを重ねる感覚が掴めたのが大きいです。',
+  },
+  {
+    title: 'Astro案件でも迷いどころが減った',
+    meta: '北海道 / 30代 / フルスタックエンジニア',
+    src: 'https://cdn.lism-css.com/img/random-2510?category=avatar&r=testimonials5',
+    body: 'React・Astro 向けの専用コンポーネントの導入に、公式の説明どおり乗る形にすると初日から手が伸びます。全部MITのパッケージ群、と表で示せるのも安心材料でした。',
+  },
+  {
+    title: '小さく始めて段階的に拡張できた',
+    meta: '沖縄県 / 40代 / テックリード',
+    src: 'https://cdn.lism-css.com/img/random-2510?category=avatar&r=testimonials6',
+    body: 'SCSS 上書きやlism.config.js の話は、拡張の段階でそのまま説得材料に使いやすいです。@lism-css/ui も、エコシステム表の通り、と他部署に示しやすいのが助かります。',
+  },
+];
+
+const informationRows: { term: string; description: string }[] = [
+  {
+    term: '運営名',
+    description: 'Lism CSS プロジェクト（デモ掲載用の架空組織）',
+  },
+  {
+    term: '所在地',
+    description: '東京都千代田区丸の内1-1-1（地図はGoogleマップ埋め込みの表示サンプル）',
+  },
+  {
+    term: '公開情報',
+    description:
+      'コアのlism-css、@lism-css/ui、lism-cli、@lism-css/mcp など、公式のエコシステム表のとおりのパッケージ群。告知や情報の一次ソースは、公式ドキュメントと各GitHub等を参照してください',
+  },
+  {
+    term: '連絡窓口',
+    description: 'OSS として各リポジトリに案内のある窓口に従ってください。本欄の住所・組織名はショーケース用の仮想表記です',
+  },
+  {
+    term: '事業内容',
+    description:
+      'ドキュメントに書かれている通り、CSS設計の理論に沿った一つのスタイルシート、レイアウト用コンポーネント、@lism-css/ui、lism-cli、@lism-css/mcp 等の配布。すべて無料でオープンソース（MIT）です',
+  },
+];
+
+const informationMapEmbed = {
+  src: 'https://www.google.com/maps/embed?pb=!1m14!1m12!1m3!1d7654.831243350634!2d139.76655044358094!3d35.68079012010135!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!5e0!3m2!1sja!2sjp!4v1769675880883!5m2!1sja!2sjp',
+  width: 1200,
+  height: 600,
+} as const;
+
+const contactBg = {
+  src: 'https://cdn.lism-css.com/img/random-2510?r=contact',
+  alt: '',
+  width: 960,
+  height: 640,
+};
+
+const footerSnsLinks = [
+  { href: '#', icon: 'logo-x' as const, label: 'X' },
+  { href: '#', icon: 'logo-instagram' as const, label: 'Instagram' },
+  { href: '#', icon: 'logo-youtube' as const, label: 'YouTube' },
+  { href: '#', icon: 'logo-line' as const, label: 'LINE' },
+] as const;
+---
+
+<DemoLayout title={title}>
+  <Wrapper contentSize="full">
+    <!-- Header -->
+
+    <Container class="z--lp001-header" as="header" pos="fixed" t="0" l="0" w="100%" z="1" hasGutter hasTransition>
+      <Grid class="z--lp001-header_inner" gtc="10rem 1fr" ai="center" h="100%" px={['0', null, '40']}>
+        <Stack class="z--lp001-header_logo">
+          <Link class="z--lp001-header_logoLink" href="#" fz="xl" lts="l" c="white" td="none">
+            <Inline fw="200">The</Inline>Minimal
+          </Link>
+        </Stack>
+        <Flex jc="fe" g="30">
+          <Flex class="z--lp001-headerNav" as="ul" d={['none', null, 'inline-flex']} ai="c" g="30" lts="l">
+            {
+              headerNavItems.map(({ href, en }) => (
+                <ListItem>
+                  <Link class="z--lp001-headerNav_link" href={href} d="block" c="white" td="none" py="10" hasTransition hov="-o">
+                    {en}
+                  </Link>
+                </ListItem>
+              ))
+            }
+            <ListItem>
+              <Button
+                class="z--lp001-headerNav_subMenuButton"
+                href="#others"
+                set="plain"
+                hasTransition
+                d="inline-flex"
+                g="10"
+                ai="c"
+                c="white"
+                td="none"
+                px="0"
+                py="10"
+                bgc="transparent"
+                bd="none"
+                hov="-o"
+              >
+                Others
+                <Icon icon="caret-down" fz="s" o="pp" />
+              </Button>
+            </ListItem>
+            <Box
+              id="others-child"
+              class="z--lp001-headerNav_subMenu"
+              set="plain"
+              bgc="base-2"
+              min-w="14rem"
+              mx="20"
+              my={[null, '5']}
+              p="20"
+              bxsh="30"
+              bdrs="20"
+            >
+              <Stack class="z--lp001-header_subMenu u--divide" p="0" ov="clip">
+                {
+                  headerOthersNavItems.map(({ href, en }) => (
+                    <BoxLink href={href} layout="grid" gtc="1fr auto" ai="c" td="none" py="15" px="10" hasTransition hov="-o">
+                      <Inline>{en}</Inline>
+                    </BoxLink>
+                  ))
+                }
+              </Stack>
+            </Box>
+          </Flex>
+          <Modal.OpenBtn modalId="menu" d={['block', null, 'none']}>
+            <Center p="10" bd bdc="divider" bdrs="10">
+              <Icon class="z--lp001-header_subMenu_buttonIcon" icon="menu" c="white" />
+            </Center>
+          </Modal.OpenBtn>
+        </Flex>
+        <Modal.Root id="menu" isContainer isWrapper="s" p="30">
+          <Modal.Inner layout="stack" pos="relative" w="100%" p="30" bdrs="20" bxsh="50">
+            <Modal.CloseBtn modalId="menu" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
+            <Modal.Body layout="stack" g="30" py="40">
+              <Stack class="z--lp001-header_menuNav u--divide" p="0" ov="clip">
+                {
+                  headerNavItems.map(({ href, en }) => (
+                    <BoxLink href={href} layout="grid" gtc="1fr auto" ai="c" fz="l" td="none" py="15" px="5">
+                      <Inline>{en}</Inline>
+                      <Icon icon="caret-right" fz="s" o="pp" />
+                    </BoxLink>
+                  ))
+                }
+                <Accordion.Root>
+                  <Accordion.Item>
+                    <Accordion.Heading m="0" p="0" w="100%">
+                      <Accordion.Button fz="l" py="15" px="5" w="100%" td="none" g="0" ai="c" ta="left">
+                        <Inline>Others</Inline>
+                      </Accordion.Button>
+                    </Accordion.Heading>
+                    <Accordion.Panel p="0" ov="clip">
+                      <Stack class="z--lp001-header_menuNav_sub u--divide" ml="20" p="0" ov="clip">
+                        {
+                          headerOthersNavItems.map(({ href, en }) => (
+                            <BoxLink href={href} layout="grid" gtc="1fr auto" ai="c" fz="l" td="none" py="15" px="5">
+                              <Inline>{en}</Inline>
+                              <Icon icon="caret-right" fz="s" o="pp" />
+                            </BoxLink>
+                          ))
+                        }
+                      </Stack>
+                    </Accordion.Panel>
+                  </Accordion.Item>
+                </Accordion.Root>
+              </Stack>
+            </Modal.Body>
+          </Modal.Inner>
+        </Modal.Root>
+      </Grid>
+    </Container>
+    <!-- Main Content -->
+    <Container as="main" class="z--lp001-main">
+      <Container class="z--lp001-mv" pos="relative">
+        <Frame class="z--lp001-mv_frame" pos="relative" h="100%">
+          <Lism
+            as="img"
+            class="z--lp001-mv_media"
+            src={mvImage.src}
+            alt={mvImage.alt}
+            w="100%"
+            h="100%"
+            exProps={{ width: mvImage.width, height: mvImage.height, loading: 'eager' }}
+          />
+          <Layer
+            style={{
+              filter: 'grayscale(50%)',
+              backgroundColor: 'hsl(0 0% 0% / 0.2)',
+            }}
+          />
+          <Stack class="z--lp001-mv_content" ai="c" jc="c" g="10" pos="absolute" t="0" l="0" w="100%" h="100%" c="white" hasGutter>
+            <Text as="p" fz="4xl" fw="400" ta="center" lts="l" m="0">Order and Harmony</Text>
+            <Text as="p" fz="l" fw="200" ta="center" lts="l" m="0">Lorem ipsum dolor sit amet.</Text>
+          </Stack>
+        </Frame>
+        <BoxLink href="#about" class="z--lp001-mv_scrollDown" layout="stack" ai="center" g="5" pos="absolute" c="white">
+          <Inline as="span" class="z--lp001-mv_scrollDownText" fz="xs" fs="italic" lts="l">SCROLL DOWN</Inline>
+          <Icon class="z--lp001-mv_scrollDownIcon" icon="caret-down" fz="m" />
+        </BoxLink>
+      </Container>
+
+      <Container id="about" class="z--lp001-about" isWrapper="s" pos="relative" py="70" hasGutter>
+        <Stack ai="c" jc="c" g="40" pos="relative">
+          <Stack class:list={['z--lp001-hgroup']} as="hgroup" ai="c" g="5">
+            <Heading level="2" class="z--lp001-hgroup_heading" fz="3xl" fw="400" lts="l" m="0">About</Heading>
+            <Heading level="3" class="z--lp001-hgroup_subHeading" d="inline-flex" ai="c" g="20" fz="s" fw="normal" lts="l" m="0">
+              Lism CSSとは
+            </Heading>
+          </Stack>
+          <Box class="z--lp001-about_visuals" pos="absolute" w="100%" h="100%" z="0">
+            {
+              aboutPhotos.map((photo, i) => (
+                <Frame class="z--lp001-about_frame" ar="4/3" pos="absolute" w={i === 0 ? '20rem' : '16rem'} bgc="base-2" bdrs="20">
+                  <Lism
+                    as="img"
+                    class="z--lp001-about_media"
+                    src={photo.src}
+                    alt={photo.alt}
+                    w="100%"
+                    h="100%"
+                    exProps={{ width: photo.width, height: photo.height, loading: 'lazy', decoding: 'async' }}
+                  />
+                  <Layer style={aboutPhotoOverlay} />
+                </Frame>
+              ))
+            }
+          </Box>
+          <Flow class="z--lp001-about_body u--fadeIn" flow="s" pos="relative" z="1">
+            <Text as="p" max-sz="full" mx="auto">
+              Lism
+              CSSは、Webサイトの骨組みをテンポ良く美しく作るための、軽量なCSS設計フレームワークです。設計理論に沿った一つのCSSが本体で、特別なビルド工程は必須ではありません。
+            </Text>
+            <Text as="p" max-sz="full" mx="auto">
+              心地よいリズムのタイポグラフィ、ワイヤーフレーム向けのレイアウトファーストなプリミティブ、CSS変数を活かしたレスポンシブにも向くユーティリティ設計を揃えています。
+              Every Layout やTailwindのような考え方から着想を得た上で、独自のCSS設計にまとまっています。
+            </Text>
+            <Text as="p" max-sz="full" mx="auto">
+              ベーススタイリングや@layer階層、トークン、命名規則まで、サイト全体のCSS設計を一貫して扱える点が「Why Lism
+              CSS?」の骨子です。CSSを一つ読み込むだけで、素のHTMLからでも導入を始められます。
+            </Text>
+            <Text as="p" max-sz="full" mx="auto">
+              コアのlism-cssのほか、@lism-css/ui、lism-cli、@lism-css/mcp等を、すべて無料・オープンソース（MIT）のパッケージ群として提供しています。
+              本ページは、公式ドキュメントで述べられている性質を体験できるショーケースに近い、代表的なセクションの並びをまとめたものです。
+            </Text>
+          </Flow>
+        </Stack>
+      </Container>
+
+      <Box id="feature" class="z--lp001-feature" pos="relative">
+        <Frame isLayer>
+          <Lism
+            as="img"
+            class="z--lp001-feature_media"
+            src={featureHero.src}
+            alt={featureHero.alt}
+            exProps={{ width: featureHero.width, height: featureHero.height, loading: 'lazy', decoding: 'async' }}
+          />
+        </Frame>
+        <Layer style={{ filter: 'grayscale(1)', backgroundColor: 'hsl(224 4% 99% / 0.85)' }} />
+        <Container isWrapper="l" py="60" hasGutter>
+          <Stack g="40">
+            <Stack class:list={['z--lp001-hgroup']} as="hgroup" ai="c" g="5">
+              <Heading level="2" class="z--lp001-hgroup_heading" fz="3xl" fw="400" lts="l" m="0">Feature</Heading>
+              <Heading level="3" class="z--lp001-hgroup_subHeading" d="inline-flex" ai="c" g="20" fz="s" fw="normal" lts="l" m="0">
+                Lism CSSの特徴
+              </Heading>
+            </Stack>
+            <Stack g="40">
+              {
+                featureCards.map((card, i) => {
+                  const isReversed = i % 2 === 1;
+                  /** 狭い: 2行1列 / md+: 1行2列。エリア名 img・text の並びで左右を決め、DOM 順は固定（ga で対応） */
+                  const gta: [string, null, string] = [`'img' 'text'`, null, isReversed ? `'text img'` : `'img text'`];
+                  return (
+                    <Grid
+                      class="z--lp001-feature_item"
+                      gtc={['auto', null, isReversed ? '3fr 2fr' : '2fr 3fr']}
+                      gta={gta}
+                      g={['20', null, '30']}
+                      ai="start"
+                    >
+                      <Frame ar="16/9" pos="relative" bdrs="20" ga="img">
+                        <Lism
+                          as="img"
+                          class="z--lp001-feature_itemMedia"
+                          src={card.src}
+                          alt={featureDefaultCardImageMeta.alt}
+                          exProps={{
+                            width: featureDefaultCardImageMeta.width,
+                            height: featureDefaultCardImageMeta.height,
+                            loading: 'lazy',
+                            decoding: 'async',
+                          }}
+                        />
+                      </Frame>
+                      <Stack class="z--lp001-feature_itemContent" g="15" max-w={['none', null, '36rem']} py="20" ga="text">
+                        <Heading level="3" fz="l" m="0">
+                          {card.title}
+                        </Heading>
+                        <Text as="p" m="0" o="p">
+                          {card.body}
+                        </Text>
+                      </Stack>
+                    </Grid>
+                  );
+                })
+              }
+            </Stack>
+          </Stack>
+        </Container>
+      </Box>
+
+      <Container id="works" class="z--lp001-works" isWrapper="l" py="60" hasGutter>
+        <Stack g="40">
+          <Stack class:list={['z--lp001-hgroup']} as="hgroup" ai="c" g="5">
+            <Heading level="2" class="z--lp001-hgroup_heading" fz="3xl" fw="400" lts="l" m="0">Works</Heading>
+            <Heading level="3" class="z--lp001-hgroup_subHeading" d="inline-flex" ai="c" g="20" fz="s" fw="normal" lts="l" m="0"> 制作実績 </Heading>
+          </Stack>
+          <Text as="p" class="u--fadeIn" max-sz="full" mx="auto" m="0">
+            以下はフィクションの制作例です。レイアウトプリミティブとデザイントークンを活かしつつ、公式ドキュメント「概要」に書かれている語彙とエコシステムの整理に沿う話に寄せたサンプルです。
+          </Text>
+          <AutoColumns cols="20rem" g="40">
+            {
+              worksItems.map((item) => (
+                <BoxLink class="z--lp001-works_item" href="#" layout="stack" set="var:hov">
+                  <Frame class="z--lp001-works_frame" ar="16/9" pos="relative" bdrs="20">
+                    <Lism
+                      as="img"
+                      class="z--lp001-works_media"
+                      src={item.src}
+                      alt={worksDefaultImage.alt}
+                      w="100%"
+                      h="auto"
+                      hasTransition
+                      hov="in:zoom"
+                      exProps={{
+                        width: worksDefaultImage.width,
+                        height: worksDefaultImage.height,
+                        loading: 'lazy',
+                        decoding: 'async',
+                      }}
+                    />
+                    <Layer
+                      hasTransition
+                      hov="in:show"
+                      style={{
+                        backgroundColor: 'rgb(0 0 0 / 30%)',
+                        backdropFilter: 'blur(4px)',
+                      }}
+                    >
+                      <Center h="100%" c="white">
+                        <Inline as="span" fz="xl" fs="italic" fw="light" lts="l" px="20" py="10">
+                          View More
+                        </Inline>
+                      </Center>
+                    </Layer>
+                  </Frame>
+                  <Stack g="10" py="20">
+                    <Heading level="3" fz="m" m="0">
+                      {item.title}
+                    </Heading>
+                    <Text as="p" fz="s" m="0" o="p">
+                      {item.body}
+                    </Text>
+                  </Stack>
+                </BoxLink>
+              ))
+            }
+          </AutoColumns>
+        </Stack>
+      </Container>
+
+      <Box id="news" class="z--lp001-news" pos="relative">
+        <Frame isLayer>
+          <Lism
+            as="img"
+            class="z--lp001-news_media"
+            src={newsBg.src}
+            alt={newsBg.alt}
+            exProps={{ width: newsBg.width, height: newsBg.height, loading: 'lazy', decoding: 'async' }}
+          />
+        </Frame>
+        <Layer style={{ filter: 'grayscale(1)', backgroundColor: 'hsl(224 4% 8% / 0.85)' }} />
+        <Container isWrapper="m" py="60" hasGutter>
+          <Stack g="40">
+            <Stack class:list={['z--lp001-hgroup', 'z--lp001-hgroup--light']} as="hgroup" ai="c" g="5">
+              <Heading level="2" class="z--lp001-hgroup_heading" fz="3xl" fw="400" lts="l" m="0">News</Heading>
+              <Heading level="3" class="z--lp001-hgroup_subHeading" d="inline-flex" ai="c" g="20" fz="s" fw="normal" lts="l" m="0">
+                お知らせ
+              </Heading>
+            </Stack>
+            <Stack g="20" c="white">
+              {
+                newsRows.map((row) => (
+                  <BoxLink class="z--lp001-news_item" href="#" layout="grid" gtc={['auto', 'auto 1fr']} g="20 40" py="15" set="var:hov">
+                    <Inline as="span">{row.date}</Inline>
+                    <Stack g="10">
+                      <Text as="p" hov="in:underline" td="none" m="0">
+                        {row.title}
+                      </Text>
+                      <Text as="p" fz="s" o="pp" m="0">
+                        {row.summary}
+                        {row.long ? ' あわせて Changelog も参照してください。' : ''}
+                      </Text>
+                    </Stack>
+                  </BoxLink>
+                ))
+              }
+            </Stack>
+          </Stack>
+        </Container>
+      </Box>
+
+      <Container id="faq" class="z--lp001-faq" isWrapper="m" py="60" hasGutter>
+        <Stack g="40">
+          <Stack class:list={['z--lp001-hgroup']} as="hgroup" ai="c" g="5">
+            <Heading level="2" class="z--lp001-hgroup_heading" fz="3xl" fw="400" lts="l" m="0">FAQ</Heading>
+            <Heading level="3" class="z--lp001-hgroup_subHeading" d="inline-flex" ai="c" g="20" fz="s" fw="normal" lts="l" m="0">
+              よくある質問
+            </Heading>
+          </Stack>
+          <Accordion.Root class="u--divide" p="0" ov="clip">
+            {
+              faqItems.map((item) => (
+                <Accordion.Item>
+                  <Accordion.Heading p="30">
+                    <Accordion.Button>{item.question}</Accordion.Button>
+                  </Accordion.Heading>
+                  <Accordion.Panel py="30" px="30">
+                    <Text m="0">{item.answer}</Text>
+                  </Accordion.Panel>
+                </Accordion.Item>
+              ))
+            }
+          </Accordion.Root>
+        </Stack>
+      </Container>
+
+      <Container id="testimonials" class="z--lp001-testimonials" isWrapper="l" bgc="base-2" py="60" hasGutter>
+        <Stack g="40">
+          <Stack class:list={['z--lp001-hgroup']} as="hgroup" ai="c" g="5">
+            <Heading level="2" class="z--lp001-hgroup_heading" fz="3xl" fw="400" lts="l" m="0">Testimonials</Heading>
+            <Heading level="3" class="z--lp001-hgroup_subHeading" d="inline-flex" ai="c" g="20" fz="s" fw="normal" lts="l" m="0">
+              お客様の声
+            </Heading>
+          </Stack>
+          <AutoColumns cols="20rem" g="40">
+            {
+              testimonialsAvatars.map((item) => (
+                <Grid class="z--lp001-testimonials_item" gtr="subgrid" gr="span 3" g="30">
+                  <Grid gtc="auto 1fr" ai="center" g="20">
+                    <Frame as="figure" ar="1/1" w="3.5rem" bdrs="99">
+                      <Lism
+                        as="img"
+                        src={item.src}
+                        alt={testimonialsDefaultAvatar.alt}
+                        w="100%"
+                        h="100%"
+                        exProps={{
+                          width: testimonialsDefaultAvatar.width,
+                          height: testimonialsDefaultAvatar.height,
+                          loading: 'lazy',
+                          decoding: 'async',
+                        }}
+                      />
+                    </Frame>
+                    <Stack w="stretch" g="15">
+                      <Text class="u--trim" fz="m" fw="bold" lh="s" m="0">
+                        {item.title}
+                      </Text>
+                    </Stack>
+                  </Grid>
+                  <Text class="u--trim" fz="s" o="p" m="0" style={{ whiteSpace: 'pre-line' }}>
+                    {item.body}
+                  </Text>
+                  <Flex jc="fe">
+                    <Inline class="u--trim" fz="xs" fs="italic" o="pp" as="span">
+                      {item.meta}
+                    </Inline>
+                  </Flex>
+                </Grid>
+              ))
+            }
+          </AutoColumns>
+        </Stack>
+      </Container>
+
+      <Container id="information" class="z--lp001-information" isWrapper="m" py="60" hasGutter>
+        <Stack jc="c" g="40" w="100%">
+          <Stack class:list={['z--lp001-hgroup']} as="hgroup" ai="c" g="5">
+            <Heading level="2" class="z--lp001-hgroup_heading" fz="3xl" fw="400" lts="l" m="0">Information</Heading>
+            <Heading level="3" class="z--lp001-hgroup_subHeading" d="inline-flex" ai="c" g="20" fz="s" fw="normal" lts="l" m="0"> お知らせ </Heading>
+          </Stack>
+          <Grid as="dl" class="z--lp001-information_dl u--divide" gtc="auto 1fr" cg="40" p="0" ov="clip">
+            {
+              informationRows.map((row) => (
+                <Grid gtc="subgrid" gc="1/-1" p="30">
+                  <dt>{row.term}</dt>
+                  <dd>{row.description}</dd>
+                </Grid>
+              ))
+            }
+          </Grid>
+          <Frame class="z--lp001-information_map" ar={['1/1', '5/2']}>
+            <iframe
+              src={informationMapEmbed.src}
+              width={informationMapEmbed.width}
+              height={informationMapEmbed.height}
+              style="border:0;"
+              allowfullscreen=""
+              loading="lazy"
+              referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </Frame>
+        </Stack>
+      </Container>
+
+      <Box id="contact" class="z--lp001-contact" pos="relative">
+        <Frame isLayer>
+          <Lism
+            as="img"
+            class="z--lp001-contact_media"
+            pos="absolute"
+            t="-20%"
+            h="140%"
+            src={contactBg.src}
+            alt={contactBg.alt}
+            w="100%"
+            exProps={{ width: contactBg.width, height: contactBg.height, loading: 'lazy', decoding: 'async' }}
+          />
+        </Frame>
+        <Layer style={{ backgroundColor: 'hsl(0 0% 0% / 0.5)' }} />
+        <Container isWrapper="s" bgc="base-2" py="60" h="65vh" hasGutter>
+          <Stack pos="relative" jc="c" g="40" c="white" h="100%">
+            <Stack class:list={['z--lp001-hgroup', 'z--lp001-hgroup--light']} as="hgroup" ai="c" g="5">
+              <Heading level="2" class="z--lp001-hgroup_heading" fz="3xl" fw="400" lts="l" m="0">Contact</Heading>
+              <Heading level="3" class="z--lp001-hgroup_subHeading" d="inline-flex" ai="c" g="20" fz="s" fw="normal" lts="l" m="0">
+                お問い合わせ
+              </Heading>
+            </Stack>
+            <Text as="p" class="u--fadeIn" max-sz="full" mx="auto" m="0">
+              本セクションはデモ用の導線です。Lism
+              CSSは軽量なCSS設計フレームワークとして、一つのCSSを読み込むことから導入でき、React・Astro向けの専用コンポーネント利用も、公式の概要（https://lism-css.com/docs/overview/）のとおり行えます。
+              採用判断や事実の確認は、同ページおよび各リポジトリの一次情報を正としてください。
+            </Text>
+            <Cluster class="u--fadeIn" jc="c" g="15">
+              <BoxLink
+                href="###"
+                layout="grid"
+                gtc="1em 1fr 1em"
+                ji="center"
+                ai="center"
+                px="20"
+                py="15"
+                g="30"
+                w="14rem"
+                td="none"
+                bgc="black"
+                c="white"
+                bdrs="99"
+                hov="neutral"
+              >
+                <Inline gc="2" fz="m" m="0"> Try Lism CSS </Inline>
+                <Icon icon="arrow-right" />
+              </BoxLink>
+            </Cluster>
+          </Stack>
+        </Container>
+      </Box>
+    </Container>
+    <!-- Footer -->
+
+    <Container as="footer" isWrapper="m" py="40" hasGutter>
+      <Stack jc="c" ai="c" g="30">
+        <Stack class="z--lp001-header_logo">
+          <Text as="p" fz="xl" fw="400" lts="l" m="0">
+            <Inline fw="200">The</Inline>Minimal
+          </Text>
+        </Stack>
+        <Cluster g="20">
+          {
+            footerSnsLinks.map(({ href, icon, label }) => (
+              <Link href={href} td="none" c="text-2" hov="-o" hasTransition aria-label={label}>
+                <Icon icon={icon} fz="l" />
+              </Link>
+            ))
+          }
+        </Cluster>
+        <Text as="p" fz="s" c="text-2" m="0">© 2026 Lism CSS.</Text>
+      </Stack>
+    </Container>
+  </Wrapper>
+</DemoLayout>
+
+<style>
+  @layer lism-custom {
+    /* Root */
+    :root {
+      --z--lp001-header-height: 112px;
+      --z--lp001-header-height--thin: 64px;
+      --u--fadeIn--animation-range: entry 0% contain 20%;
+    }
+    /* Fadein */
+    .u--fadeIn {
+      view-timeline: --u--fadeIn y;
+      animation: u--fadeIn linear both;
+      animation-timeline: --u--fadeIn;
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+    @keyframes u--fadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(32px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+    /* Background Parallax */
+    .u--bgParallax {
+      view-timeline: --u--bgParallax y;
+    }
+    .u--bgParallax .a--media {
+      position: absolute;
+      top: -20%;
+      height: 140%;
+      animation: u--bgParallax_media linear both;
+      animation-timeline: --u--bgParallax;
+      animation-range: entry 0% cover 100%;
+    }
+    @keyframes u--bgParallax_media {
+      from {
+        transform: translateY(-10%);
+      }
+      to {
+        transform: translateY(10%);
+      }
+    }
+
+    .z--lp001-header {
+      height: var(--z--lp001-header-height);
+      /* この量スクロールしてからヘッダー変化アニメーションを開始（終了は +160px スクロール地点） */
+      --z--lp001-header-scroll-animation-start: 100px;
+      --z--lp001-header-animation-range: var(--z--lp001-header-scroll-animation-start) calc(var(--z--lp001-header-scroll-animation-start) + 160px);
+      animation: z--lp001-header linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--lp001-header-animation-range);
+    }
+    @keyframes z--lp001-header {
+      to {
+        background-color: var(--white);
+        height: var(--z--lp001-header-height--thin);
+        box-shadow: var(--bxsh--20);
+      }
+    }
+    .z--lp001-header_logoLink {
+      animation: z--lp001-header_logoLink linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--lp001-header-animation-range);
+    }
+    @keyframes z--lp001-header_logoLink {
+      to {
+        color: var(--black);
+      }
+    }
+    /* Header nav */
+    .z--lp001-headerNav_subMenuButton {
+      anchor-name: --parent-anchor;
+    }
+    .z--lp001-headerNav_link,
+    .z--lp001-headerNav_subMenuButton {
+      animation: z--lp001-headerNav_link linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--lp001-header-animation-range);
+    }
+    @keyframes z--lp001-headerNav_link {
+      to {
+        color: var(--text-2);
+      }
+    }
+    .z--lp001-headerNav_subMenu {
+      position-anchor: --parent-anchor;
+      top: anchor(bottom);
+      justify-self: anchor-center;
+      position: absolute;
+
+      /* 画面端（右端）で切れる場合の自動回避設定 */
+      position-try-fallbacks: flip-inline;
+      position-try-order: most-width;
+
+      visibility: hidden;
+      opacity: 0;
+      transform: translateY(8px);
+      transition:
+        visibility 0.3s ease,
+        transform 0.3s ease,
+        opacity 0.3s ease;
+    }
+    .z--lp001-headerNav:has(.z--lp001-headerNav_subMenuButton:hover, .z--lp001-headerNav_subMenu:hover) .z--lp001-headerNav_subMenu {
+      visibility: visible;
+      opacity: 1;
+      transform: translateY(0);
+    }
+    /* Sub menu */
+    .z--lp001-header_subMenu_buttonIcon {
+      animation: z--lp001-header_subMenu_buttonIcon linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--lp001-header-animation-range);
+    }
+    @keyframes z--lp001-header_subMenu_buttonIcon {
+      to {
+        color: var(--text-2);
+      }
+    }
+    /* モバイルメニュー: +/- を caret-right（fz--s）に近い視覚サイズへ（@lism-css/ui 内 DOM は Astro スコープ外のため :global） */
+    .z--lp001-header_menuNav :global(.c--accordion_icon) {
+      font-size: var(--fz--s);
+      width: 1em;
+      height: 1em;
+      transform: scale(0.75);
+      transform-origin: center;
+    }
+
+    .z--lp001-mv {
+      --z--lp001-mv_animation-range: 0px 100svh;
+      height: 100svh;
+    }
+    .z--lp001-mv .z--lp001-mv_frame {
+      animation: z--lp001-mv_frame linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--lp001-mv_animation-range);
+    }
+    @keyframes z--lp001-mv_frame {
+      from {
+        filter: blur(0px);
+        opacity: 1;
+      }
+      to {
+        filter: blur(16px);
+        opacity: 0;
+        transform: scale(1.05);
+      }
+    }
+    .z--lp001-mv .z--lp001-mv_media {
+      animation: z--lp001-mv_media linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--lp001-mv_animation-range);
+    }
+    @keyframes z--lp001-mv_media {
+      from {
+        transform: translateY(0);
+      }
+      to {
+        transform: translateY(15%);
+      }
+    }
+    .z--lp001-mv_content {
+      top: calc(var(--z--lp001-header-height) / 2 * -1);
+      height: calc(100% + var(--z--lp001-header-height) / 2);
+      animation: z--lp001-mv_content linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--lp001-mv_animation-range);
+    }
+    @keyframes z--lp001-mv_content {
+      from {
+        transform: scale(1);
+      }
+      to {
+        transform: scale(1.2);
+      }
+    }
+    .z--lp001-mv_scrollDown {
+      bottom: 2rem;
+      left: 50%;
+      transform: translateX(-50%);
+      animation: z--lp001-mv_scrollDown linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--lp001-mv_animation-range);
+    }
+    @keyframes z--lp001-mv_scrollDown {
+      from {
+        opacity: 1;
+      }
+      to {
+        opacity: 0;
+        transform: translateX(-50%) translateY(32px);
+        filter: blur(8px);
+      }
+    }
+    .z--lp001-mv_scrollDownIcon {
+      animation: z--lp001-mv_scrollDownIcon 2.4s infinite;
+    }
+    @keyframes z--lp001-mv_scrollDownIcon {
+      0% {
+        transform: translateY(0);
+        opacity: 0;
+      }
+      50% {
+        opacity: 1;
+      }
+      100% {
+        transform: translateY(8px);
+        opacity: 0;
+      }
+    }
+
+    .z--lp001-about {
+      isolation: isolate;
+      view-timeline: --z--lp001-about-timeline y;
+      --z--lp001-about_range-start: 25%;
+      --z--lp001-about_range-end: 20%;
+    }
+    .z--lp001-about .z--lp001-hgroup {
+      position: relative;
+      z-index: 1;
+    }
+    .z--lp001-about .z--lp001-about_visuals {
+      pointer-events: none;
+    }
+    .z--lp001-about .z--lp001-about_frame {
+      animation: z--lp001-about_frame linear both;
+      animation-timeline: --z--lp001-about-timeline;
+    }
+    .z--lp001-about .z--lp001-about_frame:nth-child(1) {
+      top: -2rem;
+      right: 90%;
+      animation-range: entry 0% cover 30%;
+    }
+    .z--lp001-about .z--lp001-about_frame:nth-child(2) {
+      top: 6rem;
+      left: 90%;
+      animation-range: entry 20% cover 40%;
+    }
+    .z--lp001-about .z--lp001-about_frame:nth-child(3) {
+      bottom: -6rem;
+      right: 80%;
+      animation-range: entry 40% cover 50%;
+    }
+    @container (min-width: 800px) {
+      .z--lp001-about .z--lp001-about_frame:nth-child(1) {
+        top: -2rem;
+        right: calc(100% + 4rem);
+      }
+      .z--lp001-about .z--lp001-about_frame:nth-child(2) {
+        top: 6rem;
+        left: calc(100% + 4rem);
+      }
+      .z--lp001-about .z--lp001-about_frame:nth-child(3) {
+        bottom: -6rem;
+        right: calc(100% - 4rem);
+      }
+    }
+    @keyframes z--lp001-about_frame {
+      from {
+        opacity: 0;
+        filter: blur(16px);
+        transform: scale(1.16);
+      }
+      to {
+        opacity: 1;
+        filter: blur(0);
+        transform: scale(1);
+      }
+    }
+    .z--lp001-about .z--lp001-about_media {
+      animation: z--lp001-about_media linear both;
+      animation-timeline: --z--lp001-about-timeline;
+      animation-range: entry cover;
+    }
+    @keyframes z--lp001-about_media {
+      from {
+        transform: scale(1.2);
+      }
+      to {
+        transform: scale(1);
+      }
+    }
+
+    .z--lp001-feature {
+      view-timeline: --z--lp001-feature y;
+    }
+    .z--lp001-feature .z--lp001-feature_media {
+      width: 100%;
+      position: absolute;
+      top: -20%;
+      height: 140%;
+      animation: z--lp001-feature_media linear both;
+      animation-timeline: --z--lp001-feature;
+      animation-range: entry 0% cover 100%;
+    }
+    @keyframes z--lp001-feature_media {
+      from {
+        transform: translateY(-10%);
+      }
+      to {
+        transform: translateY(10%);
+      }
+    }
+    .z--lp001-feature .z--lp001-feature_item {
+      view-timeline: --z--lp001-feature_item y;
+      animation: u--fadeIn linear both;
+      animation-timeline: --z--lp001-feature_item;
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+    .z--lp001-feature .z--lp001-feature_itemMedia {
+      width: 100%;
+      position: absolute;
+      top: -20%;
+      height: 140%;
+      animation: z--lp001-feature_itemMedia linear both;
+      animation-timeline: --z--lp001-feature_item;
+      animation-range: entry 0% cover 100%;
+    }
+    @keyframes z--lp001-feature_itemMedia {
+      from {
+        transform: translateY(-10%);
+      }
+      to {
+        transform: translateY(10%);
+      }
+    }
+    .z--lp001-feature .z--lp001-feature_item:nth-child(even) .z--lp001-feature_itemContent {
+      justify-self: end;
+    }
+
+    .z--lp001-works .z--lp001-works_item {
+      view-timeline: --z--lp001-works_item y;
+      animation: z--lp001-works_item linear both;
+      animation-timeline: --z--lp001-works_item;
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+    @keyframes z--lp001-works_item {
+      from {
+        transform: translateY(32px) scale(1.04);
+        filter: blur(8px);
+        opacity: 0;
+      }
+      to {
+        transform: translateY(0) scale(1);
+        filter: blur(0);
+        opacity: 1;
+      }
+    }
+    .z--lp001-works .z--lp001-works_frame {
+      view-timeline: --z--lp001-works_frame y;
+    }
+    .z--lp001-works .z--lp001-works_media {
+      animation: z--lp001-works_media linear both;
+      animation-timeline: --z--lp001-works_frame;
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+    @keyframes z--lp001-works_media {
+      from {
+        transform: scale(1.2);
+      }
+      to {
+        transform: scale(1);
+      }
+    }
+    @media (any-hover: hover) {
+      .-hov\:in\:zoom {
+        scale: var(--_isHov, 1.1);
+      }
+    }
+
+    .z--lp001-news {
+      view-timeline: --z--lp001-news y;
+    }
+    .z--lp001-news .z--lp001-news_media {
+      width: 100%;
+      position: absolute;
+      top: -20%;
+      height: 140%;
+      animation: z--lp001-news_media linear both;
+      animation-timeline: --z--lp001-news;
+      animation-range: entry 0% cover 100%;
+    }
+    @keyframes z--lp001-news_media {
+      from {
+        transform: translateY(-10%);
+      }
+      to {
+        transform: translateY(10%);
+      }
+    }
+    .z--lp001-news .z--lp001-news_item {
+      view-timeline: --z--lp001-news_item y;
+      animation: z--lp001-news_item linear both;
+      animation-timeline: --z--lp001-news_item;
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+    @media (any-hover: hover) {
+      .-hov\:in\:underline {
+        text-decoration: var(--_isHov, underline);
+      }
+    }
+    @keyframes z--lp001-news_item {
+      from {
+        opacity: 0;
+        transform: translateX(-16px);
+      }
+      to {
+        opacity: 1;
+        transform: translateX(0);
+      }
+    }
+
+    .z--lp001-faq .c--accordion {
+      view-timeline: --z--lp001-faq_accordion y;
+      animation: u--fadeIn linear both;
+      animation-timeline: --z--lp001-faq_accordion;
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+    @media (any-hover: hover) {
+      .-hov\:in\:underline {
+        text-decoration: var(--_isHov, underline);
+      }
+    }
+
+    .z--lp001-testimonials .z--lp001-testimonials_item {
+      view-timeline: --z--lp001-testimonials_item y;
+      animation: u--fadeIn linear both;
+      animation-timeline: --z--lp001-testimonials_item;
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+
+    /* ページ全体の .u--fadeIn は同名 view-timeline が衝突するため、本セクションは view() で独立させる */
+    .z--lp001-information .z--lp001-information_dl {
+      animation: u--fadeIn linear both;
+      animation-timeline: view(block);
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+    .z--lp001-information .z--lp001-information_map {
+      animation: u--fadeIn linear both;
+      animation-timeline: view(block);
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+
+    .z--lp001-contact {
+      view-timeline: --z--lp001-contact y;
+    }
+    .z--lp001-contact_media {
+      animation: z--lp001-contact_media linear both;
+      animation-timeline: --z--lp001-contact;
+      animation-range: entry 0% cover 100%;
+    }
+    @keyframes z--lp001-contact_media {
+      from {
+        transform: translateY(-10%);
+      }
+      to {
+        transform: translateY(10%);
+      }
+    }
+
+    .z--lp001-hgroup {
+      view-timeline: --z--lp001-hgroup y;
+    }
+    .z--lp001-hgroup.z--lp001-hgroup--light {
+      color: var(--white);
+    }
+    .z--lp001-hgroup .z--lp001-hgroup_heading {
+      animation: z--lp001-hgroup_heading linear both;
+      animation-timeline: --z--lp001-hgroup;
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+    @keyframes z--lp001-hgroup_heading {
+      from {
+        opacity: 0;
+        letter-spacing: 0.1em;
+        text-indent: 0.1em;
+        transform: translateY(32px);
+      }
+      to {
+        opacity: 1;
+        letter-spacing: var(--lts--l);
+        text-indent: var(--lts--l);
+        transform: translateY(0);
+      }
+    }
+    .z--lp001-hgroup .z--lp001-hgroup_subHeading {
+      position: relative;
+      animation: z--lp001-hgroup_heading linear both;
+      animation-timeline: --z--lp001-hgroup;
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+    .z--lp001-hgroup .z--lp001-hgroup_subHeading:before,
+    .z--lp001-hgroup .z--lp001-hgroup_subHeading:after {
+      display: block;
+      content: '';
+      width: 12px;
+      height: 1px;
+      background-color: var(--text);
+      transform-origin: center right;
+      animation: z--lp001-hgroup_subHeading_beforeAfter linear both;
+      animation-timeline: --z--lp001-hgroup;
+      animation-range: contain 25% contain 45%;
+    }
+    .z--lp001-hgroup .z--lp001-hgroup_subHeading:after {
+      transform-origin: center left;
+    }
+    .z--lp001-hgroup.z--lp001-hgroup--light .z--lp001-hgroup_subHeading:before,
+    .z--lp001-hgroup.z--lp001-hgroup--light .z--lp001-hgroup_subHeading:after {
+      background-color: var(--white);
+    }
+    @keyframes z--lp001-hgroup_subHeading_beforeAfter {
+      from {
+        transform: scaleX(0);
+      }
+      to {
+        transform: scaleX(1);
+      }
+    }
+  }
+</style>

--- a/apps/docs/src/pages/preview/templates/lp/lp002/_style.css
+++ b/apps/docs/src/pages/preview/templates/lp/lp002/_style.css
@@ -1,0 +1,1 @@
+/* LP002: Simple Natural LP */

--- a/apps/docs/src/pages/preview/templates/lp/lp002/index.astro
+++ b/apps/docs/src/pages/preview/templates/lp/lp002/index.astro
@@ -1,0 +1,1531 @@
+---
+import DemoLayout from '@/layouts/DemoLayout.astro';
+import {
+  AutoColumns,
+  Box,
+  BoxLink,
+  Center,
+  Cluster,
+  Container,
+  Flex,
+  Frame,
+  Grid,
+  Heading,
+  Icon,
+  Inline,
+  Layer,
+  Link,
+  Lism,
+  ListItem,
+  Media,
+  Stack,
+  Text,
+  Wrapper,
+} from 'lism-css/astro';
+import { Accordion, Avatar, Button, Modal } from '@lism-css/ui/astro';
+
+export const title = 'LP002: Simple Natural LP';
+
+/** デスクトップ上部ナビ（5件） */
+const headerPrimaryNavItems = [
+  { href: '#mission', ja: 'ミッション', en: 'Mission' },
+  { href: '#feature', ja: '特長', en: 'Feature' },
+  { href: '#service', ja: 'サービス', en: 'Service' },
+  { href: '#step', ja: 'ご依頼の流れ', en: 'Step' },
+  { href: '#voice', ja: 'お客様の声', en: 'Voice' },
+] as const;
+
+/** モバイルドロワー内の全アンカー（デスクトップ行とは構成が異なる） */
+const headerMenuNavItems = [
+  { href: '#top', ja: 'トップ', en: 'Top' },
+  { href: '#mission', ja: 'ミッション', en: 'Mission' },
+  { href: '#message', ja: 'コーディネート', en: 'Message' },
+  { href: '#feature', ja: '特長', en: 'Feature' },
+  { href: '#service', ja: 'サービス', en: 'Service' },
+  { href: '#step', ja: 'ご依頼の流れ', en: 'Step' },
+  { href: '#voice', ja: 'お客様の声', en: 'Voice' },
+  { href: '#faq', ja: 'よくあるご質問', en: 'FAQ' },
+  { href: '#contact', ja: 'お問い合わせ', en: 'Contact' },
+] as const;
+
+const mvImage = {
+  src: 'https://cdn.lism-css.com/img/room/a-Rrr1UZO5Ji.jpg',
+  alt: '赤いソファと観葉植物のあるモダンなリビング',
+  width: 1920,
+  height: 1080,
+} as const;
+
+const missionImage = {
+  src: 'https://cdn.lism-css.com/img/room/u-MojU9rQhZn.jpg',
+  alt: '日差しの入るリビング。ソファ、ラグ、大きな窓と観葉植物のある室内',
+  width: 1920,
+  height: 1280,
+} as const;
+
+const missionBody =
+  '暮らしの形は、家族構成も予算も理想もそれぞれ違います。LISM Lifeは、賃貸でも戸建てでも、日々の暮らし方や悩みを丁寧にお伺いし、家具の選び方からコーディネート、必要に応じた配置やお手伝いまでを一貫して支えます。雑誌の切り抜きがなくても、イメージのかけらから具体的な部屋づくりへと一緒に形にします。小さな相談と本格的な部屋作り、どちらも「自分らしい住みよさ」へつながる一歩になればと考えています。';
+
+/**
+ * 1・2 行目のテキスト列の最大幅（Lism `max-sz`）。
+ * 従来の「列いっぱい」に戻す: `undefined` にして保存（または `max-sz={mission2TextMaxSz}` 2 行を削除）。
+ */
+const mission2TextMaxSz: 's' | undefined = 's';
+
+/** ヘッダー主ナビと同一5件 */
+const footerPrimaryNavItems = [
+  { href: '#mission', ja: 'ミッション', en: 'Mission' },
+  { href: '#feature', ja: '特長', en: 'Feature' },
+  { href: '#service', ja: 'サービス', en: 'Service' },
+  { href: '#step', ja: 'ご依頼の流れ', en: 'Step' },
+  { href: '#voice', ja: 'お客様の声', en: 'Voice' },
+] as const;
+
+const footerSnsLinks = [
+  { href: '#', icon: 'logo-x' as const, label: 'X' },
+  { href: '#', icon: 'logo-instagram' as const, label: 'Instagram' },
+  { href: '#', icon: 'logo-youtube' as const, label: 'YouTube' },
+  { href: '#', icon: 'logo-line' as const, label: 'LINE' },
+] as const;
+
+const featureImage = {
+  src: 'https://cdn.lism-css.com/img/room/u-jh2GpjGKEp.jpg',
+  alt: '明るいリビングにイエローのアームチェアとフロアランプが置かれたインテリア',
+  width: 1600,
+  height: 1067,
+};
+
+/** Lism プリセットアイコン名（ https://lism-css.com/docs/primitives/a--icon/ ） */
+type FeatureCardIcon =
+  | 'home'
+  | 'heart'
+  | 'calendar'
+  | 'book'
+  | 'chat'
+  | 'tag'
+  | 'clock'
+  | 'lightbulb'
+  | 'cart'
+  | 'star'
+  | 'bookmark'
+  | 'user'
+  | 'gear'
+  | 'arrow-right';
+
+/** カードごとの表示内容（タイトル・本文・アイコンを独立して管理） */
+const featureCards: { title: string; body: string; icon: FeatureCardIcon }[] = [
+  {
+    icon: 'home',
+    title: '賃貸でも戸建てでも、住まいの形に合わせる',
+    body: '入居期間や間取り、子どもやペットの有無に応じたご提案を心がけています。既製の家具同士の組み合わせから、小さなスペースの活かし方まで、状況に合わせて一緒に考えます。',
+  },
+  {
+    icon: 'heart',
+    title: '悩み相談から、コーディネートまで一貫して',
+    body: '雑多な要望の整理、色や素材の方向性づくり、具体的な品の候補づくりまで、必要な深さに合わせて伴走します。相談だけのご利用と、手配・設置のお願いまで、幅のある対応が可能です。',
+  },
+  {
+    icon: 'arrow-right',
+    title: '多様な取り扱いと、自社アイテムのご案内',
+    body: '暮らし方に合わせ、多様なブランドを扱い、自社企画の家具や小物のご紹介も行っています。価帯やデザインの好みに応じ、選び方の比較もお手伝いします。',
+  },
+  {
+    icon: 'book',
+    title: '予算と目的に合わせた、無理のない段取り',
+    body: 'まず手を入れたい場所から整える、将来に備え徐々に揃えるといった段階のご相談も歓迎です。想定おおよその費用感の整理や、優先度の相談にもお答えします。',
+  },
+  {
+    icon: 'chat',
+    title: '打ち合わせは来店、オンライン、お電話のいずれも可',
+    body: '日々の予定に合わせ、ヒアリングの仕方を選べます。写真や図面をお持ちの場合は共有いただくと、打ち合わせが円滑です。遠方の方も、まずは内容を伺うところから始められます。',
+  },
+];
+
+const heroImage = {
+  src: 'https://cdn.lism-css.com/img/room/a-6wASe0C2nM.jpg',
+  alt: '花の額、木机とパソコン。本棚付き日当たりの良い在宅デスク',
+  width: 1920,
+  height: 1280,
+};
+
+const serviceSubCards: {
+  index: string;
+  titleJa: string;
+  titleEn: string;
+  body: string;
+  image: { src: string; alt: string; width: number; height: number };
+}[] = [
+  {
+    index: '01',
+    titleJa: '要望の幅に合わせる',
+    titleEn: 'Scope that fits you',
+    body: '部屋づくりのご相談内容は多様です。相談だけ、家具の買い足し、間取りに合わせた一式の手配といった違いに対応し、打ち合わせからおおまかな費用感の整理までお気軽にどうぞ。',
+    image: {
+      src: 'https://cdn.lism-css.com/img/room/u-M1jaFJaeKW.jpg',
+      alt: '白ソファ、黄色系額9枚、カラークッション、フロア灯。明るいリビング',
+      width: 1920,
+      height: 1282,
+    },
+  },
+  {
+    index: '02',
+    titleJa: '好みと暮らしやすさの両立',
+    titleEn: 'Comfort and your taste',
+    body: '見た目の好みと、毎日の導線や片づけやすさを同時に考えます。流行に流されすぎない素材感や、長く手放しにくい造りの家具もご提案の対象です。',
+    image: {
+      src: 'https://cdn.lism-css.com/img/room/u-muaD49UlYx.jpg',
+      alt: '木ベッド、白木のナイトと卓上灯。グレー壁の寝室',
+      width: 1920,
+      height: 1280,
+    },
+  },
+  {
+    index: '03',
+    titleJa: 'ほっと戻れる、自分の部屋へ',
+    titleEn: 'A room to come back to',
+    body: '仕事帰りや家事の合間に、落ち着いて過ごしたい。そうした声を大切に、照明や配置の工夫、リラックスできるコーナーづくりもご一緒に考えます。',
+    image: {
+      src: 'https://cdn.lism-css.com/img/room/u-8HzizEUdqH.jpg',
+      alt: '木天井と間接灯、L字ソファ、大理石風ローテーブル、本棚。広めのリビング',
+      width: 1920,
+      height: 1283,
+    },
+  },
+];
+
+const stepImage = {
+  src: 'https://cdn.lism-css.com/img/room/a-0ojkYuqTrl.jpg',
+  alt: '日差しの入るホームオフィスとソファ、デスクが並んだ室内',
+  width: 1920,
+  height: 1080,
+};
+
+type StepCard = {
+  title: string;
+  body: string;
+  image?: { src: string; alt: string; width: number; height: number };
+};
+
+const stepCards: StepCard[] = [
+  {
+    title: 'お問い合わせと初回のヒアリング',
+    body: 'フォームやお電話、来店のいずれかでご連絡ください。ざっくりとした希望や、今いちばん困っている点を言葉に整え、次回以降の打ち合わせで詰める内容の目安を共有します。オンライン面談も選べます。',
+    image: {
+      src: 'https://cdn.lism-css.com/img/working/a_6SNi6XvWBT.jpg',
+      alt: '打ち合わせを行う室内のイメージ',
+      width: 1920,
+      height: 1280,
+    },
+  },
+  {
+    title: '暮らしの課題と、イメージのすり合わせ',
+    body: '日々の動線、収納、好みの雰囲気や色の傾向などを一緒に言葉にします。既にお持ちの家具や、残したいものの有無も伺い、後の打ち合わせが円滑になるよう整えます。',
+  },
+  {
+    title: '方向性づくりと、おおまかな費用感',
+    body: '家具の候補やレイアウト案、作業範囲のイメージを固め、優先度に沿った大まかな費用感の整理に進みます。納得いただくまで、説明のペースに合わせて調整します。',
+    image: {
+      src: 'https://cdn.lism-css.com/img/room/a-Kt7MCU3Mad.jpg',
+      alt: '明るいリビングのインテリア写真',
+      width: 1200,
+      height: 900,
+    },
+  },
+  {
+    title: '手配と設置・立ち上げの作業',
+    body: 'ご了承のうえ、家具の手配、搬入、設置や簡易な立ち上げ作業のお願いに進みます。入居日や来客の都合、マンションの管理規則の確認が必要な場合は事前に共有いただけますと助かります。',
+  },
+  {
+    title: '納品後のフォロー',
+    body: '使ってみたあとの違和感、追加で揃えたい小物の相談もお気軽にどうぞ。大きなリフォームまでは扱いませんが、配置の微調整や次の一歩の相談も同じ流れで承ります。',
+  },
+];
+
+/**
+ * アバター: 本番・CMS ではカードごとに URL がばらばらになり得るため、`avatarBase` は使わず `src` にフル URL を直書きする
+ * @see https://lism-css.com/docs/ui/avatar/
+ */
+type VoiceCard = {
+  avatar: { src: string; alt: string };
+  title: string;
+  body: string;
+  attribution: string;
+};
+
+const voiceCards: VoiceCard[] = [
+  {
+    avatar: { src: 'https://cdn.lism-css.com/img/avatar/a_DpTwx1lZU3.jpg', alt: '相談者のポートレート（1）' },
+    title: '一人暮らしの部屋で迷子でした',
+    body: '「落ち着く」は何かを言葉にするのに時間がかかりました。家具の大きさと導線の相談で、本当に買う量が決まり、開けたときの圧迫感がかなり減りました。雑多な要望に辛抱強く乗っていただき、感謝しています。',
+    attribution: '20代・ワンルーム相談',
+  },
+  {
+    avatar: { src: 'https://cdn.lism-css.com/img/avatar/a_Bp5H4TO2tS.jpg', alt: '相談者のポートレート（2）' },
+    title: '家族の物が一気所に流れ着く家でした',
+    body: '子どもが小さく、動線と収納の相談が中心でした。既製のユニットと手元の物の掛け合わせで、予算内で我慢せず使える動きになりました。途中で好みの変化も出ましたが、一緒に再調整してもらい安心でした。',
+    attribution: '30代・戸建て相談',
+  },
+  {
+    avatar: { src: 'https://cdn.lism-css.com/img/avatar/a_To1qVvQb79.jpg', alt: '相談者のポートレート（3）' },
+    title: '角部屋の形に合う家具探し',
+    body: '賃貸の角部屋で、定番サイズの家具が合わない場面が多く困っていました。寸法感とメーカーの違いを比較しながら、落ち着いた色面でまとめてもらいました。日当たりの印象も変えずに、すっきり見えています。',
+    attribution: '40代・賃貸相談',
+  },
+  {
+    avatar: { src: 'https://cdn.lism-css.com/img/avatar/a_TjjtOsU0kg.jpg', alt: '相談者のポートレート（4）' },
+    title: 'リモート用の作業机まわりを整えたい',
+    body: '在宅中心になり、本棚とデスク、照明のバランスが課題でした。小さな部屋のまま、仕切り方と照度感を相談し、作業中の集中と夕方以降の落ち着きの両方を意識した提案でした。買い足しの順序も一緒に考え助かりました。',
+    attribution: '50代・在宅併用',
+  },
+  {
+    avatar: { src: 'https://cdn.lism-css.com/img/avatar/a_syw7vEz0mS.jpg', alt: '相談者のポートレート（5）' },
+    title: '母の家の改め方を相談',
+    body: '足腰を考え、座椅子から椅子への入れ替えと、廊下の明るさの話を一緒に整理しました。派手に変えすぎず、慣れ親しんだ家財も活かしつつ、毎日の足取りを軽くする方向性で合意して進められました。',
+    attribution: '60代・家族代理の相談',
+  },
+  {
+    avatar: { src: 'https://cdn.lism-css.com/img/avatar/a_w7f7eeA81h.jpg', alt: '相談者のポートレート（6）' },
+    title: '小さな相談のつもりでした',
+    body: '最初は「このテーブルで合うか」程度の相談でしたが、他の部屋のバランスまで見てもらい、我が家向けの配色の軸を決めてもらいました。一気に全部は揃えず、段階的に揃えていく方針が腹落ちしました。',
+    attribution: '20代・初めての家具相談',
+  },
+];
+
+/** 各項目は質問・回答を独立して管理（必要に応じて初期展開を指定） */
+const faqItems: { question: string; answer: string; defaultOpen?: boolean }[] = [
+  {
+    question: 'まず相談だけ、という利用も可能ですか？',
+    answer:
+      '可能です。暮らしの悩みの整理、家具の大きさや配置の当たり前の確認、費用感の大まかな目安づくりなど、範囲に応じてお受けします。以降の手配はご希望とご了承のうえで段階的に進められます。',
+    defaultOpen: true,
+  },
+  {
+    question: '打ち合わせの合間で方針を変えたいのですが、流れを教えてください',
+    answer:
+      '中間段階で方針の修正が出ることは少なくありません。都度、優先度と費用感をすり合わせ、新しい要望に合わせて候補を入れ替えます。大きな変更の場合は、手配前に必ず合意形成を図るようにしています。',
+  },
+  {
+    question: '家具代のお支払い方法を教えてください',
+    answer:
+      '品やお取引条件により、前金・引き渡し前の一括、分割のご相談など、内容に合わせて案内します。各種のお支払い方法に対応している場合と、都度明細化する場合とがあります。初回面談で大まかな形を共有します。',
+  },
+  {
+    question: '賃貸のため、取り付けに制限があります',
+    answer:
+      '管理規則に照らし、釘やビスの可否、重い家具の搬入ルート、壁面の扱いなど、事前に確認が必要な点を一緒に洗い出します。家具選びの段階で、後から手戻りが出にくい候補に寄せることも可能です。',
+  },
+  {
+    question: '戸建てで、作業範囲の線引きを知りたいです',
+    answer:
+      '大規模なリフォームや水回りの工事専業は範囲外とさせていただくことがあり、家具の手配、搬入、設置や簡易な立ち上げに合わせたお手伝いを中心にします。線引きの個別相談は、現地や図面を共有いただけると円滑です。',
+  },
+];
+
+const bgImage = {
+  src: 'https://cdn.lism-css.com/img/room/u-N1EvhlxYpo.jpg',
+  alt: '窓から光が差し込む開放的なリビング',
+  width: 1920,
+  height: 1080,
+};
+
+/** 各フィールドの表示・name・プレースホルダーを独立して管理 */
+type ContactField =
+  | {
+      id: string;
+      name: string;
+      label: string;
+      type: 'text' | 'email';
+      placeholder: string;
+      inputMode?: 'email' | 'text';
+      autoComplete?: string;
+      /** 検証エラー時の補助テキスト（例示用。本番は状態に応じて出し分け） */
+      errorMessage?: string;
+    }
+  | {
+      id: string;
+      name: string;
+      label: string;
+      type: 'textarea';
+      placeholder: string;
+      rows: number;
+      errorMessage?: string;
+    };
+
+const contactFields: ContactField[] = [
+  {
+    id: 'lp002-contact-name',
+    name: 'name',
+    label: '名前',
+    type: 'text',
+    placeholder: '鈴木 太郎',
+    autoComplete: 'name',
+  },
+  {
+    id: 'lp002-contact-email',
+    name: 'email',
+    label: 'メールアドレス',
+    type: 'email',
+    placeholder: 'example@lism.com',
+    inputMode: 'email',
+    autoComplete: 'email',
+    errorMessage: '正しいメールアドレス形式で入力してください。',
+  },
+  {
+    id: 'lp002-contact-subject',
+    name: 'subject',
+    label: '件名',
+    type: 'text',
+    placeholder: '部屋作りのご相談',
+    autoComplete: 'off',
+  },
+  {
+    id: 'lp002-contact-message',
+    name: 'message',
+    label: '問い合わせ内容',
+    type: 'textarea',
+    placeholder: 'お問い合わせ内容はこちらにご記入ください。',
+    rows: 6,
+  },
+];
+---
+
+<DemoLayout title={title}>
+  <link rel="preconnect" href="https://fonts.googleapis.com" slot="head" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin slot="head" />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" slot="head" />
+  <Wrapper class="z--lp002-root" contentSize="full">
+    <!-- Header -->
+
+    <Box as="header" class="z--lp002-header" pos="fixed" i="0" w="100%" z="1" hasTransition>
+      <Container class="z--lp002-header_container" isWrapper="xl" hasGutter h="100%">
+        <Grid class="z--lp002-header_inner" gtc="10rem 1fr" ai="center" h="100%">
+          <Stack class="z--lp002-header_logo">
+            <Link class="z--lp002-header_logoLink" href="#top" fz="2xl" fw="bold" lts="l" c="text" td="none" ff="accent"> LISM Life </Link>
+          </Stack>
+          <Flex jc="fe" g="30">
+            <Flex class="z--lp002-headerNav" as="ul" d={['none', null, 'inline-flex']} ai="c" g="30" fz="s" lts="l">
+              {
+                headerPrimaryNavItems.map(({ href, ja }) => (
+                  <ListItem>
+                    <Link class="z--lp002-headerNav_link" href={href} d="block" c="text" td="none" py="10" hasTransition hov="-o">
+                      {ja}
+                    </Link>
+                  </ListItem>
+                ))
+              }
+            </Flex>
+            <Box d={['none', null, 'flex']} ai="c">
+              <Button href="#contact" fz="xs" bdrs="99"> お問い合わせ </Button>
+            </Box>
+            <Modal.OpenBtn modalId="menu" d={['block', null, 'none']}>
+              <Center p="6" ai="c" jc="c">
+                <Icon icon="menu" c="text" fz="2xl" aria-hidden="true" />
+              </Center>
+            </Modal.OpenBtn>
+          </Flex>
+          <Modal.Root id="menu" class="z--lp002-header_menuModal" isContainer p="0">
+            <Modal.Inner class="z--lp002-header_menuInner" layout="stack" g="0" pos="relative" p="30" bxsh="50" offset="-100% 0">
+              <Modal.CloseBtn modalId="menu" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
+              <Modal.Body layout="stack" g="30" py="40" fx="1" min-h="0" ov-y="auto" w="100%">
+                <Stack class="z--lp002-header_menuNav u--divide" p="0" ov="clip">
+                  {
+                    headerMenuNavItems.map(({ href, ja }) => (
+                      <BoxLink href={href} layout="grid" gtc="1fr auto" ai="c" fz="m" td="none" py="15" px="5">
+                        <Inline>{ja}</Inline>
+                        <Icon icon="caret-right" fz="s" o="pp" />
+                      </BoxLink>
+                    ))
+                  }
+                </Stack>
+              </Modal.Body>
+            </Modal.Inner>
+          </Modal.Root>
+        </Grid>
+      </Container>
+    </Box>
+    <!-- Main Content -->
+    <Container as="main" class="z--lp002-main" pos="relative" z="0">
+      <Box as="section" class="z--lp002-mv" id="top" pos="relative" ov="hidden" aria-label="メインビジュアル">
+        <Heading level="1" class="z--lp002-mv_title" m="0" ta="center" c="white" fw="bold" lts="l" ff="accent">
+          Simple<br />
+          <Inline as="span" whs="nowrap">LP Design</Inline>
+        </Heading>
+        <Box class="z--lp002-mv_imageRail">
+          <Container class="z--lp002-mv_imageInner" isWrapper="l" hasGutter h="100%">
+            <Frame class="z--lp002-mv_frame" ov="hidden" w="100%" h="100%">
+              <Lism
+                as="img"
+                class="z--lp002-mv_media"
+                src={mvImage.src}
+                alt={mvImage.alt}
+                w="100%"
+                h="100%"
+                exProps={{
+                  width: mvImage.width,
+                  height: mvImage.height,
+                  loading: 'eager',
+                  decoding: 'async',
+                  fetchpriority: 'high',
+                }}
+              />
+            </Frame>
+          </Container>
+        </Box>
+      </Box>
+
+      <Lism as="section" id="mission" isContainer class="z--lp002-mission" pos="relative" py="50" my-s="60" ov="hidden">
+        <Lism class="z--lp002-mission_bg" exProps={{ 'aria-hidden': 'true' }} />
+        <Flex fxd={['column', null, 'row']} ai={['start', null, 'stretch']} g={['40', null, '50']} pos="relative" z="1" w="100%">
+          <Flex class="z--lp002-mission_text" fxd="column" ai="start" min-w="0" w="100%">
+            <Stack g="40" ai="start">
+              <Stack g="10" ai="start">
+                <Heading level="2" m="0" fz="5xl" fw="bold" lts="l" c="text" ff="accent"> Mission </Heading>
+                <Text as="p" m="0" fz="xl" fw="bold" lts="l" c="text"> 私たちが目指すもの </Text>
+              </Stack>
+              <Text as="p" m="0" fz="m" lh="l" lts="s" c="text-2">
+                {missionBody}
+              </Text>
+            </Stack>
+          </Flex>
+          <!-- Frame 本体に padding すると l--frame のトークンと競合しやすいため、拡縮用ラッパーに右ガターを乗せる -->
+          <Lism class="z--lp002-mission_figureShell" min-w="0" w="100%">
+            <Frame as="figure" class="z--lp002-mission_figure" m="0" w="100%" min-w="0" jslf="start" ar="3/2" ov="hidden" pos="relative">
+              <img
+                src={missionImage.src}
+                width={missionImage.width}
+                height={missionImage.height}
+                alt={missionImage.alt}
+                loading="lazy"
+                decoding="async"
+                class="z--lp002-mission_img"
+              />
+            </Frame>
+          </Lism>
+        </Flex>
+      </Lism>
+
+      <Wrapper as="section" id="message" contentSize="xl" py="50" hasGutter>
+        <Container>
+          <Stack g="40" class="z--lp002-mission2">
+            <Grid gta={[`'.' 'side'`, null, `'side .'`]} gtc={[null, null, '24rem 1fr']} ai="c" g="40" w="100%">
+              <Stack g="30" w="100%" class="z--lp002-mission2-row1" max-sz={mission2TextMaxSz}>
+                <Heading level="3" fz="xl" lts="l">暮らしに合わせたコーディネート</Heading>
+                <Text>
+                  生活リズムや家族構成、日々の悩みまで丁寧にヒアリングし、あなたに合う心地よさを軸に考えをまとめます。家具の取り合わせに加え、収納の工夫や小さなレイアウトの提案も含め、長く手を放せる部屋づくりを一緒に進めます。
+                </Text>
+              </Stack>
+              <Frame ga="side" ar="3/2">
+                <Media
+                  src="https://cdn.lism-css.com/img/room/a-Kt7MCU3Mad.jpg"
+                  alt="明るいリビングをイメージしたインテリア写真"
+                  width={1200}
+                  height={900}
+                />
+              </Frame>
+            </Grid>
+            <Grid gta={[`'.' 'side'`, null, `'. side'`]} gtc={[null, null, '1fr 24rem']} ai="c" g="40" w="100%">
+              <Stack class="z--lp002-mission2-row2" w="100%" max-sz={mission2TextMaxSz} ai={[null, null, 'end']} g="30">
+                <Heading level="3" fz="xl" lts="l">想いを、部屋の形に</Heading>
+                <Text>
+                  コーディネートの方針づくりから家具の手配、必要に応じた立ち上げ作業のお手伝いまで、一つの流れとして対応します。完成イメージの写真がなくても、色や好きな雰囲気、暮らしの不満点から一緒に言葉にし、納得のいくまで整えます。
+                </Text>
+              </Stack>
+              <Frame ga="side" ar="3/2">
+                <Media
+                  src="https://cdn.lism-css.com/img/room/u-1K4PsDvC6W.jpg"
+                  alt="ワークスペースをイメージしたインテリア"
+                  width={1200}
+                  height={900}
+                />
+              </Frame>
+            </Grid>
+          </Stack>
+        </Container>
+      </Wrapper>
+
+      <Box as="section" id="feature" class="z--lp002-feature" ov-x="clip">
+        <Container isWrapper="l" hasGutter py="50">
+          <Grid gtc={['1fr', null, 'minmax(0, 1fr) minmax(0, 1fr)']} g={['30', null, '40']} ai="stretch">
+            <Stack class="z--lp002-feature_main" g="40" jc="start">
+              <Stack g="10" ai="c" class="z--lp002-feature_head">
+                <Heading level="2" fz="4xl" lts="l" m="0" ta="center" ff="accent"> Point </Heading>
+                <Text as="p" fz="m" fw="bold" lts="l" m="0" c="text" o="p" ta="center">暮らしに寄り添う特長</Text>
+              </Stack>
+
+              <Stack g="30">
+                {
+                  featureCards.map((card) => (
+                    <Stack class="z--lp002-feature_card" p="30" bgc="base" bd bdc="divider" bdrs="10">
+                      <Flex ai="start" g="20" class="z--lp002-feature_cardInner">
+                        <Icon icon={card.icon} size="2.5rem" c="text-2" />
+                        <Stack g="10" class="z--lp002-feature_cardBody">
+                          <Heading level="3" fz="l" m="0">
+                            {card.title}
+                          </Heading>
+                          <Text as="p" fz="s" m="0" c="text-2">
+                            {card.body}
+                          </Text>
+                        </Stack>
+                      </Flex>
+                    </Stack>
+                  ))
+                }
+              </Stack>
+            </Stack>
+
+            <Box class="z--lp002-feature_rail">
+              <Box class="z--lp002-feature_sticky">
+                <Frame class="z--lp002-feature_frame" ov="hidden" bdrs="0">
+                  <Media
+                    src={featureImage.src}
+                    alt={featureImage.alt}
+                    width={featureImage.width}
+                    height={featureImage.height}
+                    exProps={{ loading: 'lazy', decoding: 'async' }}
+                  />
+                </Frame>
+              </Box>
+            </Box>
+          </Grid>
+        </Container>
+      </Box>
+
+      <Box as="section" id="service" class="z--lp002-service" bgc="base-2" py="50">
+        <Container isWrapper="l" hasGutter>
+          <Stack g="50">
+            <Stack g="40">
+              <Stack g="10" ai="c">
+                <Heading level="2" fz="4xl" lts="l" m="0" ta="center" ff="accent">Service</Heading>
+                <Text as="p" fz="m" fw="bold" lts="l" m="0" c="text" o="p" ta="center">ご要望に合わせたサービス</Text>
+              </Stack>
+
+              <!-- md 未満: 1列（画像上・テキスト下）。md 以上: 2列（画像左・テキスト右） -->
+              <Grid gtc={['1fr', null, 'minmax(0, 1fr) minmax(0, 1fr)']} g={['30', null, '40']} ai="center">
+                <Frame ar="3/2" ov="hidden">
+                  <Media
+                    src={heroImage.src}
+                    alt={heroImage.alt}
+                    width={heroImage.width}
+                    height={heroImage.height}
+                    exProps={{ loading: 'lazy', decoding: 'async' }}
+                  />
+                </Frame>
+                <Stack g="20" jc="c">
+                  <Heading level="3" fz="2xl" lts="l" m="0">
+                    予算や目的に合わせ、
+                    <br />
+                    柔軟に対応します
+                  </Heading>
+                  <Text as="p" m="0" c="text-2">
+                    暮らし方や優先して整えたい場所、購入や配置までお願いしたい範囲などを伺い、無理のない形でご提案にまとめます。来店、オンライン、お電話のいずれからでも打ち合わせを受け付けています。
+                  </Text>
+                  <Text as="p" m="0" c="text-2">
+                    小さな悩み相談から、家具の買い付けに伴う作業のお願いまで、目的に合わせて一つずつ。賃貸・戸建てを問わず、住まいの性質に合う選び方を一緒に考えます。
+                  </Text>
+                </Stack>
+              </Grid>
+            </Stack>
+
+            <Stack g="40">
+              <Heading level="3" fz="xl" lts="l" m="0" ta="center">更なる特徴です</Heading>
+              <!-- md 未満: 1列。md 以上: 3列 -->
+              <Grid gtc={['1fr', null, 'repeat(3, minmax(0, 1fr))']} g="40" ai="start">
+                {
+                  serviceSubCards.map((item) => (
+                    <Flex class="z--lp002-service_card" fxd={['row-reverse', null, 'column']} ai="stretch" g="30" min-w="0">
+                      <Frame class="z--lp002-service_cardFigure" ar="3/2" ov="hidden">
+                        <Media
+                          src={item.image.src}
+                          alt={item.image.alt}
+                          width={item.image.width}
+                          height={item.image.height}
+                          exProps={{ loading: 'lazy', decoding: 'async' }}
+                        />
+                      </Frame>
+                      <Stack g="20" min-w="0" fx="1" jc="start">
+                        <Flex ai="c" g="20" util="trimAll">
+                          <Box as="span" class="z--lp002-service_num" fz="3xl" fw="bold" ff="accent" c="text" whs="nowrap">
+                            {item.index}
+                          </Box>
+                          <Box class="z--lp002-service_rule" w="1px" bgc="text" fxsh="0" />
+                          <Stack g="0" class="z--lp002-service_cardTitles" util="trimAll">
+                            <Heading level="4" fz="m" m="0">
+                              {item.titleJa}
+                            </Heading>
+                            <Text as="p" fz="xs" lh="s" m="0" c="text-2" o="p" ff="accent">
+                              {item.titleEn}
+                            </Text>
+                          </Stack>
+                        </Flex>
+                        <Text as="p" fz="s" m="0" c="text-2">
+                          {item.body}
+                        </Text>
+                      </Stack>
+                    </Flex>
+                  ))
+                }
+              </Grid>
+            </Stack>
+          </Stack>
+        </Container>
+      </Box>
+
+      <Box as="section" id="step" class="z--lp002-step" ov-x="clip">
+        <Container isWrapper="l" hasGutter py="50">
+          <Grid gtc={['1fr', null, 'minmax(0, 1fr) minmax(0, 1fr)']} g={['30', null, '40']} ai="stretch">
+            <Stack class="z--lp002-step_main" g="40" jc="start">
+              <Stack g="10" ai="c" class="z--lp002-step_head">
+                <Heading level="2" fz="4xl" lts="l" m="0" ta="center" ff="accent">Step</Heading>
+                <Text as="p" fz="m" fw="bold" lts="l" m="0" c="text" o="p" ta="center">ご依頼から納品までの流れ</Text>
+              </Stack>
+
+              <Stack g="15" ai="stretch" w="100%">
+                {
+                  stepCards.map((card, i) => (
+                    <>
+                      {i > 0 && (
+                        <Flex class="z--lp002-step_caret" jc="center" ai="center" w="100%" fxsh="0">
+                          <Icon icon="caret-down-fill" fz="2xl" />
+                        </Flex>
+                      )}
+                      <Stack class="z--lp002-step_card" g="15" p="30" bgc="base" bd bdc="divider" bdrs="10" ov="hidden" min-w="0">
+                        {card.image && (
+                          <Frame class="z--lp002-step_cardFrame" ar="3/2" ov="hidden" bdrs="0">
+                            <Media
+                              src={card.image.src}
+                              alt={card.image.alt}
+                              width={card.image.width}
+                              height={card.image.height}
+                              exProps={{ loading: 'lazy', decoding: 'async' }}
+                            />
+                          </Frame>
+                        )}
+                        <Stack g="10" class="z--lp002-step_cardBody">
+                          <Heading level="3" fz="l" m="0">
+                            {card.title}
+                          </Heading>
+                          <Text as="p" fz="s" m="0" c="text-2">
+                            {card.body}
+                          </Text>
+                        </Stack>
+                      </Stack>
+                    </>
+                  ))
+                }
+              </Stack>
+            </Stack>
+
+            <Box class="z--lp002-step_rail">
+              <Box class="z--lp002-step_sticky">
+                <Frame class="z--lp002-step_frame" ov="hidden" bdrs="0">
+                  <Media
+                    src={stepImage.src}
+                    alt={stepImage.alt}
+                    width={stepImage.width}
+                    height={stepImage.height}
+                    exProps={{ loading: 'lazy', decoding: 'async' }}
+                  />
+                </Frame>
+              </Box>
+            </Box>
+          </Grid>
+        </Container>
+      </Box>
+
+      <Box as="section" id="voice" class="z--lp002-voice" bgc="base">
+        <Container isWrapper="l" hasGutter py="50" isContainer>
+          <Stack g="40">
+            <Stack g="10" ai="c">
+              <Heading level="2" fz="4xl" lts="l" m="0" ta="center" ff="accent">Voice</Heading>
+              <Text as="p" fz="m" fw="bold" lts="l" m="0" c="text" o="p" ta="center">お客様の声です</Text>
+            </Stack>
+
+            {
+              /**
+               * md 未満: Flex + hasSnap（公式 Reel の Flex 例と同型。Grid の gaf:column は縦積みになりやすい）
+               * md 以上: AutoColumns（最小幅 24rem、折り返し）
+               * @see https://lism-css.com/docs/ui/examples/reel/
+               * @see https://lism-css.com/docs/primitives/l--autoColumns/
+               */
+            }
+            <Box class="z--lp002-voice_layout" min-w="0" w="100%">
+              <Flex class="z--lp002-voice_reel" hasSnap ov="auto" g="20" fxd="row" fxw="nowrap" ai="stretch" w="100%" min-w="0" tabindex={0}>
+                {
+                  voiceCards.map((card) => (
+                    <Box
+                      class="z--lp002-voice_card z--lp002-voice_slide"
+                      p="30"
+                      bgc="base"
+                      bd
+                      bdc="divider"
+                      bdrs="20"
+                      fxsh="0"
+                      min-w="0"
+                      min-h="0"
+                      d="flex"
+                      fxd="column"
+                      aslf="stretch"
+                    >
+                      <Stack g="20" ai="stretch" fx="1" min-h="0" jc="start">
+                        <Avatar src={card.avatar.src} alt={card.avatar.alt} size="5.5rem" mx="auto" />
+                        <Heading level="3" fz="l" fw="bold" m="0" ta="center">
+                          {card.title}
+                        </Heading>
+                        <Text as="p" fz="s" m="0" c="text" lh="l" ta="left">
+                          {card.body}
+                        </Text>
+                        <Text class="z--lp002-voice_attribution" as="p" fz="xs" m="0" c="text-2" o="p" ta="end" w="100%" mt="auto">
+                          {card.attribution}
+                        </Text>
+                      </Stack>
+                    </Box>
+                  ))
+                }
+              </Flex>
+
+              <AutoColumns class="z--lp002-voice_auto" cols="24rem" g="30" w="100%" min-w="0">
+                {
+                  voiceCards.map((card) => (
+                    <Box class="z--lp002-voice_card" p="30" bgc="base" bd bdc="divider" bdrs="20" min-w="0" d="flex" fxd="column" h="100%">
+                      <Stack g="20" ai="stretch" fx="1" min-h="0" jc="start">
+                        <Avatar src={card.avatar.src} alt={card.avatar.alt} size="5.5rem" mx="auto" />
+                        <Heading level="3" fz="l" fw="bold" m="0" ta="center">
+                          {card.title}
+                        </Heading>
+                        <Text as="p" fz="s" m="0" c="text" lh="l" ta="left">
+                          {card.body}
+                        </Text>
+                        <Text class="z--lp002-voice_attribution" as="p" fz="xs" m="0" c="text-2" o="p" ta="end" w="100%" mt="auto">
+                          {card.attribution}
+                        </Text>
+                      </Stack>
+                    </Box>
+                  ))
+                }
+              </AutoColumns>
+            </Box>
+          </Stack>
+        </Container>
+      </Box>
+
+      <Box as="section" id="faq" class="z--lp002-faq" bgc="base-2">
+        <Container isWrapper="l" hasGutter py="50">
+          <Stack g="40">
+            <Stack g="10" ai="c">
+              <Heading level="2" fz="4xl" lts="l" m="0" ta="center" ff="accent">FAQ</Heading>
+              <Text as="p" fz="m" fw="bold" lts="l" m="0" c="text" o="p" ta="center">よくあるご質問</Text>
+            </Stack>
+
+            <Accordion.Root class="z--lp002-faq_acc" p="0" g="20">
+              {
+                faqItems.map((item) => (
+                  <Accordion.Item bgc="base" bdrs="20" bxsh="10" {...(item.defaultOpen ? { 'data-opened': '' } : {})}>
+                    <Accordion.Heading p="30">
+                      <Accordion.Button fw="bold" ta="start" isOpen={item.defaultOpen === true}>
+                        {item.question}
+                      </Accordion.Button>
+                    </Accordion.Heading>
+                    <Accordion.Panel py="30" px="30" isOpen={item.defaultOpen === true}>
+                      <Text m="0" fz="s" c="text-2" lh="l">
+                        {item.answer}
+                      </Text>
+                    </Accordion.Panel>
+                  </Accordion.Item>
+                ))
+              }
+            </Accordion.Root>
+          </Stack>
+        </Container>
+      </Box>
+
+      <Box as="section" id="contact" class="z--lp002-contact" pos="relative" ov="hidden">
+        <Frame isLayer class="z--lp002-contact_mediaWrap">
+          <Lism
+            as="img"
+            class="z--lp002-contact_media"
+            src={bgImage.src}
+            alt={bgImage.alt}
+            w="100%"
+            h="100%"
+            exProps={{ width: bgImage.width, height: bgImage.height, loading: 'lazy', decoding: 'async' }}
+          />
+        </Frame>
+        <!-- 背景写真の上に半透明の黒レイヤーでコントラストを確保 -->
+        <Layer
+          pos="absolute"
+          exProps={{
+            style: {
+              inset: 0,
+              pointerEvents: 'none',
+              background: 'hsl(0 0% 0% / 0.52)',
+            },
+          }}
+        />
+        <Container class="z--lp002-contact_inner" isWrapper="l" hasGutter py="60" pos="relative">
+          <Stack g="40" ai="c">
+            <Stack g="10" ai="c" max-w="36rem" w="100%">
+              <Heading level="2" fz="4xl" lts="l" m="0" ta="center" c="white" ff="accent">Contact</Heading>
+              <Text as="p" fz="m" fw="bold" lts="l" m="0" c="white" ta="center">お問い合わせ</Text>
+            </Stack>
+
+            <Text as="p" fz="s" m="0" c="white" ta="center" lh="l" max-w="36rem" w="100%">
+              初めての方もどうぞお気軽にお問い合わせください。<br />このフォームはダミーです。
+            </Text>
+
+            <Box as="form" class="z--lp002-contact_form" max-w="36rem" w="100%" method="post" action="#">
+              <Stack g="20">
+                {
+                  contactFields.map((field) => (
+                    <Stack g="10" ai="stretch">
+                      <Lism as="label" for={field.id} fz="s" fw="bold" m="0" c="white">
+                        {field.label}
+                      </Lism>
+                      {field.type === 'textarea' ? (
+                        <textarea
+                          id={field.id}
+                          class="z--lp002-contact_input z--lp002-contact_input--textarea"
+                          name={field.name}
+                          rows={field.rows}
+                          placeholder={field.placeholder}
+                          aria-invalid={field.errorMessage ? 'true' : undefined}
+                          aria-describedby={field.errorMessage ? `${field.id}-error` : undefined}
+                        />
+                      ) : (
+                        <input
+                          id={field.id}
+                          class="z--lp002-contact_input"
+                          name={field.name}
+                          type={field.type}
+                          placeholder={field.placeholder}
+                          inputmode={field.inputMode}
+                          autocomplete={field.autoComplete}
+                          aria-invalid={field.errorMessage ? 'true' : undefined}
+                          aria-describedby={field.errorMessage ? `${field.id}-error` : undefined}
+                        />
+                      )}
+                      {/*
+                  【テンプレート用】フィールド下のエラー文サンプル（`contactFields` の `errorMessage` と対）
+                  本番でクライアント等のバリデーション表示を有効にする場合は、下の <Text> ブロックのコメントを外してください。
+                  id は `lp002-contact-email-error` のように `${field.id}-error` となり、上記 input/textarea の aria-describedby と対応します。
+
+                {field.errorMessage && (
+                  <Text
+                    class='z--lp002-contact_error'
+                    id={`${field.id}-error`}
+                    as='p'
+                    fz='xs'
+                    m='0'
+                    mt='5'
+                    c='red'
+                    role='alert'
+                  >
+                    {field.errorMessage}
+                  </Text>
+                )}
+                */}
+                    </Stack>
+                  ))
+                }
+                <button type="submit" class="z--lp002-contact_submit">この内容で送信 (dummy)</button>
+              </Stack>
+            </Box>
+          </Stack>
+        </Container>
+      </Box>
+    </Container>
+    <!-- Footer -->
+
+    <Box as="footer" class="z--lp002-footer" bgc="base-2" w="100%">
+      <Container class="z--lp002-footer_container" isContainer isWrapper="xl" py="40" hasGutter>
+        <Stack jc="c" ai="c" g="30">
+          <Stack class="z--lp002-header_logo">
+            <Link class="z--lp002-header_logoLink" href="#top" fz="2xl" fw="bold" lts="l" c="text" td="none" ff="accent"> LISM Life </Link>
+          </Stack>
+          <Flex
+            as="ul"
+            class="z--lp002-footerNav z--lp002-headerNav"
+            fxd={['column', 'column', 'row']}
+            ai={['stretch', 'stretch', 'c']}
+            jc={['start', 'start', 'c']}
+            fxw={['nowrap', 'nowrap', 'wrap']}
+            g={['0', '0', '30']}
+            w={['100%', '100%', 'auto']}
+            min-w="0"
+            fz="s"
+            lts="l"
+            m="0"
+            p="0"
+          >
+            {
+              footerPrimaryNavItems.map(({ href, ja }) => (
+                <ListItem>
+                  <Link
+                    class="z--lp002-headerNav_link"
+                    href={href}
+                    d="block"
+                    c="text"
+                    td="none"
+                    w={['100%', '100%', 'auto']}
+                    py={['15', '15', '10']}
+                    hasTransition
+                    hov="-o"
+                  >
+                    {ja}
+                  </Link>
+                </ListItem>
+              ))
+            }
+          </Flex>
+          <Cluster g="20">
+            {
+              footerSnsLinks.map(({ href, icon, label }) => (
+                <Link href={href} td="none" c="text-2" hov="-o" hasTransition aria-label={label}>
+                  <Icon icon={icon} fz="xl" />
+                </Link>
+              ))
+            }
+          </Cluster>
+          <Text as="p" fz="s" c="text-2" m="0">© 2026 Lism CSS.</Text>
+        </Stack>
+      </Container>
+    </Box>
+  </Wrapper>
+</DemoLayout>
+
+<style>
+  @layer lism-custom {
+    /**
+   * `ff:accent`（`--ff--accent`）: セリフに寄らないよう、Montserrat 以外は日本語ゴシック＋汎用 sans へ
+   * @see https://fonts.google.com/specimen/Montserrat
+   */
+    .z--lp002-root {
+      --ff--accent:
+        'Montserrat', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', 'Hiragino Kaku Gothic Pro', 'Yu Gothic', 'YuGothic', 'Noto Sans JP',
+        'BIZ UDGothic', ui-sans-serif, system-ui, sans-serif;
+    }
+
+    :root {
+      --z--lp002-header-height: 112px;
+      --z--lp002-header-height--thin: 64px;
+      --base-2: #ececec;
+    }
+
+    .z--lp002-header {
+      /* ドロワー右の「抜き」幅。ここで --s50 を別トークンや px に差し替え可 */
+      --z--lp002-header-menu-peek: var(--s50);
+      box-sizing: border-box;
+      height: var(--z--lp002-header-height);
+      background-color: transparent;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+      border-block-end: 1px solid transparent;
+      box-shadow: none;
+      /* この量スクロールしてからヘッダー変化アニメーションを開始（終了は +160px スクロール地点） */
+      --z--lp002-header-scroll-animation-start: 100px;
+      --z--lp002-header-animation-range: var(--z--lp002-header-scroll-animation-start) calc(var(--z--lp002-header-scroll-animation-start) + 160px);
+      animation: z--lp002-header linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--lp002-header-animation-range);
+    }
+    /**
+   * スクロール後: 白の半透明 + backdrop-filter（Lism 公式ドキュメントのヘッダーに近いガラス風）
+   * @see https://lism-css.com/docs/overview/
+   */
+    @keyframes z--lp002-header {
+      to {
+        height: var(--z--lp002-header-height--thin);
+        background-color: color-mix(in srgb, var(--white) 68%, transparent);
+        backdrop-filter: blur(12px) saturate(1.08);
+        -webkit-backdrop-filter: blur(12px) saturate(1.08);
+        border-block-end: 1px solid var(--divider);
+        box-shadow: none;
+      }
+    }
+
+    /**
+   * モバイルメニュー: 左からスライド＋全高。右端は --z--lp002-header-menu-peek 分空け、
+   * そのエリア（dialog 本体のダイミング）クリックは setModal により閉じる
+   * @see https://lism-css.com/ui/modal/ ドロワー例（offset） / 公式: dialog 全面 + ::backdrop 非使用
+   */
+    :global(.z--lp002-header_menuModal.c--modal) {
+      min-height: 100svh;
+    }
+    :global(.z--lp002-header_menuModal.c--modal[open]) {
+      justify-content: flex-start;
+      align-items: flex-start;
+    }
+    /**
+   * width: Lism の l--stack / -w 等が後勝ちすると 100% 固定になり、peek を変えても右余白が動かない → !important で calc を優先
+   */
+    :global(.z--lp002-header_menuModal .c--modal_inner.z--lp002-header_menuInner) {
+      width: calc(100% - var(--z--lp002-header-menu-peek, var(--s50))) !important;
+      min-height: 100svh;
+      box-sizing: border-box;
+    }
+
+    /*
+   * .z--lp002-mv 設計トークン（Lism の --gutter-size / --s* / セマンティックカラーと併用）
+   * 子へ継承する。h1 の font-size は inherit し、本ブロックの font-size と揃えて
+   * --z--lp002-mv-title-line2-center の em が画像位置計算と一致するようにしている。
+   *
+   * [見出し・画像レールの絶対配置]
+   *   --z--lp002-mv-title-offset-from-header … 固定ヘッダー下端 → 見出し（h1）上端 までの距離
+   *   --z--lp002-mv-title-line2-center … 見出し上端 → 2行目の縦方向おおよそ中央 までの距離（line-height:1.1 想定）
+   *       → .z--lp002-mv_imageRail の top は header高 + 上記2つの合算（画像上端が 2 行目中央付近になる）
+   *   --z--lp002-mv-image-bottom-offset … .z--lp002-mv_imageRail に渡す bottom（画像列の下端オフセット）
+   *   --z--lp002-mv-image-bottom-inset … md（800px）以上で --z--lp002-mv-image-bottom-offset に切り替える量（= --gutter-size）
+   *       → md 未満の既定は has--gutter と同じ --gutter-size（:root の --gutter-size、通常 var(--s30)）
+   *
+   * [セクション全体の高さ・背景]
+   *   --z--lp002-mv-max-block-size … MV の高さ上限。実際の高さは min(100svh, 本値)。sm 幅以下は別途 100svh 固定
+   *   --z--lp002-mv-white-strip … セクション最下部の「白（--base）」帯の高さ。それより上の背景は --base-2
+   */
+    .z--lp002-mv {
+      --z--lp002-mv-title-offset-from-header: 1rem;
+      --z--lp002-mv-white-strip: 10rem;
+      --z--lp002-mv-max-block-size: 64rem;
+      --z--lp002-mv-title-line2-center: 1.75em;
+      /* md 以上: 画像レール下の余白＝gutter（has--gutter の --gutter-size） */
+      --z--lp002-mv-image-bottom-inset: var(--gutter-size);
+      --z--lp002-mv-image-bottom-offset: var(--gutter-size);
+      height: min(100svh, var(--z--lp002-mv-max-block-size));
+      min-height: min(100svh, var(--z--lp002-mv-max-block-size));
+      background: linear-gradient(
+        to bottom,
+        var(--base-2) 0,
+        var(--base-2) calc(100% - var(--z--lp002-mv-white-strip)),
+        var(--base) calc(100% - var(--z--lp002-mv-white-strip)),
+        var(--base) 100%
+      );
+      /* h1 は font-size:inherit。clamp の em 基準を画像レールの top 計算と共有する */
+      font-size: clamp(2.75rem, 1.5rem + 9vw, 6rem);
+    }
+
+    /* Lism sm = min-width 480px。幅 480px 以下では --z--lp002-mv-max-block-size を使わず高さを必ず 100svh（フルブリード時はビューポート幅≒コンテナ幅） */
+    @media (max-width: 480px) {
+      .z--lp002-mv {
+        height: 100svh;
+        min-height: 100svh;
+      }
+    }
+
+    /* Lism md = 800px。md 以上: 画像下端オフセットを --z--lp002-mv-image-bottom-inset に */
+    @media (min-width: 800px) {
+      .z--lp002-mv {
+        --z--lp002-mv-image-bottom-offset: var(--z--lp002-mv-image-bottom-inset);
+      }
+    }
+
+    .z--lp002-mv_imageRail {
+      position: absolute;
+      inset-inline: 0;
+      top: calc(var(--z--lp002-header-height) + var(--z--lp002-mv-title-offset-from-header) + var(--z--lp002-mv-title-line2-center));
+      bottom: var(--z--lp002-mv-image-bottom-offset);
+      z-index: 0;
+    }
+
+    .z--lp002-mv_imageInner {
+      margin-inline: auto;
+      height: 100%;
+    }
+
+    .z--lp002-mv_frame {
+      display: block;
+    }
+
+    .z--lp002-mv_media {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
+    }
+
+    /* top = ヘッダー下端 + --z--lp002-mv-title-offset-from-header。画像上端は本要素の 2 行目中央に合わせてレール側で加算 */
+    .z--lp002-mv_title {
+      position: absolute;
+      left: 50%;
+      translate: -50% 0;
+      top: calc(var(--z--lp002-header-height) + var(--z--lp002-mv-title-offset-from-header));
+      z-index: 1;
+      line-height: 1.1;
+      pointer-events: none;
+      max-width: 100%;
+      padding-inline: var(--s10);
+      box-sizing: border-box;
+      font-size: inherit;
+    }
+
+    /* l 左: ビュー基準。右端（xl 相当）: 子孫で 100cqi＝#mission 幅 main 内でも正しい */
+    .z--lp002-mission {
+      --_mission-l-pad: max(var(--gutter-size, var(--s30)), calc((100vw - min(100vw, var(--sz--l, 1280px))) / 2));
+    }
+    .z--lp002-mission_bg {
+      position: absolute;
+      inset-block: 0;
+      z-index: 0;
+      right: 0;
+      background-color: var(--base-2, #ececec);
+      pointer-events: none;
+    }
+    @container (min-width: 800px) {
+      .z--lp002-mission_bg {
+        left: calc(var(--_mission-l-pad) + 10rem);
+      }
+    }
+    @container not (min-width: 800px) {
+      .z--lp002-mission_bg {
+        left: 10rem;
+      }
+    }
+    .z--lp002-mission_text {
+      position: relative;
+      z-index: 1;
+      box-sizing: border-box;
+      max-width: 100%;
+      padding-inline-start: var(--_mission-l-pad);
+    }
+    @container (min-width: 800px) {
+      .z--lp002-mission_text {
+        flex: 1 1 0;
+        min-width: 0;
+        padding-inline-end: var(--s20);
+        /* 行内で交差軸に伸長（min-h:auto 由来の上寄せに縛られない）→ 主軸方向の center が効く */
+        align-self: stretch;
+        justify-content: center;
+      }
+    }
+    .z--lp002-mission_figure {
+      box-sizing: border-box;
+    }
+    .z--lp002-mission_figureShell {
+      position: relative;
+      z-index: 1;
+      box-sizing: border-box;
+    }
+    @container (min-width: 800px) {
+      .z--lp002-mission_figureShell {
+        flex: 1 1 0;
+        padding-inline-end: max(1.25rem, var(--gutter-size, var(--s30)), calc((100cqi - min(100cqi, var(--sz--xl, 90rem))) / 2));
+      }
+    }
+    @container not (min-width: 800px) {
+      .z--lp002-mission_text {
+        justify-content: flex-start;
+        padding-inline-end: max(1.25rem, var(--gutter-size, var(--s30)), calc((100cqi - min(100cqi, var(--sz--xl, 90rem))) / 2));
+      }
+      .z--lp002-mission_figureShell {
+        padding-inline-start: var(--_mission-l-pad);
+        padding-inline-end: max(1.25rem, var(--gutter-size, var(--s30)), calc((100cqi - min(100cqi, var(--sz--xl, 90rem))) / 2));
+      }
+    }
+    .z--lp002-mission_img {
+      position: absolute;
+      inset: 0;
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    /**
+     * md 以上: 外側を xl 左（Wrapper）〜 l 右で切る。両グリッドを max-sz:l + mx で寄せるのをやめ、
+     * 左は xl コンテンツ左端、右は l コンテンツ右端（viewport 基準の同一中心線トークン差の半分）に揃える。
+     */
+    @container (min-width: 800px) {
+      .z--lp002-mission2 {
+        box-sizing: border-box;
+        padding-inline-end: max(0px, calc((min(100vw, var(--sz--xl, 90rem)) - min(100vw, var(--sz--l, 1280px))) / 2));
+      }
+    }
+
+    /* `max-sz` 付き列をグリッドセル内で左／右に寄せる（2 列時。md 未満は 1 列のため事実上フル幅） */
+    .z--lp002-mission2-row1 {
+      justify-self: start;
+    }
+    .z--lp002-mission2-row2 {
+      text-align: start;
+      justify-self: start;
+    }
+    @container (min-width: 800px) {
+      .z--lp002-mission2-row2 {
+        text-align: end;
+        justify-self: end;
+      }
+    }
+
+    .z--lp002-footerNav {
+      list-style: none;
+    }
+
+    .z--lp002-footerNav :global(.z--lp002-headerNav_link) {
+      text-align: center;
+    }
+    @container (min-width: 800px) {
+      .z--lp002-footerNav :global(.z--lp002-headerNav_link) {
+        text-align: start;
+      }
+    }
+
+    /* md 未満: 縦並びの項目間に区切り（最後の行の下には付けない） */
+    .z--lp002-footerNav > :global(li:not(:last-child)) {
+      border-block-end: 1px solid var(--divider);
+    }
+
+    @container (min-width: 800px) {
+      .z--lp002-footerNav > :global(li:not(:last-child)) {
+        border-block-end: none;
+      }
+    }
+
+    .z--lp002-feature_rail {
+      min-width: 0;
+      /* グリッド行の高さ（＝左カラムの内容高さ）を子の % 計算に渡す */
+      align-self: stretch;
+    }
+
+    .z--lp002-feature_sticky {
+      position: relative;
+    }
+
+    .z--lp002-feature_frame {
+      aspect-ratio: 4 / 3;
+    }
+
+    @container (min-width: 800px) {
+      /**
+       * ヘッダー下端で固定。高さは「ビューポート」と「左テキスト列の高さ」の小さい方
+       * （グリッド行高＝左カラムのため、100% は左側コンテンツの高さに一致）
+       */
+      .z--lp002-feature_sticky {
+        position: sticky;
+        /* lp002 :root のヘッダー（スクロール後の高さ＝下端基準） */
+        top: var(--z--lp002-header-height--thin, 64px);
+        align-self: start;
+        height: min(calc(100dvh - var(--z--lp002-header-height--thin, 64px)), 100%);
+        min-height: 0;
+      }
+
+      .z--lp002-feature_frame {
+        aspect-ratio: auto;
+        height: 100%;
+        min-height: 0;
+      }
+
+      /**
+       * 画像列だけ右端をビューポート端まで伸ばす（左端は2カラム境界のまま）
+       * 中央寄せの `size=l` コンテナ外側〜画面右端の余白 + 右ガターを吸収
+       */
+      .z--lp002-feature_rail {
+        width: calc(100% + max(0px, (100vw - min(100vw, var(--sz--l))) / 2) + var(--gutter-size, 0px));
+        max-width: none;
+        height: 100%;
+      }
+    }
+
+    /* md 未満: カード内は画像 | テキスト Stack。md 以上: 縦積み（先祖 is--container の 800px 基準） */
+    .z--lp002-service_card {
+      min-width: 0;
+    }
+
+    .z--lp002-service_cardFigure {
+      min-width: 0;
+    }
+
+    /* sm 以下（max-width: 480px）：画像非表示。Lism の sm ブレークポイント 480px に合わせる */
+    @container (max-width: 480px) {
+      .z--lp002-service_cardFigure {
+        display: none;
+      }
+    }
+
+    @container not (min-width: 800px) {
+      /* テキスト列の高さに合わせて画像を縦いっぱい（`ar` を上書きして flex stretch を効かせる） */
+      .z--lp002-service_cardFigure {
+        flex: 0 0 38%;
+        max-width: 12rem;
+        align-self: stretch;
+        aspect-ratio: auto;
+        min-height: 0;
+      }
+    }
+
+    @container (min-width: 800px) {
+      .z--lp002-service_cardFigure {
+        width: 100%;
+        align-self: stretch;
+      }
+    }
+
+    .z--lp002-service_rule {
+      align-self: stretch;
+    }
+
+    .z--lp002-service_num {
+      line-height: 1;
+    }
+
+    /* テキスト色を 15%（残りは base）でミックス — 薄すぎる base-2 より本文に近い階調 */
+    .z--lp002-step_caret .a--icon {
+      color: color-mix(in oklch, var(--text) 15%, var(--base));
+      opacity: 1;
+    }
+
+    .z--lp002-step_main {
+      min-width: 0;
+    }
+
+    .z--lp002-step_rail {
+      min-width: 0;
+      /* グリッド行の高さを子の % 計算に渡す */
+      align-self: stretch;
+    }
+
+    .z--lp002-step_sticky {
+      position: relative;
+    }
+
+    .z--lp002-step_frame {
+      aspect-ratio: 4 / 3;
+    }
+
+    /**
+     * md 以上: グリッドの視覚順を rail | main にし、sticky・左張り出しを有効化。
+     * md 未満: DOM 順のまま（main → rail）で 1 列・テキスト上・画像下（Feature と同型）。
+     */
+    @container (min-width: 800px) {
+      .z--lp002-step_rail {
+        order: 1;
+        margin-inline-start: calc(-1 * (max(0px, (100vw - min(100vw, var(--sz--l))) / 2) + var(--gutter-size, 0px)));
+        width: calc(100% + max(0px, (100vw - min(100vw, var(--sz--l))) / 2) + var(--gutter-size, 0px));
+        max-width: none;
+        height: 100%;
+      }
+
+      .z--lp002-step_main {
+        order: 2;
+      }
+
+      .z--lp002-step_sticky {
+        position: sticky;
+        top: var(--z--lp002-header-height--thin, 64px);
+        align-self: start;
+        height: min(calc(100dvh - var(--z--lp002-header-height--thin, 64px)), 100%);
+        min-height: 0;
+      }
+
+      .z--lp002-step_frame {
+        aspect-ratio: auto;
+        height: 100%;
+        min-height: 0;
+      }
+    }
+
+    /**
+     * 横リール: 中央スナップ（has--snap の子へ --snapAlign が効く）
+     * @see https://lism-css.com/ui/examples/reel/
+     */
+    .z--lp002-voice_reel {
+      --snapType: x mandatory;
+      --snapAlign: center;
+      align-items: stretch;
+    }
+
+    /* 行内で最も高いカードに合わせてスライドの高さを揃える（h:100% は未定義高さで stretch を阻害しやすい） */
+    .z--lp002-voice_slide {
+      flex: 0 0 min(24rem, 85%);
+      align-self: stretch;
+      height: auto;
+    }
+
+    .z--lp002-voice_auto {
+      display: none;
+    }
+
+    @container (min-width: 800px) {
+      .z--lp002-voice_reel {
+        display: none !important;
+        overflow: visible;
+      }
+
+      .z--lp002-voice_auto {
+        display: grid;
+      }
+    }
+
+    .z--lp002-contact {
+      min-height: min(88vh, 52rem);
+    }
+
+    .z--lp002-contact_mediaWrap {
+      position: absolute;
+      inset: 0;
+    }
+
+    .z--lp002-contact_media {
+      display: block;
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
+      /* 完全な grayscale(1) ではなく、彩度を少し残す */
+      filter: grayscale(0.55) saturate(0.72) contrast(0.96) brightness(1.02);
+    }
+
+    .z--lp002-contact_input {
+      box-sizing: border-box;
+      width: 100%;
+      margin: 0;
+      padding: var(--s15) var(--s20);
+      font: inherit;
+      font-size: var(--fz--s);
+      line-height: calc(1em + var(--hl--base) * 2);
+      color: var(--text);
+      background-color: var(--base);
+      border: 1px solid var(--divider);
+      border-radius: var(--bdrs--20);
+      box-shadow: var(--bxsh--10);
+    }
+
+    .z--lp002-contact_input::placeholder {
+      color: var(--text-2);
+      opacity: var(--o--pp);
+    }
+
+    .z--lp002-contact_input:focus-visible {
+      outline: 2px solid var(--brand);
+      outline-offset: 2px;
+    }
+
+    .z--lp002-contact_input--textarea {
+      min-height: 10rem;
+      resize: vertical;
+    }
+
+    /* ヘッダー @lism-css/ui Button（.c--button）と同じセマンティック: bg=--text, 字=--base */
+    .z--lp002-contact_submit {
+      box-sizing: border-box;
+      width: 100%;
+      margin: 0;
+      margin-block-start: var(--s10);
+      padding: var(--s15) var(--s30);
+      font: inherit;
+      font-size: var(--fz--m);
+      font-weight: var(--fw--bold);
+      letter-spacing: var(--lts--l);
+      color: var(--base);
+      cursor: pointer;
+      background-color: var(--text);
+      border: 1px solid var(--text);
+      border-radius: var(--bdrs--99);
+      box-shadow: var(--bxsh--20);
+    }
+
+    .z--lp002-contact_submit:hover {
+      opacity: 0.92;
+    }
+
+    .z--lp002-contact_submit:focus-visible {
+      outline: 2px solid var(--base);
+      outline-offset: 3px;
+    }
+  }
+</style>

--- a/apps/docs/src/pages/preview/templates/lp/lp002/index.astro
+++ b/apps/docs/src/pages/preview/templates/lp/lp002/index.astro
@@ -22,7 +22,10 @@ import {
   Text,
   Wrapper,
 } from 'lism-css/astro';
-import { Accordion, Avatar, Button, Modal } from '@lism-css/ui/astro';
+import { Accordion } from '@lism-css/ui/astro/Accordion';
+import { Avatar } from '@lism-css/ui/astro/Avatar';
+import { Button } from '@lism-css/ui/astro/Button';
+import { Modal } from '@lism-css/ui/astro/Modal';
 
 export const title = 'LP002: Simple Natural LP';
 
@@ -1157,7 +1160,7 @@ const contactFields: ContactField[] = [
 
     /* l 左: ビュー基準。右端（xl 相当）: 子孫で 100cqi＝#mission 幅 main 内でも正しい */
     .z--lp002-mission {
-      --_mission-l-pad: max(var(--gutter-size, var(--s30)), calc((100vw - min(100vw, var(--sz--l, 1280px))) / 2));
+      --_mission-l-pad: max(var(--gutter-size, var(--s30)), calc((100vw - min(100vw, var(--sz--l))) / 2));
     }
     .z--lp002-mission_bg {
       position: absolute;
@@ -1205,17 +1208,17 @@ const contactFields: ContactField[] = [
     @container (min-width: 800px) {
       .z--lp002-mission_figureShell {
         flex: 1 1 0;
-        padding-inline-end: max(1.25rem, var(--gutter-size, var(--s30)), calc((100cqi - min(100cqi, var(--sz--xl, 90rem))) / 2));
+        padding-inline-end: max(1.25rem, var(--gutter-size, var(--s30)), calc((100cqi - min(100cqi, var(--sz--xl))) / 2));
       }
     }
     @container not (min-width: 800px) {
       .z--lp002-mission_text {
         justify-content: flex-start;
-        padding-inline-end: max(1.25rem, var(--gutter-size, var(--s30)), calc((100cqi - min(100cqi, var(--sz--xl, 90rem))) / 2));
+        padding-inline-end: max(1.25rem, var(--gutter-size, var(--s30)), calc((100cqi - min(100cqi, var(--sz--xl))) / 2));
       }
       .z--lp002-mission_figureShell {
         padding-inline-start: var(--_mission-l-pad);
-        padding-inline-end: max(1.25rem, var(--gutter-size, var(--s30)), calc((100cqi - min(100cqi, var(--sz--xl, 90rem))) / 2));
+        padding-inline-end: max(1.25rem, var(--gutter-size, var(--s30)), calc((100cqi - min(100cqi, var(--sz--xl))) / 2));
       }
     }
     .z--lp002-mission_img {
@@ -1234,7 +1237,7 @@ const contactFields: ContactField[] = [
     @container (min-width: 800px) {
       .z--lp002-mission2 {
         box-sizing: border-box;
-        padding-inline-end: max(0px, calc((min(100vw, var(--sz--xl, 90rem)) - min(100vw, var(--sz--l, 1280px))) / 2));
+        padding-inline-end: max(0px, calc((min(100vw, var(--sz--xl)) - min(100vw, var(--sz--l))) / 2));
       }
     }
 

--- a/apps/docs/src/pages/preview/templates/lp/lp003/_style.css
+++ b/apps/docs/src/pages/preview/templates/lp/lp003/_style.css
@@ -1,0 +1,1 @@
+/* LP003: Japanese Ryokan LP */

--- a/apps/docs/src/pages/preview/templates/lp/lp003/index.astro
+++ b/apps/docs/src/pages/preview/templates/lp/lp003/index.astro
@@ -1,0 +1,1658 @@
+---
+import DemoLayout from '@/layouts/DemoLayout.astro';
+import {
+  Box,
+  BoxLink,
+  Center,
+  Cluster,
+  Container,
+  Flex,
+  Frame,
+  Grid,
+  Heading,
+  Icon,
+  Inline,
+  Layer,
+  Link,
+  Lism,
+  ListItem,
+  Stack,
+  Text,
+  WithSide,
+  Wrapper,
+} from 'lism-css/astro';
+import { Accordion, Button, Modal } from '@lism-css/ui/astro';
+
+export const title = 'LP003: Japanese Ryokan LP';
+
+const logoLabel = '静寂の隠れ宿';
+
+const headerNavItems = [
+  { href: '#about', ja: '当宿について', en: 'About' },
+  { href: '#feature', ja: '宿の特徴', en: 'Feature' },
+  { href: '#plans', ja: '宿泊プラン', en: 'Plan' },
+  { href: '#information', ja: '設備紹介', en: 'Facilities' },
+  { href: '#faq', ja: 'よくあるご質問', en: 'Faq' },
+] as const;
+
+const mvDefaultCopyLines = ['都会の喧騒から離れ、', '心安らぐ自然の中で', '至福のひとときを。'];
+
+const {
+  mvImages: mvImagesProp,
+  mvDurationPerImage = 7,
+  mvFadeTime = 3,
+  mvCopyLines: mvCopyLinesProp,
+  mvLineRevealStartDelay = 0.55,
+  mvLineRevealStagger = 0.72,
+  mvLineRevealDuration = 1.55,
+  mvLineRevealBlurPx = 14,
+  mvBgImageScaleMax = 1.05,
+} = Astro.props;
+
+const mvResolvedCopyLines: readonly string[] = mvCopyLinesProp && mvCopyLinesProp.length > 0 ? mvCopyLinesProp : mvDefaultCopyLines;
+
+const mvResolvedImages: readonly string[] =
+  mvImagesProp && mvImagesProp.length > 0
+    ? mvImagesProp
+    : ['https://cdn.lism-css.com/img/japan/u-Dczv0Klww4.jpg', 'https://cdn.lism-css.com/img/japan/a_JNaB1eSLPA.jpg'];
+
+const mvBgCycleDuration = mvDurationPerImage * mvResolvedImages.length;
+const mvHoldPercent = ((mvDurationPerImage - mvFadeTime) / mvBgCycleDuration) * 100;
+const mvFadeOutPercent = (mvDurationPerImage / mvBgCycleDuration) * 100;
+const mvHiddenPercent = ((mvBgCycleDuration - mvFadeTime) / mvBgCycleDuration) * 100;
+
+/** フェードイン終端（100%/0% 接続）までに進む scale。フェードイン区間でも拡大が継続する */
+const mvBgScaleGrowthSpan = 100 - mvHiddenPercent + mvHoldPercent;
+const mvBgScaleJoin = mvBgScaleGrowthSpan > 0 ? 1 + ((100 - mvHiddenPercent) / mvBgScaleGrowthSpan) * (mvBgImageScaleMax - 1) : mvBgImageScaleMax;
+const mvBgScaleJoinCss = mvBgScaleJoin.toFixed(6);
+const mvBgScaleMaxCss = Number(mvBgImageScaleMax).toFixed(6);
+
+/** 背景クロスフェード + scale（非表示→フェードイン→ホールド終端まで 1→mvBgImageScaleMax） */
+const mvLayeredKeyframesStyle = `@layer lism-custom {
+  @keyframes lp003-mv-bgFade {
+    0% {
+      opacity: 1;
+      transform: scale(${mvBgScaleJoinCss});
+    }
+    ${mvHoldPercent}% {
+      opacity: 1;
+      transform: scale(${mvBgScaleMaxCss});
+    }
+    ${mvFadeOutPercent}% {
+      opacity: 0;
+      transform: scale(${mvBgScaleMaxCss});
+    }
+    ${mvHiddenPercent}% {
+      opacity: 0;
+      transform: scale(1);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(${mvBgScaleJoinCss});
+    }
+  }
+}`;
+
+/**
+ * 左右の高さ: Grid の `ai` stretch + 右列 `Flex` 内 `fx:1` の img（`min-h:0`）。
+ * 旧実装: `syncAboutRightMaxHeight` + `--z--lp003-about-right-max-h`（復元は git 履歴参照）
+ */
+
+const aboutImgLeft = {
+  src: 'https://cdn.lism-css.com/img/japan/u-qQGCFQFlkT.jpg',
+  alt: '池を泳ぐ鯉',
+  width: 1920,
+  height: 1280,
+};
+const aboutImgRight = {
+  src: 'https://cdn.lism-css.com/img/japan/u-lCzkkcbJUb.jpg',
+  alt: '座敷から望む秋の庭園',
+  width: 1600,
+  height: 1200,
+};
+
+const aboutBodyCopy =
+  '百余年の歴史を刻む、風格ある佇まい。古き良き日本の情緒を残しつつ、現代の快適さを融合させた空間で皆様をお迎えいたします。手入れの行き届いた日本庭園を眺め、静寂に包まれて味わう名湯は、格別な癒やし。受け継がれてきたおもてなしの心で、特別な旅を鮮やかに彩ります。四季折々の風情が移ろく庭先では、新緑の香り、深緑の日陰、紅葉の燃えるような美しさ、静かな雪化粧の趣まで、日々違う表情を呈します。佇まい、器、会席、湯、そして言葉少ななもてなし。それらすべてに至るまで、余韻深く、お客さまの記憶に残る一時を大切に紡ぎたい。都会を離れ、ここ静寂の隠れ宿で、心ほどけゆく至福のひとときをどうぞお味わいください。';
+
+/**
+ * 左右分割＋縦組み見出し。ウォーターマークの cqi は `Container` の isContainer に依存。
+ */
+
+const featureImg = {
+  src: 'https://cdn.lism-css.com/img/japan/u-L4YLmcBryx.jpg',
+  alt: '千本鳥居が続く参道',
+  width: 1920,
+  height: 1280,
+};
+
+const featureLead = '春の桜、秋の紅葉。';
+const featureBody =
+  '四季の移ろいが最も美しい瞬間を切り取る当宿は、まるで一幅の絵画のように自然と調和いたします。名湯と旬の味わいを、大切な方々とご一緒にお楽しみください。桜の頃は窓越しに淡い色の雪の様子を、夏は深い緑と風鈴の音を、秋は燃えるような紅葉と澄んだ空を、冬は静かな雪化粧と湯けむりを、それぞれ五感で味わえます。';
+
+const feature2Bg = {
+  src: 'https://cdn.lism-css.com/img/japan/u-MES3nTNrVq.jpg',
+  alt: '',
+  width: 1920,
+  height: 1080,
+} as const;
+
+/** 各要素の `src` に任意の画像URLを直指定（下記は従来どおりのプレースホルダー）。 */
+const feature2GalleryPhotos = [
+  { src: 'https://cdn.lism-css.com/img/random-2510?category=japan&r=lp003feature2-a', alt: '富士と朝焼けの風景' },
+  { src: 'https://cdn.lism-css.com/img/random-2510?category=japan&r=lp003feature2-b', alt: '日本の山並みと雲海' },
+  { src: 'https://cdn.lism-css.com/img/random-2510?category=japan&r=lp003feature2-c', alt: '湖畔の夕景' },
+  { src: 'https://cdn.lism-css.com/img/random-2510?category=japan&r=lp003feature2-d', alt: '雪化粧の峰' },
+] as const;
+
+const feature2IntroBody =
+  '静寂に包まれた隠れ宿で、四季の移ろいを五感で味わうひととき。露天風呂に身をゆだねれば木々のざわめきと鳥の声、移ろう空の色が心を解きほぐします。伝統美と現代の心地よさが溶け合う空間で、大切な方と過ごす至福の時間をお約束いたします。桜前線が北上する頃には淡い霧雨に濡れた石畳、夏の宵には蛍火が池面を揺らす。秋の名月を浴びるテラス席では、澄んだ大気の中、遠い街の明かりがまるで散りばめられた金砂のよう。冬深く雪が庭を白く覆う日には、囲炉裏端で温めた一献が旅の労をそっと癒してくれます。茶寮にて厳選した茶葉の香を嗜み、図書角では旅立ち前の一冊に触れる時間。季節折々、土地の採れを極味でお届けする献立と、人の手で丁寧に手入れを続けた庭の景色が、毎年欠かすことのない贈り物のように、お客さまの記憶に深く留まることを心より願っております。名湯の湯煙の向こうに、明日への静かな活力と、人や自然との新たな出会いを、どうぞ静かに抱いてお戻りください。';
+
+/**
+ * 画像は CDN の japan 配下（実URLは `https://cdn.lism-css.com/img/japan/u-*.jpg`）。
+ * `.../images/japan` は未使用のため `img/japan` を利用。
+ */
+type PlanStat = {
+  label: string;
+  value: string;
+};
+
+type Plan = {
+  title: string;
+  description: string;
+  stats: readonly [PlanStat, PlanStat, PlanStat];
+  image: {
+    src: string;
+    alt: string;
+    width: number;
+    height: number;
+  };
+};
+
+const plans = [
+  {
+    title: '夕朝食・露天風呂付きゆったりプラン',
+    description:
+      '季節の会席と朝の御膳、そして湯冷めしない露天風呂までひと続きの時間。お部屋でゆっくりとお食事をご堪能いただき、湯浴みの合間には庭園を眺めながらのんびりとお過ごしください。お飲み物の追加オーダーやアレルギー対応も可能ですので、ご予約時にお申し付けください。',
+    stats: [
+      { label: 'ご予約可能人数', value: '1〜2名様' },
+      { label: '料金', value: '29,800円〜' },
+      { label: 'お部屋タイプ', value: '露天付き和室' },
+    ],
+    image: {
+      src: 'https://cdn.lism-css.com/img/japan/a_YWq6k0dioX.jpg',
+      alt: '紅葉の庭園と母屋',
+      width: 1920,
+      height: 1080,
+    },
+  },
+  {
+    title: '旬会席・半露天付き特別室ステイ',
+    description:
+      'その日の仕入れで組み立てる旬会席と、半露天から望む山並みのグラデーション。記念日やご家族のお祝いに、少し贅沢なお時間をご用意いたしました。',
+    stats: [
+      { label: 'ご予約可能人数', value: '2〜4名様' },
+      { label: '料金', value: '39,800円〜' },
+      { label: 'お部屋タイプ', value: '半露天付き特別室' },
+    ],
+    image: {
+      src: 'https://cdn.lism-css.com/img/japan/a_AgvZ1VdMXz.jpg',
+      alt: '千本鳥居が続く参道',
+      width: 1920,
+      height: 1280,
+    },
+  },
+  {
+    title: '一泊朝食のみ・湯めぐり楽々プラン',
+    description:
+      '夕食は外で自由に、朝は当宿の炊きたてご飯と汁物で。近隣の外湯めぐりや散策を楽しみたい方に、身軽な滞在スタイルをご提案します。チェックアウト後の荷物預かりも承りますので、観光の前後にご活用ください。',
+    stats: [
+      { label: 'ご予約可能人数', value: '1〜3名様' },
+      { label: '料金', value: '18,500円〜' },
+      { label: 'お部屋タイプ', value: '和室10畳＋広縁' },
+    ],
+    image: {
+      src: 'https://cdn.lism-css.com/img/japan/u-qQGCFQFlkT.jpg',
+      alt: '池を泳ぐ鯉と庭園',
+      width: 1920,
+      height: 1280,
+    },
+  },
+  {
+    title: '連泊エコノミー・温泉三昧プラン',
+    description:
+      'お得な連泊料金で、名湯と静寂にどっぷり浸かる旅。お食事はシンプルな定番御膳に、湯上がりの甘味までお部屋にお届けする心地よさをご用意しました。',
+    stats: [
+      { label: 'ご予約可能人数', value: '2名様〜' },
+      { label: '料金', value: '52,000円〜 / 2泊' },
+      { label: 'お部屋タイプ', value: '和洋室ツイン' },
+    ],
+    image: {
+      src: 'https://cdn.lism-css.com/img/japan/a_BybmIMidVa.jpg',
+      alt: '座敷から望む秋の庭園',
+      width: 1600,
+      height: 1200,
+    },
+  },
+] as const satisfies readonly Plan[];
+
+/** Lism プリセットアイコン名（ https://lism-css.com/docs/primitives/a--icon/ ） */
+type InformationIcon =
+  | 'home'
+  | 'clock'
+  | 'cart'
+  | 'gear'
+  | 'book'
+  | 'chat'
+  | 'heart'
+  | 'lightbulb'
+  | 'search'
+  | 'note'
+  | 'bookmark'
+  | 'user'
+  | 'lock';
+
+type InformationItem = {
+  icon: InformationIcon;
+  title: string;
+  description: string;
+};
+
+/** 各カードのアイコン・見出し・本文は別レコードで管理（内容の差し替えが容易） */
+const informationItems = [
+  {
+    icon: 'home',
+    title: 'ロビー・ラウンジ',
+    description: '到着直後のひとときから夜の湯上がりまで。珈琲や茶菓のセルフサービスとともに、庭側の座敷席で静かにお過ごしいただけます。',
+  },
+  {
+    icon: 'clock',
+    title: '24時間対応のフロント',
+    description: 'チェックインのご案内、周辺の散策コース、タクシーや送迎の手配まで。お困りごとがあれば、いつでもお声がけください。',
+  },
+  {
+    icon: 'cart',
+    title: '館内売店・土産コーナー',
+    description: '地酒や銘菓、オリジナルタオルに浴用アメニティまで。旅のちょっとした備えやお土産選びに、ぜひお立ち寄りください。',
+  },
+  {
+    icon: 'book',
+    title: '閲覧室・書斎コーナー',
+    description: '旅館・温泉郷のガイドブックや写真集をご用意しました。湯上がりにページをめくりながら、翌日の予定をゆっくり練るのもおすすめです。',
+  },
+] as const satisfies readonly InformationItem[];
+
+const informationIntro =
+  '湯治から滞在型の寛ぎまで、館内の設備で旅のリズムを整えられます。湯殿から客室まで動線を短くし、夜遅くのご利用にも配慮した案内でお迎えいたします。';
+
+/** 各項目は質問・回答を独立して管理（必要に応じて初期展開を指定） */
+const faqItems: { question: string; answer: string; defaultOpen?: boolean }[] = [
+  {
+    question: '初めて利用するのですが難しくないですか？',
+    answer:
+      'はい、全く問題ありません。初めての方でも戸惑うことなくご利用いただけます。もしお困りの際はフロントがお問い合わせにも対応いたしますので、安心してご利用ください。',
+    defaultOpen: true,
+  },
+  {
+    question: '予約のキャンセルはできますか？',
+    answer:
+      'プランごとにキャンセル規定が定められております。ご予約確定メールに記載の期限までにマイページまたはお電話にてお手続きください。直前の変更については空室状況を確認のうえご案内いたします。',
+  },
+  {
+    question: '宿泊プランを予約後に変更したくなった場合は、どのように変更できますか？',
+    answer:
+      'ご希望の日付・人数・お部屋タイプをお知らせいただければ、空室状況を確認のうえ差し替えを承ります。アップグレードに伴う差額やキャンセル規定の適用については、フロントにてご説明いたします。',
+  },
+  {
+    question: 'チェックイン・アウトの時間は決まっていますか？',
+    answer:
+      'チェックインは15時、チェックアウトは11時を目安としております。早めのご到着や遅めのご出発をご希望の場合は、事前にフロントまでお問い合わせください。空き状況に応じてご相談に乗れます。',
+  },
+  {
+    question: 'お食事のアレルギー・苦手な食材には対応できますか？',
+    answer:
+      'ご予約時にできる限り詳しくお知らせください。取り扱いの難しい食材もございますが、可能な範囲で代替や調整をいたします。当日のご変更は調理の都合上お受けできない場合がございます。',
+  },
+  {
+    question: 'お部屋に露天風呂は付いていますか？',
+    answer:
+      'プランおよびお部屋タイプにより異なります。露天風呂付きの客室、大浴場のみのプランなどをご用意しております。ご予約画面の設備欄またはフロントまでお問い合わせください。',
+  },
+  {
+    question: 'Wi-Fi は利用できますか？',
+    answer:
+      '全館で無料の Wi-Fi をご利用いただけます。お部屋番号とご案内のパスワードで接続ください。混雑時は速度が落ちる場合がございますのでご了承ください。',
+  },
+  {
+    question: '子ども連れの宿泊は可能ですか？',
+    answer:
+      '可能です。添い寝のお子様の料金やベッドのご用意はプランにより異なります。ベビーベッドの貸し出しは台数に限りがございますので、事前にご予約ください。',
+  },
+  {
+    question: '記念日のサプライズを依頼できますか？',
+    answer:
+      'ケーキや花束の手配、お食事のメッセージプレートなど、事前にご相談いただければ可能な範囲でお手伝いいたします。ご予算やお届けタイミングをお聞きしたうえでご提案いたします。',
+  },
+  {
+    question: '近隣の観光地へのアクセスや送迎はありますか？',
+    answer:
+      '最寄り駅からの送迎は定時運行のシャトルをご利用いただけます（要予約・台数限定）。観光地までのタクシー手配や地図の貸し出しも承りますので、フロントまでお声がけください。',
+  },
+];
+
+const faqImage = {
+  src: 'https://cdn.lism-css.com/img/japan/u-v9tUs6AiFT.jpg',
+  alt: '雨上がりの石畳の路地を、赤い和傘を差して歩く舞妓さんの後ろ姿',
+  width: 1920,
+  height: 1280,
+};
+
+/** ヘッダーと同一のナビ（アンカー） */
+const footerNavItems = [
+  { href: '#about', ja: '当宿について', en: 'About' },
+  { href: '#feature', ja: '宿の特徴', en: 'Feature' },
+  { href: '#plans', ja: '宿泊プラン', en: 'Plan' },
+  { href: '#information', ja: '設備紹介', en: 'Facilities' },
+  { href: '#faq', ja: 'よくあるご質問', en: 'Faq' },
+] as const;
+
+const footerSnsLinks = [
+  { href: '#', icon: 'logo-x' as const, label: 'X' },
+  { href: '#', icon: 'logo-instagram' as const, label: 'Instagram' },
+  { href: '#', icon: 'logo-youtube' as const, label: 'YouTube' },
+  { href: '#', icon: 'logo-tiktok' as const, label: 'TikTok' },
+  { href: '#', icon: 'logo-line' as const, label: 'LINE' },
+];
+
+/** 背景（指定 URL） */
+const bgImage = {
+  src: 'https://cdn.lism-css.com/img/japan/u-xJdqvxp0ak.jpg',
+  alt: '夕暮れの京都の路地と五重塔',
+  width: 1920,
+  height: 1080,
+};
+
+/**
+ * カード用サムネイル（CDN の japan 配下。`.../images/japan` は未使用のため `img/japan` を利用）
+ * @see Plans.astro 冒頭コメント
+ */
+type SiteCard = {
+  title: string;
+  body: string;
+  href: string;
+  image: { src: string; alt: string; width: number; height: number };
+};
+
+const reservationSites: readonly SiteCard[] = [
+  {
+    title: 'トラベルトリップ',
+    body: '特典：早期予約で料金が割引になるキャンペーンを実施中です。空室カレンダーから日程を選べます。',
+    href: '#',
+    image: {
+      src: 'https://cdn.lism-css.com/img/japan/a_77prliRsZS.jpg',
+      alt: 'トラベルトリップのイメージ写真',
+      width: 1920,
+      height: 1080,
+    },
+  },
+  {
+    title: 'らくらく旅行予約',
+    body: '特典：地域密着サポート付きプランをご用意しています。変更・キャンセルは各サイトの規定に従います。',
+    href: '#',
+    image: {
+      src: 'https://cdn.lism-css.com/img/japan/a_AgvZ1VdMXz.jpg',
+      alt: 'らくらく旅行予約のイメージ写真',
+      width: 1920,
+      height: 1280,
+    },
+  },
+];
+---
+
+<DemoLayout title={title}>
+  <link rel="preconnect" href="https://fonts.googleapis.com" slot="head" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin slot="head" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@200..900&family=Yuji+Syuku&display=swap" rel="stylesheet" slot="head" />
+  <Wrapper class="z--lp003-root" contentSize="full">
+    <!-- Header -->
+
+    <Lism as="header" class="z--lp003-header" pos="fixed" i="0" w="100%" z="1" hasTransition>
+      <Container class="z--lp003-header_bar" isWrapper="xl" mx="auto" hasGutter h="100%">
+        <Grid class="z--lp003-header_inner" gtc="minmax(0,auto) 1fr" ai="center" h="100%" g="20">
+          <Stack class="z--lp003-header_logo">
+            <Link
+              class="z--lp003-header_logoLink"
+              href="#"
+              td="none"
+              fw="normal"
+              ff="accent"
+              c="white"
+              lts="l"
+              fz={['2xl', null, '3xl']}
+              lh="s"
+              whs="nowrap"
+            >
+              {logoLabel}
+            </Link>
+          </Stack>
+          <Flex class="z--lp003-header_actions" jc="fe" g="20" ai="c">
+            <Flex class="z--lp003-headerNav" as="ul" d={['none', null, 'inline-flex']} ai="c" m="0" p="0" fxw="nowrap" g={['15', null, '30']}>
+              {
+                headerNavItems.map(({ href, ja, en }) => (
+                  <ListItem>
+                    <Link
+                      class="z--lp003-headerNav_link"
+                      href={href}
+                      d="grid"
+                      jc="c"
+                      ji="c"
+                      td="none"
+                      py="10"
+                      px="5"
+                      hasTransition
+                      hov="-o"
+                      ta="c"
+                      g="5"
+                    >
+                      <Inline>{ja}</Inline>
+                      <Inline as="span" class="z--lp003-headerNav_en" fz="2xs" fw="normal" lts="l" lh="xs" m="0" ta="c" d="block">
+                        {en}
+                      </Inline>
+                    </Link>
+                  </ListItem>
+                ))
+              }
+            </Flex>
+            <Modal.OpenBtn modalId="lp003-menu" d={['block', null, 'none']}>
+              <Center p="5" ai="c" jc="c">
+                <Icon icon="menu" c="white" fz="2xl" aria-hidden="true" />
+              </Center>
+            </Modal.OpenBtn>
+          </Flex>
+        </Grid>
+      </Container>
+    </Lism>
+    <Modal.Root id="lp003-menu" isContainer isWrapper="s" p="30">
+      <Modal.Inner layout="stack" pos="relative" w="100%" p="30" bdrs="20" bxsh="50">
+        <Modal.CloseBtn modalId="lp003-menu" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
+        <Modal.Body layout="stack" g="30" py="40">
+          <Stack as="ul" class="z--lp003-header_menuNav" g="0" m="0" p="0" ov="clip">
+            {
+              headerNavItems.map(({ href, ja, en }) => (
+                <ListItem>
+                  <BoxLink href={href} layout="grid" gtc="1fr auto" ai="c" fz="l" td="none" py="15" px="5" w="100%">
+                    <Stack g="5">
+                      <Inline>{ja}</Inline>
+                      <Inline as="span" class="z--lp003-header_menuNav_en" fz="s" m="0" o="pp">
+                        {en}
+                      </Inline>
+                    </Stack>
+                    <Icon icon="caret-right" fz="s" o="pp" />
+                  </BoxLink>
+                </ListItem>
+              ))
+            }
+            <ListItem>
+              <BoxLink href="#reservation" layout="grid" gtc="1fr auto" ai="c" fz="l" td="none" py="15" px="5" w="100%">
+                <Stack g="5">
+                  <Inline>ご予約はこちら</Inline>
+                  <Inline as="span" class="z--lp003-header_menuNav_en" fz="s" m="0" o="pp"> Reservation </Inline>
+                </Stack>
+                <Icon icon="caret-right" fz="s" o="pp" />
+              </BoxLink>
+            </ListItem>
+          </Stack>
+        </Modal.Body>
+      </Modal.Inner>
+    </Modal.Root>
+    <!-- Main Content -->
+    <Container as="main" class="z--lp003-main" pos="relative" z="0">
+      <Container
+        class="z--lp003-mv"
+        as="section"
+        pos="relative"
+        w="100%"
+        m="0"
+        p="0"
+        max-w="none"
+        ov="clip"
+        style={{
+          minHeight: '100svh',
+          '--z--lp003-mv-bgCycleDuration': `${mvBgCycleDuration}s`,
+          '--z--lp003-mv-lineBlurMax': `${mvLineRevealBlurPx}px`,
+          '--z--lp003-mv-lineDuration': `${mvLineRevealDuration}s`,
+          '--z--lp003-mv-lineStartDelay': `${mvLineRevealStartDelay}s`,
+          '--z--lp003-mv-lineStagger': `${mvLineRevealStagger}s`,
+        }}
+      >
+        <Frame isLayer class="z--lp003-mv_bg">
+          {
+            mvResolvedImages.map((src, index) => {
+              const mvLayerDelay = index * mvDurationPerImage - mvBgCycleDuration;
+
+              return (
+                <div
+                  class="z--lp003-mv_layer"
+                  style={{
+                    '--z--lp003-mv-layerBgImage': `url('${src}')`,
+                    '--z--lp003-mv-layerDelay': `${mvLayerDelay}s`,
+                  }}
+                />
+              );
+            })
+          }
+        </Frame>
+        <Layer bgc="black:30%" exProps={{ 'aria-hidden': 'true' }} />
+        <Stack
+          pos="relative"
+          z="1"
+          ai="c"
+          jc="c"
+          g="0"
+          w="100%"
+          m="0"
+          p="0"
+          px={['20', null, '40']}
+          py-e="40"
+          min-h="100svh"
+          c="white"
+          style={{ paddingBlockStart: 'calc(var(--z--header-height) + var(--s30))' }}
+        >
+          <Lism as="p" class="z--lp003-mv_copy" m="0">
+            {
+              mvResolvedCopyLines.map((line, i) => (
+                <span class="z--lp003-mv_line" style={{ '--z--lp003-mv-lineIndex': i }}>
+                  {line}
+                </span>
+              ))
+            }
+          </Lism>
+        </Stack>
+      </Container>
+      <!-- MV の動的 @keyframes はマージで抽出されないため、元コンポーネントと同じ set:html を明示注入 -->
+      <style set:html={mvLayeredKeyframesStyle}></style>
+
+      <Lism as="section" id="about" class="z--lp003-about" isContainer py-s="60" py-e="60" bgc="black" c="white">
+        <Grid
+          class="z--lp003-about_grid"
+          gtc={['1fr', '1fr', 'minmax(0, 1fr) minmax(0, 50%)']}
+          cg="0"
+          rg={['30', '30', '0']}
+          ai={['start', 'start', 'stretch']}
+        >
+          <Stack
+            class="z--lp003-about_col z--lp003-about_col--left"
+            g={['40', '40', '50']}
+            px-e={['0', '0', '50']}
+            h={['auto', 'auto', '100%']}
+            min-h={['0', '0', '0']}
+            min-w="0"
+          >
+            <Stack class="z--lp003-about_stack" g="0" ai="start">
+              <Text as="p" fz={['l', null, 'xl']} m="0" mb="10" lts="l" ff="base" c="white" o="pp"> About us </Text>
+              <Heading level="2" fz={['2xl', null, '4xl']} fw="500" m="0" mb="50" lts="l"> 当宿について </Heading>
+              <Text class="z--lp003-about_body" as="p" m="0" fz="m" lh="l" lts="s" c="white" o="p">
+                {aboutBodyCopy}
+              </Text>
+            </Stack>
+            <Frame as="figure" class="z--lp003-about_figureLeft" ar={['16/10', '16/10', '4/3']} ov="hidden">
+              <img
+                src={aboutImgLeft.src}
+                alt={aboutImgLeft.alt}
+                width={aboutImgLeft.width}
+                height={aboutImgLeft.height}
+                loading="lazy"
+                decoding="async"
+              />
+            </Frame>
+          </Stack>
+          <Flex
+            as="figure"
+            class="z--lp003-about_figureRight"
+            fxd="column"
+            h={['auto', 'auto', '100%']}
+            min-h={['0', '0', '0']}
+            pb={['0', '0', '50']}
+            ov="hidden"
+          >
+            <Lism
+              as="img"
+              class="z--lp003-about_mediaRightImg"
+              src={aboutImgRight.src}
+              alt={aboutImgRight.alt}
+              fx={['0', '0', '1']}
+              min-h={['0', '0', '0']}
+              w="100%"
+              exProps={{ width: aboutImgRight.width, height: aboutImgRight.height, loading: 'lazy', decoding: 'async' }}
+            />
+          </Flex>
+        </Grid>
+      </Lism>
+
+      <Lism as="section" id="feature" class="z--lp003-feature" bgc="base" c="text" py="60">
+        <Container isWrapper="l" hasGutter isContainer pos="relative">
+          <Grid
+            class="z--lp003-feature_grid"
+            gtc={['1fr', '1fr', 'minmax(0, 1.05fr) minmax(0, 1fr)']}
+            rg={['30', '30', '0']}
+            cg={['0', '0', '50']}
+            ai={['stretch', 'stretch', 'stretch']}
+          >
+            <Lism as="figure" class="z--lp003-feature_figure" ov="hidden" bdrs="10">
+              <img src={featureImg.src} alt={featureImg.alt} width={featureImg.width} height={featureImg.height} loading="lazy" decoding="async" />
+            </Lism>
+            <Stack class="z--lp003-feature_textCol" pos="relative" g="0" ai="stretch" min-w="0" h="100%">
+              <Lism as="span" class="z--lp003-feature_watermark" exProps={{ 'aria-hidden': 'true' }}> Experience </Lism>
+              <Flex
+                class="z--lp003-feature_copyRow"
+                fxd={['column', 'column', 'row']}
+                g={['50', '50', '40']}
+                ai="stretch"
+                pos="relative"
+                fx="1"
+                min-h="0"
+                w="100%"
+              >
+                <Heading level="2" class="z--lp003-feature_title" m="0" fz={['2xl', null, '3xl']} fw="600" lts="l">
+                  <Box class="z--lp003-feature_titleInner" lts="l">
+                    <Inline class="z--lp003-feature_titleLine1">特別な旅と</Inline>
+                    <Inline class="z--lp003-feature_titleLine2">静寂の体験</Inline>
+                  </Box>
+                </Heading>
+                <Stack class="z--lp003-feature_bodyStack" g="30" ai="start" min-w="0">
+                  <Text as="p" class="z--lp003-feature_lead" m="0" fz={['l', null, 'xl']} fw="600" lts="l" c="text">
+                    {featureLead}
+                  </Text>
+                  <Text as="p" class="z--lp003-feature_body" m="0" fz="m" lh="l" lts="s" c="text" max-w="100%">
+                    {featureBody}
+                  </Text>
+                </Stack>
+              </Flex>
+            </Stack>
+          </Grid>
+        </Container>
+      </Lism>
+
+      <Lism as="section" id="feature2" class="z--lp003-feature2" pos="relative" ov-x="clip" c="white">
+        <Frame isLayer>
+          <Lism
+            as="img"
+            src={feature2Bg.src}
+            alt={feature2Bg.alt}
+            w="100%"
+            h="100%"
+            exProps={{
+              width: feature2Bg.width,
+              height: feature2Bg.height,
+              loading: 'lazy',
+              decoding: 'async',
+              'aria-hidden': 'true',
+            }}
+          />
+        </Frame>
+        <Layer bgc="black:75%" exProps={{ 'aria-hidden': 'true' }} />
+        <Container isWrapper="l" hasGutter isContainer pos="relative" z="1" pt="60" pb="0">
+          <WithSide sideW="24em" g="50" ai="start">
+            <Stack isSide g="30" ai="start" w="100%" min-w="0">
+              <Heading level="2" m="0" fz={['3xl', null, '4xl']} fw="500" lts="l" lh="l">
+                季節の移ろいを、<br />肌で感じる。
+              </Heading>
+              <Inline as="span" fz="l" ff="base" m="0" c="white" w="100%" lts="l"> Feeling the seasons </Inline>
+            </Stack>
+            <Stack g="0" ai="start" min-w="0" w="100%">
+              <Text as="p" m="0" fz="m" lh="l" lts="s" c="white" o="mp" w="100%">
+                {feature2IntroBody}
+              </Text>
+            </Stack>
+          </WithSide>
+        </Container>
+        <Container isWrapper="xl" hasGutter isContainer pos="relative" z="1" pt="0" pb="60">
+          <Grid
+            w="100%"
+            min-w="0"
+            mt="50"
+            gtc={['repeat(2, minmax(0, 1fr))', 'repeat(2, minmax(0, 1fr))', 'repeat(4, minmax(0, 1fr))']}
+            g={['20', null, '40']}
+            ai="start"
+          >
+            {
+              feature2GalleryPhotos.map(({ src, alt }, i) => (
+                <Frame
+                  as="figure"
+                  ar="4/3"
+                  m="0"
+                  w="100%"
+                  min-w="0"
+                  jslf="stretch"
+                  pos="relative"
+                  ov="hidden"
+                  mt={i === 1 || i === 3 ? ['0', '0', '40'] : '0'}
+                >
+                  <img src={src} alt={alt} width={800} height={600} loading="lazy" decoding="async" />
+                </Frame>
+              ))
+            }
+          </Grid>
+        </Container>
+      </Lism>
+
+      <Lism as="section" id="plans" bgc="black" c="white" py="60">
+        <Container isWrapper="l" hasGutter>
+          <Stack g="50" ai="stretch" w="100%">
+            <Stack g="10" ai="center" ta="center">
+              <Text as="p" m="0" fz="m" lts="l" ff="base" o="pp"> Plan </Text>
+              <Heading level="2" m="0" fz={['2xl', null, '3xl']} fw="500" lts="l"> 宿泊プラン </Heading>
+            </Stack>
+
+            <Stack g="50" w="100%" ai="stretch">
+              {
+                plans.map((plan) => (
+                  <Flex fxd={['column', 'column', 'row-reverse']} ai="stretch" g={['30', '30', '50']} w="100%">
+                    <Frame as="figure" class="z--lp003-plans_media" m="0" ar="16/10" ov="hidden" bdrs="10" w="100%" min-w="0">
+                      <img
+                        src={plan.image.src}
+                        alt={plan.image.alt}
+                        width={plan.image.width}
+                        height={plan.image.height}
+                        loading="lazy"
+                        decoding="async"
+                      />
+                    </Frame>
+
+                    <Flex g="30" fxd="column" fx="1" min-w="0" min-h="0" w="100%" ai="stretch" jc="space-between">
+                      <Stack g="30" ai="stretch">
+                        <Heading level="3" m="0" fz={['l', null, 'xl']} fw="500" lts="l">
+                          {plan.title}
+                        </Heading>
+                        <Text as="p" m="0" fz="s" lts="s" o="p">
+                          {plan.description}
+                        </Text>
+                      </Stack>
+
+                      <Stack g="30" ai="stretch" w="100%" fxsh="0">
+                        <Grid gtc="repeat(3, minmax(0, 1fr))" bd bdc="white:35%" bdrs="20" ov="hidden" w="100%" m="0" ai="stretch">
+                          {plan.stats.map((stat, index) => (
+                            <Stack g="10" p="15" ai="center" ta="center" bdc="white:35%" class:list={[{ '-bd-x-s': index > 0 }]}>
+                              <Text as="p" m="0" fz="xs" lts="s" o="pp">
+                                {stat.label}
+                              </Text>
+                              <Text as="p" m="0" fz="m" fw="500" lts="l">
+                                {stat.value}
+                              </Text>
+                            </Stack>
+                          ))}
+                        </Grid>
+
+                        <Lism isContainer w="100%" min-w="0">
+                          <Button
+                            class="z--lp003-plans_reserve"
+                            href="#contact"
+                            layout="flex"
+                            w="100%"
+                            fxd={['column', 'row', 'row']}
+                            jc="center"
+                            ai={['center', 'center', 'flex-end']}
+                            g="10"
+                            bgc="white"
+                            c="black"
+                            bdrs="99"
+                            py="15"
+                            px="20"
+                            max-w="100%"
+                            ta="center"
+                          >
+                            <Inline as="span" m="0" fz="m" fw="500" lts="l">
+                              このプランを予約する
+                            </Inline>
+                            <Inline as="span" m="0" fz="xs" o="pp" lts="s">
+                              （予約サイトに移動します）
+                            </Inline>
+                          </Button>
+                        </Lism>
+                      </Stack>
+                    </Flex>
+                  </Flex>
+                ))
+              }
+            </Stack>
+          </Stack>
+        </Container>
+      </Lism>
+
+      <Lism as="section" id="information" pos="relative" bgc="black" c="white" py="60" ov="hidden">
+        <!-- Plan セクションよりわずかに明るいチャコール: 黒ベースの上に薄い白膜（Layer + bgc トークン） -->
+        <Layer aria-hidden="true" bgc="white:6%" />
+        <Container isWrapper="l" hasGutter pos="relative" z="1">
+          <Stack g="40" ai="stretch" w="100%">
+            <!-- jc=start / 狭い gap で見出しブロックのすぐ右にリード文（max-sz で折返し幅を制限） -->
+            <Flex fxd={['column', null, 'row']} g={['30', null, '50']} ai={['start', null, 'end']} jc="start" w="100%" fxw="wrap">
+              <Flex fxd="column" g="10" ai="start" min-w="0" fxsh="0" p-e={['0', null, '40']}>
+                <Text as="p" m="0" fz="s" lts="l" ff="base" o="pp"> Facilities </Text>
+                <Heading level="2" m="0" fz={['xl', null, '2xl']} fw="500" lts="l"> 館内設備 </Heading>
+              </Flex>
+              <Text as="p" m="0" fz="s" lh="l" lts="s" o="p" max-sz="s" min-w="0" fx="1">
+                {informationIntro}
+              </Text>
+            </Flex>
+
+            <Grid gtc={['1fr', null, 'repeat(2, minmax(0, 1fr))']} g="30" ai="stretch">
+              {
+                informationItems.map((item) => (
+                  <Lism bd bdrs="20" bdc="white:35%" ov="hidden" w="100%" p={['20', null, '30']}>
+                    <Flex g={['20', null, '30']} ai="center" w="100%" min-w="0">
+                      <Icon icon={item.icon} size="48px" c="white:35%" />
+                      <Stack g="10" ai="stretch" min-w="0" fx="1">
+                        <Heading level="3" m="0" fz={['m', null, 'l']} fw="500" lts="l">
+                          {item.title}
+                        </Heading>
+                        <Text as="p" m="0" fz="s" lts="s" o="p">
+                          {item.description}
+                        </Text>
+                      </Stack>
+                    </Flex>
+                  </Lism>
+                ))
+              }
+            </Grid>
+          </Stack>
+        </Container>
+      </Lism>
+
+      <Lism as="section" id="faq" bgc="base" c="text" py="60">
+        <Container isWrapper="l" hasGutter>
+          <Grid class="z--lp003-faq_layout" w="100%" g="50" ai="stretch">
+            <Stack class="z--lp003-faq_head" g="10" ai="center" ta="center">
+              <Text as="p" m="0" fz="m" lts="l" ff="base" c="text-2" o="pp"> FAQ </Text>
+              <Heading level="2" m="0" fz={['2xl', null, '3xl']} fw="500" lts="l"> よくあるご質問 </Heading>
+            </Stack>
+
+            <Frame as="figure" class="z--lp003-faq_media" m="0" ar={['16/10', null, '1/1']} ov="hidden" bdrs="10" w="100%" min-w="0">
+              <img src={faqImage.src} alt={faqImage.alt} width={faqImage.width} height={faqImage.height} loading="lazy" decoding="async" />
+            </Frame>
+
+            <Lism class="z--lp003-faq_acc" min-w="0">
+              <Accordion.Root g="0" p="0" ov="visible">
+                {
+                  faqItems.map((item) => (
+                    <Accordion.Item bgc="transparent" bdrs="0" bxsh="0" ov="visible" {...(item.defaultOpen ? { 'data-opened': '' } : {})}>
+                      <Accordion.Heading p="0">
+                        <Accordion.Button fw="500" fz={['s', null, 'm']} ta="start" py="20" isOpen={item.defaultOpen === true}>
+                          {item.question}
+                        </Accordion.Button>
+                      </Accordion.Heading>
+                      <Accordion.Panel py="0" pb="20" isOpen={item.defaultOpen === true}>
+                        <Text m="0" fz="s" c="text-2" lh="l" lts="s">
+                          {item.answer}
+                        </Text>
+                      </Accordion.Panel>
+                    </Accordion.Item>
+                  ))
+                }
+              </Accordion.Root>
+            </Lism>
+          </Grid>
+        </Container>
+      </Lism>
+
+      <Lism as="section" id="reservation" pos="relative" py="60" ov="hidden" c="white">
+        <Frame isLayer m="0">
+          <Lism
+            as="img"
+            src={bgImage.src}
+            alt={bgImage.alt}
+            w="100%"
+            h="100%"
+            exProps={{
+              width: bgImage.width,
+              height: bgImage.height,
+              loading: 'lazy',
+              decoding: 'async',
+            }}
+          />
+        </Frame>
+        <Layer bgc="black:50%" exProps={{ 'aria-hidden': 'true' }} />
+
+        <Container isWrapper="l" hasGutter pos="relative" z="1" max-sz="full">
+          <Grid isContainer gtc={['1fr', null, 'minmax(0, 0.6fr) minmax(0, 1fr)']} g={['40', null, '50']} ai="stretch">
+            <Stack g="30" ai="start" min-w="0">
+              <Stack g="10" ai="start">
+                <Text as="p" m="0" fz="m" lts="l" ff="base" o="pp"> Reservation </Text>
+                <Heading level="2" m="0" fz={['2xl', null, '3xl']} fw="500" lts="l"> ご予約はこちら </Heading>
+              </Stack>
+              <Text as="p" m="0" fz="s" lh="l" lts="s" o="p" max-sz="m">
+                お好みの予約サイトからご予約いただけます。予約完了後は各サイトから確認メールが届きます。キャンセルや変更はご利用のサイトの案内に従ってお手続きください。
+              </Text>
+            </Stack>
+
+            <Grid w="100%" min-w="0" gtc="1fr" g={['40', null, '40']} gc={['1/-1', null, '2/-1']}>
+              {
+                reservationSites.map((site) => (
+                  <Lism pos="relative" bgc="white" c="text" bdrs="20" ov="hidden" min-w="0" w="100%" set="var:bdrsInner">
+                    <Flex fxd={['column', null, 'row']} ai="stretch" w="100%" min-w="0">
+                      <Frame as="figure" m="0" ar="16/10" ov="hidden" bdrs="0" w={['100%', null, '12rem']} fxsh="0" min-w="0">
+                        <img
+                          src={site.image.src}
+                          alt={site.image.alt}
+                          width={site.image.width}
+                          height={site.image.height}
+                          loading="lazy"
+                          decoding="async"
+                        />
+                      </Frame>
+                      <Stack
+                        g="15"
+                        ai="stretch"
+                        min-h="0"
+                        min-w="0"
+                        fx="1"
+                        w="100%"
+                        m="0"
+                        px-s={['20', null, '30']}
+                        px-e={['20', null, '30']}
+                        py={['20', null, '30']}
+                        ov="auto"
+                      >
+                        <Heading level="3" m="0" fz="l" fw="600" lts="l" lh="l">
+                          {site.title}
+                        </Heading>
+                        <Text as="p" m="0" fz="s" c="text-2" lts="s" o="p">
+                          {site.body}
+                        </Text>
+                        <Button href={site.href} w="100%" bdrs="inner" py="15" px="20" fz="s" fw="500" lts="s" ta="center">
+                          サイトに移動する
+                        </Button>
+                      </Stack>
+                    </Flex>
+                  </Lism>
+                ))
+              }
+            </Grid>
+          </Grid>
+        </Container>
+      </Lism>
+    </Container>
+    <!-- Footer -->
+
+    <Lism as="footer" id="footer" class="z--lp003-footer" bgc="black" c="white" py={['50', null, '60']}>
+      <Container isContainer isWrapper="xl" hasGutter>
+        <Stack g={['40', null, '50']} ai="stretch" w="100%">
+          <!-- キャッチコピーをロゴの左隣に。下揃え（flex-end） -->
+          <Flex fxd="row" ai="end" jc="start" fxw="wrap" g={['15', null, '40']} w="100%">
+            <Heading level="2" m="0" fz={['2xl', null, '3xl']} fw="normal" lts="l" lh="l" ff="accent">
+              {logoLabel}
+            </Heading>
+            <Text as="p" m="0" fz={['s', null, 'm']} lh="l" lts="s" o="p" max-sz="m">
+              都会の喧騒から離れ、心安らぐ自然の中で、至福のひとときを。
+            </Text>
+          </Flex>
+
+          <!-- ナビと SNS を下揃え（flex-end） -->
+          <Flex fxd={['column', null, 'row']} ai="end" jc="between" g={['30', null, '40']} w="100%">
+            <Flex
+              as="ul"
+              class="z--lp003-footer_nav"
+              fxd={['column', null, 'row']}
+              ai="stretch"
+              m="0"
+              p="0"
+              g={['0', null, '0']}
+              fxw={['nowrap', null, 'wrap']}
+              w={['100%', null, 'auto']}
+              fx="1"
+              min-w="0"
+            >
+              {
+                footerNavItems.map(({ href, ja, en }) => (
+                  <ListItem>
+                    <BoxLink
+                      class="z--lp003-footer_navLink"
+                      href={href}
+                      layout="grid"
+                      gtc={['1fr auto', null, '1fr']}
+                      ji={['start', 'start', 'center']}
+                      ai="center"
+                      fz="m"
+                      td="none"
+                      py={['15', null, '0']}
+                      px={['5', null, '10']}
+                      c="inherit"
+                      hov="-o"
+                    >
+                      <Stack class="z--lp003-footer_navStack" g="5">
+                        <Inline>{ja}</Inline>
+                        <Inline as="span" class="z--lp003-footer_navEn" fz="s" m="0" o="pp">
+                          {en}
+                        </Inline>
+                      </Stack>
+                      <Icon class="z--lp003-footer_navCaret" icon="caret-right" fz="s" o="pp" />
+                    </BoxLink>
+                  </ListItem>
+                ))
+              }
+            </Flex>
+
+            <Cluster g="20" jc={['center', null, 'end']} ai="end" fxw="wrap" w={['100%', null, 'auto']}>
+              {
+                footerSnsLinks.map(({ href, icon, label }) => (
+                  <Link href={href} td="none" c="inherit" o="pp" hov="-o" hasTransition aria-label={label} exProps={{ style: { '--hov-o': 1 } }}>
+                    <Icon icon={icon} fz="xl" />
+                  </Link>
+                ))
+              }
+            </Cluster>
+          </Flex>
+
+          <Text as="p" m="0" fz="xs" o="pp" lts="s" ta="center"> © 2026 Lism CSS. </Text>
+        </Stack>
+      </Container>
+    </Lism>
+
+    <Button
+      class="z--lp003-reservationFab"
+      href="#reservation"
+      pos="fixed"
+      z="99"
+      layout="flex"
+      fxd="column"
+      ai="center"
+      jc="center"
+      g="5"
+      py="10"
+      px="20"
+      bdrs="99"
+      bd
+      bdc="white:35%"
+      bgc="black"
+      c="white"
+      bxsh="20"
+      set="var:bxsh"
+      td="none"
+      fz="s"
+      lts="s"
+      ta="center"
+      style={{
+        right: 'max(var(--s30), env(safe-area-inset-right))',
+        bottom: 'max(var(--s30), env(safe-area-inset-bottom))',
+      }}
+    >
+      <Inline as="span" m="0" fz="s" fw="500" lts="s"> ご予約はこちら </Inline>
+      <Inline as="span" m="0" fz="2xs" o="pp" lts="l"> Reservation </Inline>
+    </Button>
+  </Wrapper>
+</DemoLayout>
+
+<style>
+  @layer lism-custom {
+    /* lp003: 明朝ベース（Google Fonts / Noto Serif JP） */
+    .z--lp003-root {
+      font-family: 'Noto Serif JP', 'Yu Mincho', YuMincho, 'Hiragino Mincho ProN', 'Hiragino Mincho Pro', serif;
+      font-optical-sizing: auto;
+      /* Lism の `ff:base`（既定はゴシック系）— lp003 では日本語明朝に統一 */
+      --ff--base: 'Noto Serif JP', 'Yu Mincho', YuMincho, 'Hiragino Mincho ProN', 'Hiragino Mincho Pro', serif;
+      /* ロゴ（`ff:accent`）用: Google Fonts / Yuji Syuku（Lism タイポ `--ff--accent`） */
+      --ff--accent: 'Yuji Syuku', 'Noto Serif JP', 'Yu Mincho', YuMincho, 'Hiragino Mincho ProN', 'Hiragino Mincho Pro', serif;
+      /* Feature ほか和紙調のベージュ背景（セマンティック `--base` を上書き） */
+      --base: hsl(38 32% 92%);
+      /* #reservation の named view timeline を兄弟の FAB から参照可能に */
+      timeline-scope: --z--lp003-reservation;
+    }
+    /* Reservation がビューポートに入る進行に合わせて FAB を非表示 */
+    #reservation {
+      view-timeline-name: --z--lp003-reservation;
+      view-timeline-axis: block;
+    }
+    @keyframes lp003_reservationFab_hide {
+      from {
+        opacity: 1;
+        pointer-events: auto;
+        visibility: visible;
+      }
+      to {
+        opacity: 0;
+        pointer-events: none;
+        visibility: hidden;
+      }
+    }
+    .z--lp003-reservationFab {
+      animation: lp003_reservationFab_hide linear both;
+      animation-timeline: --z--lp003-reservation;
+      animation-range: entry 0% entry 30%;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .z--lp003-reservationFab {
+        animation: none;
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+      }
+    }
+
+    /* Root */
+    :root {
+      --z--header-height: 100px;
+      --z--header-height--thin: 56px;
+      --u--fadeIn--animation-range: entry 0% contain 20%;
+    }
+    /* Fadein */
+    .u--fadeIn {
+      view-timeline: --u--fadeIn y;
+      animation: u--fadeIn linear both;
+      animation-timeline: --u--fadeIn;
+      animation-range: var(--u--fadeIn--animation-range);
+    }
+    @keyframes u--fadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(32px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+    /* Background Parallax */
+    .u--bgParallax {
+      view-timeline: --u--bgParallax y;
+    }
+    .u--bgParallax .a--media {
+      position: absolute;
+      top: -20%;
+      height: 140%;
+      animation: u--bgParallax_media linear both;
+      animation-timeline: --u--bgParallax;
+      animation-range: entry 0% cover 100%;
+    }
+    @keyframes u--bgParallax_media {
+      from {
+        transform: translateY(-10%);
+      }
+      to {
+        transform: translateY(10%);
+      }
+    }
+
+    .z--lp003-header {
+      height: var(--z--header-height);
+      color: var(--white);
+      background-color: transparent;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+      box-sizing: border-box;
+      --z--header-scroll-animation-start: 80px;
+      --z--header-animation-range: var(--z--header-scroll-animation-start) calc(var(--z--header-scroll-animation-start) + 140px);
+      animation: z--header_lp003 linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--header-animation-range);
+    }
+    .z--lp003-header :where(a) {
+      color: inherit;
+    }
+    /**
+   * モーダル内ナビ: Footer と同様に `li:not(:last-child)` + `border-block-end: dashed`（`u--divide` は未使用）
+   * フッターは黒地へ `color-mix(…, var(--white) 38%, …)`。モーダルは `.c--modal_inner` の `var(--base)` 地のため `var(--text)` を使用
+   * @see Footer.astro / tokens.md --text / `color-mix`
+   */
+    .z--lp003-header_menuNav {
+      list-style: none;
+    }
+    .z--lp003-header_menuNav > :global(li) {
+      list-style: none;
+    }
+    .z--lp003-header_menuNav > :global(li:not(:last-child)) {
+      border-block-end: 1px dashed color-mix(in srgb, var(--text) 38%, transparent);
+    }
+    /* md 以上: has--gutter の左右に s20 を上乗せ（Lism: `--gutter-size` 既定は `--s30`） */
+    @media (min-width: 800px) {
+      .z--lp003-header_bar {
+        padding-inline: calc(var(--gutter-size) + var(--s20));
+      }
+    }
+    /**
+   * ロゴは Logo.astro 内で描画されるため、Astro スコープ外。:global で子コンポーネントの a に一致させる。
+   * @see https://docs.astro.build/en/guides/styling/#global-styles
+   */
+    :global(.z--lp003-header_logoLink) {
+      transform-origin: left center;
+      animation: z--lp003-header_logo_lp003 linear both;
+      animation-timeline: scroll(root);
+      /* 継承: 先祖 `.z--lp003-header` の `--z--header-animation-range` */
+      animation-range: var(--z--header-animation-range);
+    }
+    /**
+   * スクロール後: 黒ベースの半透明 + backdrop-filter で奥行きをぼかし視認性を確保。
+   * 下端の極細ハイライトで帯として切り分ける。
+   */
+    @keyframes z--header_lp003 {
+      to {
+        background-color: hsl(0 0% 0% / 0.78);
+        color: var(--white);
+        height: var(--z--header-height--thin);
+        backdrop-filter: blur(14px) saturate(1.12);
+        -webkit-backdrop-filter: blur(14px) saturate(1.12);
+        box-shadow:
+          0 8px 32px hsl(0 0% 0% / 0.42),
+          inset 0 -1px 0 hsl(0 0% 100% / 0.07);
+      }
+    }
+    @keyframes z--lp003-header_logo_lp003 {
+      from {
+        transform: scale(1);
+      }
+      to {
+        /* 3xl 時も以前（2xl×0.9 相当）のスクロール後サイズ感に近づける */
+        transform: scale(0.75);
+      }
+    }
+    .z--lp003-headerNav_en {
+      max-height: 2.5em;
+      overflow: hidden;
+      animation: z--lp003-headerNav_en_lp003 linear both;
+      animation-timeline: scroll(root);
+      animation-range: var(--z--header-animation-range);
+    }
+    @keyframes z--lp003-headerNav_en_lp003 {
+      to {
+        opacity: 0;
+        max-height: 0;
+        margin: 0;
+        padding: 0;
+      }
+    }
+
+    .z--lp003-mv {
+      background-color: #000;
+    }
+
+    .z--lp003-mv_bg {
+      inset: 0;
+    }
+
+    .z--lp003-mv_layer {
+      position: absolute;
+      inset: 0;
+      background-image: var(--z--lp003-mv-layerBgImage);
+      background-size: cover;
+      background-position: center;
+      background-repeat: no-repeat;
+      transform-origin: center center;
+      opacity: 0;
+      transform: scale(1);
+      animation: lp003-mv-bgFade var(--z--lp003-mv-bgCycleDuration) infinite;
+      animation-timing-function: linear;
+      animation-delay: var(--z--lp003-mv-layerDelay);
+    }
+
+    /* MVSimple と同一の縦書きブロック */
+    .z--lp003-mv_copy {
+      font-feature-settings: 'palt' 1;
+      font-size: clamp(1.1rem, 3.4vw, 1.75rem);
+      line-height: 1.85;
+      letter-spacing: 0.22em;
+      writing-mode: vertical-rl;
+      text-orientation: mixed;
+      display: flex;
+      flex-direction: column;
+      flex-wrap: nowrap;
+      align-items: stretch;
+      gap: clamp(1.4rem, 4vw, 3rem);
+    }
+    .z--lp003-mv_copy .z--lp003-mv_line:first-child {
+      transform: translateY(-1em);
+    }
+    .z--lp003-mv_copy .z--lp003-mv_line:last-child:not(:first-child) {
+      transform: translateY(1em);
+    }
+
+    /* コピー行: ブラー＋フェード（開始は --z--lp003-mv-lineIndex でスタガード） */
+    @keyframes lp003-mv-lineReveal {
+      from {
+        opacity: 0;
+        filter: blur(var(--z--lp003-mv-lineBlurMax, 12px));
+      }
+      to {
+        opacity: 1;
+        filter: blur(0);
+      }
+    }
+
+    .z--lp003-mv_copy .z--lp003-mv_line {
+      opacity: 0;
+      filter: blur(var(--z--lp003-mv-lineBlurMax, 12px));
+      animation: lp003-mv-lineReveal var(--z--lp003-mv-lineDuration, 1s) ease forwards;
+      animation-delay: calc(var(--z--lp003-mv-lineStartDelay, 0s) + var(--z--lp003-mv-lineStagger, 0.2s) * var(--z--lp003-mv-lineIndex, 0));
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .z--lp003-mv_layer {
+        animation: none;
+        opacity: 0;
+        transform: none;
+      }
+      .z--lp003-mv_layer:first-child {
+        opacity: 1;
+      }
+      .z--lp003-mv_copy .z--lp003-mv_line {
+        animation: none;
+        opacity: 1;
+        filter: none;
+      }
+    }
+
+    /*
+   * ビューポート全幅: 親の max-width に依存しないよう、自身を 100vw で中央に置く。
+   */
+    .z--lp003-about {
+      --z--lp003-about-l-inset: max(var(--gutter-size), calc((100vw - var(--sz--l)) / 2));
+      --z--lp003-about-xl-inset: max(var(--gutter-size), calc((100vw - var(--sz--xl)) / 2));
+      position: relative;
+      left: 50%;
+      transform: translateX(-50%);
+      box-sizing: border-box;
+      width: 100vw;
+      max-width: 100vw;
+      overflow-x: clip;
+    }
+    .z--lp003-about_mediaRightImg {
+      display: block;
+      object-fit: cover;
+    }
+    .z--lp003-about_figureLeft,
+    .z--lp003-about_figureRight {
+      margin: 0;
+    }
+    @media (min-width: 800px) {
+      .z--lp003-about_col--left {
+        box-sizing: border-box;
+        min-width: 0;
+        /* 見出し・本文: グローバルな size=l の左端（Lism の px-s はカスタム計算のため CSS のみ） */
+        padding-inline-start: var(--z--lp003-about-l-inset);
+      }
+      .z--lp003-about_stack {
+        align-self: start;
+        width: min(100%, var(--sz--l));
+        min-width: 0;
+      }
+      .z--lp003-about_body {
+        padding-inline-start: var(--s50);
+      }
+      .z--lp003-about_figureLeft {
+        align-self: start;
+        margin-block-start: auto;
+        padding-block-start: var(--s30);
+        margin-inline-start: calc(var(--z--lp003-about-xl-inset) - var(--z--lp003-about-l-inset));
+        box-sizing: border-box;
+        min-inline-size: 0;
+        max-inline-size: 100%;
+        inline-size: min(20rem, 100%);
+      }
+    }
+    @media (max-width: 799px) {
+      .z--lp003-about_grid {
+        padding-inline: var(--gutter-size);
+        box-sizing: border-box;
+      }
+      .z--lp003-about_figureLeft {
+        inline-size: 100%;
+        max-inline-size: none;
+      }
+      .z--lp003-about_mediaRightImg {
+        aspect-ratio: 4 / 3;
+        block-size: auto;
+      }
+    }
+
+    /* 左端プル: コンテナ幅 l + gutter と整合 */
+    .z--lp003-feature {
+      --z--lp003-feature-pull: max(var(--gutter-size, 0px), calc((100vw - min(100vw, var(--sz--l))) / 2));
+      --z--lp003-feature-figure-max-h: 540px;
+      position: relative;
+    }
+    /* isContainer 祖先幅: Lism md と同じ (min-width: 800px) / not で補集合（max-width:799 との境目ギャップを避ける） */
+    @container not (min-width: 800px) {
+      .z--lp003-feature_textCol {
+        order: 1;
+      }
+      .z--lp003-feature_figure {
+        order: 2;
+        margin-inline: 0;
+        inline-size: 100%;
+        max-inline-size: none;
+        aspect-ratio: 16 / 10;
+        max-block-size: var(--z--lp003-feature-figure-max-h);
+      }
+      .z--lp003-feature_bodyStack {
+        align-self: stretch;
+        margin-inline-start: 0;
+        max-inline-size: 100%;
+      }
+      .z--lp003-feature_lead,
+      .z--lp003-feature_body {
+        text-align: start;
+        text-wrap: pretty;
+      }
+      .z--lp003-feature_title {
+        align-self: end;
+      }
+    }
+    .z--lp003-feature_figure {
+      margin: 0;
+      position: relative;
+      box-sizing: border-box;
+      align-self: stretch;
+      max-block-size: var(--z--lp003-feature-figure-max-h);
+    }
+    .z--lp003-feature_figure > img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    @container (min-width: 800px) {
+      .z--lp003-feature_figure {
+        margin-inline-start: calc(-1 * var(--z--lp003-feature-pull));
+        width: calc(100% + var(--z--lp003-feature-pull));
+        max-width: none;
+        border-radius: 0 var(--bdrs--10) var(--bdrs--10) 0;
+        min-height: min(22rem, 52vw, var(--z--lp003-feature-figure-max-h));
+      }
+      .z--lp003-feature_figure > img {
+        min-height: min(22rem, 52vw, var(--z--lp003-feature-figure-max-h));
+      }
+    }
+    .z--lp003-feature_textCol {
+      min-height: 0;
+      overflow-x: visible;
+    }
+    /* 2列時: 見出しは上・本文は下（上端・下端揃え） */
+    @container (min-width: 800px) {
+      .z--lp003-feature_copyRow {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        grid-template-rows: 1fr auto;
+        min-height: min(22rem, 52vw);
+      }
+      .z--lp003-feature_title {
+        grid-column: 2;
+        grid-row: 1 / -1;
+        align-self: start;
+        justify-self: end;
+      }
+      .z--lp003-feature_bodyStack {
+        grid-column: 1;
+        grid-row: 2;
+        align-self: end;
+        max-inline-size: min(100%, 26rem);
+      }
+      .z--lp003-feature_lead,
+      .z--lp003-feature_body {
+        text-align: start;
+      }
+    }
+    .z--lp003-feature_title {
+      flex-shrink: 0;
+      line-height: 1.65;
+    }
+    /* 縦書き2列: 横書きの flex 列＋子に writing-mode: vertical-rl */
+    .z--lp003-feature_titleInner {
+      display: flex;
+      flex-direction: row-reverse;
+      align-items: flex-start;
+      gap: 0.65em;
+    }
+    .z--lp003-feature_titleLine1,
+    .z--lp003-feature_titleLine2 {
+      display: block;
+      writing-mode: vertical-rl;
+      text-orientation: mixed;
+    }
+    .z--lp003-feature_titleLine2 {
+      transform: translateY(1em);
+    }
+    /* 共有。左右位置は Lism md（@container 800px）に同期 */
+    .z--lp003-feature_watermark {
+      position: absolute;
+      z-index: 0;
+      margin: 0;
+      padding: 0;
+      inset-block-start: 0;
+      transform: none;
+      font-family: var(--ff--base, ui-serif, 'Times New Roman', Times, serif);
+      font-weight: 700;
+      line-height: 0.82;
+      letter-spacing: 0.03em;
+      color: rgb(0 0 0 / 0.07);
+      white-space: nowrap;
+      pointer-events: none;
+      user-select: none;
+      direction: ltr;
+      unicode-bidi: isolate;
+    }
+    @container (min-width: 800px) {
+      .z--lp003-feature_watermark {
+        inset-inline-start: 0;
+        inset-inline-end: auto;
+        transform-origin: left center;
+        font-size: clamp(2.75rem, 11cqi, 7.5rem);
+      }
+    }
+    @container not (min-width: 800px) {
+      .z--lp003-feature_watermark {
+        inset-inline-start: auto;
+        inset-inline-end: 0;
+        transform-origin: right center;
+        font-size: clamp(3.15rem, 14cqi, 6.5rem);
+      }
+    }
+
+    /*
+   * Lism の md は viewport の @media ではなく @container (min-width: 800px)（prop-responsive.md）。
+   * また -max-w:100%（max-width）と max-inline-size の併用や、flex 子の % 解決で上限が効かないことがあるため、
+   * コンテナクエリ内で max-width + cqi を使い、fxd の row 切替と同じ基準で min(32rem, 40cqi) に揃える（40cqi はクエリコンテナ行内幅の 40% 相当の上限）。
+   */
+    .z--lp003-plans_media {
+      max-width: 100%;
+    }
+    @container (min-width: 800px) {
+      .z--lp003-plans_media {
+        max-width: min(32rem, 40cqi);
+      }
+    }
+
+    /* UI Button のデフォルト（--text 地）を上書きし、デザインどおり白ピル＋黒字に */
+    .z--lp003-plans_reserve.c--button {
+      --bgc: var(--white);
+      --c: var(--black);
+      --bdc: var(--white);
+    }
+
+    /*
+   * 見出し＋（画像｜質問）をひとつの Grid で管理。
+   * md 以上: 画像列と質問列を repeat(2, 1fr) で 1:1。
+   */
+    .z--lp003-faq_layout {
+      display: grid;
+      grid-template-areas: 'head' 'acc' 'img';
+      grid-template-columns: minmax(0, 1fr);
+    }
+    .z--lp003-faq_head {
+      grid-area: head;
+    }
+    .z--lp003-faq_acc {
+      grid-area: acc;
+    }
+    .z--lp003-faq_media {
+      grid-area: img;
+    }
+    @container (min-width: 800px) {
+      .z--lp003-faq_layout {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-areas:
+          'head head'
+          'img acc';
+      }
+    }
+
+    .z--lp003-faq_acc :global(.c--accordion_item) {
+      border-block-end: 1px solid var(--divider);
+    }
+    .z--lp003-faq_acc :global(.c--accordion_item:last-of-type) {
+      border-block-end: none;
+    }
+
+    .z--lp003-footer :where(a) {
+      color: inherit;
+    }
+    .z--lp003-footer_nav :global(li) {
+      list-style: none;
+    }
+
+    /* md 未満: 縦並びの項目間に区切り（最後の行の下には付けない） */
+    .z--lp003-footer_nav > :global(li:not(:last-child)) {
+      border-block-end: 1px dashed color-mix(in srgb, var(--white) 38%, transparent);
+    }
+
+    /* md 以上: 縦の区切りをやめ、項目の「間」だけ左に縦線（先頭左・末尾右には付けない） */
+    @container (min-width: 800px) {
+      .z--lp003-footer_nav > :global(li:not(:last-child)) {
+        border-block-end: none;
+      }
+      .z--lp003-footer_nav > :global(li + li) {
+        border-inline-start: 1px dashed color-mix(in srgb, var(--white) 38%, transparent);
+        padding-inline-start: var(--s20);
+        margin-inline-start: var(--s20);
+      }
+    }
+
+    /* md 未満: 左寄せ。`ta` プロパティのインラインが CSS より優先するため、指定はここに集約 */
+    .z--lp003-footer_navStack {
+      text-align: start;
+      align-items: flex-start;
+    }
+    @container (min-width: 800px) {
+      .z--lp003-footer_navStack {
+        text-align: center;
+        align-items: center;
+      }
+    }
+
+    /* md 以上: caret は非表示 */
+    .z--lp003-footer_navCaret {
+      display: block;
+    }
+    @container (min-width: 800px) {
+      .z--lp003-footer_navCaret {
+        display: none;
+      }
+    }
+
+    /* ピル型 FAB: UI Button のセマンティック色を上書き */
+    .z--lp003-reservationFab.c--button {
+      --bgc: var(--black);
+      --c: var(--white);
+      min-width: 12rem;
+    }
+    .z--lp003-reservationFab:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--white) 50%, transparent);
+      outline-offset: 3px;
+    }
+  }
+</style>

--- a/apps/docs/src/pages/preview/templates/lp/lp003/index.astro
+++ b/apps/docs/src/pages/preview/templates/lp/lp003/index.astro
@@ -21,7 +21,9 @@ import {
   WithSide,
   Wrapper,
 } from 'lism-css/astro';
-import { Accordion, Button, Modal } from '@lism-css/ui/astro';
+import { Accordion } from '@lism-css/ui/astro/Accordion';
+import { Button } from '@lism-css/ui/astro/Button';
+import { Modal } from '@lism-css/ui/astro/Modal';
 
 export const title = 'LP003: Japanese Ryokan LP';
 


### PR DESCRIPTION
TemplatesにLPテンプレート001〜003を新規追加しました。
以下テンプレートの概要です。

- 001：Minimal LP（ミニマル、スクロール駆動アニメ）
- 002：Simple Natural LP（シンプル、頻出レイアウトサンプル）
- 003：Japanese Ryokan LP（日本の伝統的な旅館、変則レイアウトサンプル）

内容問題なければマージお願いします。

## note

_style.cssが空だとコミット時に```pnpm exec lint-staged```が走りコミットが出来なかったのでコメントを追加してコミットしました。

<img width="1920" height="1058" alt="20260430-213015" src="https://github.com/user-attachments/assets/ccbcbecf-9ccb-4ca9-bb25-04ebdba4ec0b" />