### PR TITLE
fix(lism-css): is--wrapper 直下に inline-size: 100% を付与

### DIFF
--- a/apps/docs/src/content/en/changelog.mdx
+++ b/apps/docs/src/content/en/changelog.mdx
@@ -13,7 +13,7 @@ Breaking changes may continue frequently until the v1.0 release, so all notable 
 
 ### Apply `inline-size: 100%` to direct children of `is--wrapper` (#355)
 
-Added `inline-size: 100%` to `is--wrapper > *` so that children whose natural width is below `--contentSize` (short paragraphs, `<table>`, etc.) no longer cause width mismatches under `l--stack` and other vertical flex layouts.
+Added `inline-size: 100%` to `is--wrapper > *` so children whose natural width is below `--contentSize` (short paragraphs, `<table>`, etc.) always stretch to the parent width, fixing width misalignment under `l--stack` and other vertical flex layouts.
 
 ```scss
 .is--wrapper > * {

--- a/apps/docs/src/content/en/changelog.mdx
+++ b/apps/docs/src/content/en/changelog.mdx
@@ -9,6 +9,26 @@ Breaking changes may continue frequently until the v1.0 release, so all notable 
 
 <Divider bds="dashed" my="40" />
 
+## lism-css v.0.16.2
+
+### Apply `inline-size: 100%` to direct children of `is--wrapper` (#355)
+
+Added `inline-size: 100%` to `is--wrapper > *` so that children whose natural width is below `--contentSize` (short paragraphs, `<table>`, etc.) no longer cause width mismatches under `l--stack` and other vertical flex layouts.
+
+```scss
+.is--wrapper > * {
+  inline-size: 100%;
+  max-inline-size: min(100%, var(--contentSize));
+  margin-inline: auto;
+}
+```
+
+**Side effect**: A `<table>` placed directly inside `is--wrapper` no longer falls back to its content-driven natural width — it always stretches to the wrapper width. If you need the table to keep its intrinsic width, wrap it in another element so that `is--wrapper` is not its direct parent.
+
+To prevent this from breaking the negative-margin "hang" of `-max-sz:full` inside `has--gutter` and the centered placement of `-max-sz:container`, both classes now also set `inline-size: auto` to reset the inherited `inline-size: 100%`.
+
+<Divider bds="dashed" my="40" />
+
 ## lism-css v.0.16.1 (2026.04.29)
 
 - Changed the `--list-px-s` fallback value to `1.75em`

--- a/apps/docs/src/content/en/trait-class/is--wrapper.mdx
+++ b/apps/docs/src/content/en/trait-class/is--wrapper.mdx
@@ -12,6 +12,12 @@ import { Wrapper, Box, Lism, Spacer } from "lism-css/astro";
 
 <SrcCode path="src/scss/trait/is/_wrapper.scss" />
 
+Direct children get `inline-size: 100%`, so even elements whose natural width is below `--contentSize` (short paragraphs, `<table>`, etc.) are first stretched to fill the parent and then constrained by `max-inline-size`. This keeps widths consistent under `l--stack` and other vertical layouts and prevents jagged edges.
+
+:::caution
+A `<table>` placed as a direct child of `is--wrapper` no longer falls back to its content-driven natural width — it always stretches to the wrapper width. If you need the table to keep its intrinsic width, wrap it in another element so that `is--wrapper` is not its direct parent.
+:::
+
 
 ## Using with Lism Components
 

--- a/apps/docs/src/content/en/trait-class/is--wrapper.mdx
+++ b/apps/docs/src/content/en/trait-class/is--wrapper.mdx
@@ -12,7 +12,7 @@ import { Wrapper, Box, Lism, Spacer } from "lism-css/astro";
 
 <SrcCode path="src/scss/trait/is/_wrapper.scss" />
 
-Direct children get `inline-size: 100%`, so even elements whose natural width is below `--contentSize` (short paragraphs, `<table>`, etc.) are first stretched to fill the parent and then constrained by `max-inline-size`. This keeps widths consistent under `l--stack` and other vertical layouts and prevents jagged edges.
+Direct children receive `inline-size: 100%`, so even elements whose natural width is below `--contentSize` (short paragraphs, `<table>`, etc.) always stretch to the parent width. This keeps widths consistent under `l--stack` and other vertical layouts and prevents jagged edges.
 
 :::caution
 A `<table>` placed as a direct child of `is--wrapper` no longer falls back to its content-driven natural width — it always stretches to the wrapper width. If you need the table to keep its intrinsic width, wrap it in another element so that `is--wrapper` is not its direct parent.

--- a/apps/docs/src/content/ja/changelog.mdx
+++ b/apps/docs/src/content/ja/changelog.mdx
@@ -9,6 +9,26 @@ v.1.0リリースまでしばらく激しい変更が続く可能性があるた
 
 <Divider bds="dashed" my="40" />
 
+## lism-css v.0.16.2
+
+### `is--wrapper` 直下の子要素に `inline-size: 100%` を付与 (#355)
+
+`is--wrapper > *` に `inline-size: 100%` を追加し、`l--stack` などの flex 縦並び配下で子要素の自然幅依存によって横幅が揃わない問題を解消しました。
+
+```scss
+.is--wrapper > * {
+  inline-size: 100%;
+  max-inline-size: min(100%, var(--contentSize));
+  margin-inline: auto;
+}
+```
+
+**副作用**: `is--wrapper` 直下に置いた `<table>` は内容依存の自然幅にはならず、常に wrapper 幅まで広がるようになりました。テーブルの自然幅を保ちたい場合は `is--wrapper` を直接の親にせず、間に別の要素を挟んでください。
+
+合わせて、上記との干渉で `has--gutter` 内の `-max-sz:full` の hang が効かなくなる問題、および `-max-sz:container` の中央配置が崩れる問題を解消するため、それぞれに `inline-size: auto` を追加しました。
+
+<Divider bds="dashed" my="40" />
+
 ## lism-css v.0.16.1 (2026.04.29)
 
 - `--list-px-s` のフォールバック値を `1.75em` に変更

--- a/apps/docs/src/content/ja/trait-class/is--wrapper.mdx
+++ b/apps/docs/src/content/ja/trait-class/is--wrapper.mdx
@@ -12,6 +12,12 @@ import { Wrapper, Box, Lism, Spacer } from "lism-css/astro";
 
 <SrcCode path="src/scss/trait/is/_wrapper.scss" />
 
+直下の子要素には `inline-size: 100%` が当たるため、自然幅が `--contentSize` 未満の要素（短い段落や `<table>` など）も常に親幅まで広がります。これにより `l--stack` などの縦並び配下でも横幅が揃い、ガタつきが起きません。
+
+:::caution
+`<table>` を `is--wrapper` の直下に置くと内容依存の自然幅にはならず、常に wrapper 幅まで広がります。テーブルの自然幅を保ちたい場合は、`is--wrapper` を直接の親にしないように間に別の要素を挟んでください。
+:::
+
 
 ## Lismコンポーネントでの使い方
 

--- a/packages/lism-css/src/scss/props/_size.scss
+++ b/packages/lism-css/src/scss/props/_size.scss
@@ -2,14 +2,14 @@
   max-inline-size: 100%;
 
   :where(.has--gutter) > & {
-    inline-size: auto;
+    inline-size: auto; // is--wrapper > * の inline-size: 100% を打ち消し、負 margin による hang を効かせる
     max-inline-size: calc(100% + var(--gutter-size) * 2);
     margin-inline: calc(var(--gutter-size) * -1);
   }
 }
 
 .-max-sz\:container {
-  inline-size: auto;
+  inline-size: auto; // is--wrapper > * の inline-size: 100% を打ち消し、container 幅まで広げて中央配置する
   max-inline-size: var(--sz--container, 100cqi);
   margin-inline: calc(50% - var(--sz--container) / 2);
 }

--- a/packages/lism-css/src/scss/props/_size.scss
+++ b/packages/lism-css/src/scss/props/_size.scss
@@ -2,12 +2,14 @@
   max-inline-size: 100%;
 
   :where(.has--gutter) > & {
+    inline-size: auto;
     max-inline-size: calc(100% + var(--gutter-size) * 2);
     margin-inline: calc(var(--gutter-size) * -1);
   }
 }
 
 .-max-sz\:container {
+  inline-size: auto;
   max-inline-size: var(--sz--container, 100cqi);
   margin-inline: calc(50% - var(--sz--container) / 2);
 }

--- a/packages/lism-css/src/scss/trait/is/_wrapper.scss
+++ b/packages/lism-css/src/scss/trait/is/_wrapper.scss
@@ -2,7 +2,7 @@
   // 子要素の制御
   --contentSize: var(--sz--m, 100%);
   > * {
-    inline-size: 100%;
+    inline-size: 100%; // l--stack 等の縦並び配下で自然幅要素のガタつきを防ぐ
     max-inline-size: min(100%, var(--contentSize)); // min ないとimg要素等がはみ出す
     margin-inline: auto;
   }

--- a/packages/lism-css/src/scss/trait/is/_wrapper.scss
+++ b/packages/lism-css/src/scss/trait/is/_wrapper.scss
@@ -2,6 +2,7 @@
   // 子要素の制御
   --contentSize: var(--sz--m, 100%);
   > * {
+    inline-size: 100%;
     max-inline-size: min(100%, var(--contentSize)); // min ないとimg要素等がはみ出す
     margin-inline: auto;
   }

--- a/skills/lism-css-guide/property-class/max-sz.md
+++ b/skills/lism-css-guide/property-class/max-sz.md
@@ -32,13 +32,14 @@
   max-inline-size: 100%;
 
   :where(.has--gutter) > & {
+    inline-size: auto;
     max-inline-size: calc(100% + var(--gutter-size) * 2);
     margin-inline: calc(var(--gutter-size) * -1);
   }
 }
 ```
 
-`has--gutter` の内側で全幅画像・全幅バナーなどを配置したい時に使う。
+`has--gutter` の内側で全幅画像・全幅バナーなどを配置したい時に使う。`inline-size: auto` は、親が `is--wrapper` の場合に当たる `inline-size: 100%` を打ち消し、負 margin による hang を効かせるためのリセット。
 
 ### `-max-sz:container`
 
@@ -46,12 +47,13 @@
 
 ```scss
 .-max-sz\:container {
+  inline-size: auto;
   max-inline-size: var(--sz--container, 100cqi);
   margin-inline: calc(50% - var(--sz--container) / 2);
 }
 ```
 
-`margin-inline` で中央配置されるので、`is--wrapper` の内側にあっても container 基準の幅に広げつつ中央に揃う。
+`margin-inline` で中央配置されるので、`is--wrapper` の内側にあっても container 基準の幅に広げつつ中央に揃う。`inline-size: auto` も同じく、`is--wrapper > *` で当たる `inline-size: 100%` を打ち消すためのリセット。
 
 ## Usage
 

--- a/skills/lism-css-guide/trait-class/is--wrapper.md
+++ b/skills/lism-css-guide/trait-class/is--wrapper.md
@@ -80,6 +80,21 @@
 </div>
 ```
 
+## 直下の子要素の挙動
+
+`is--wrapper` 直下の子要素には次のスタイルが当たる：
+
+```scss
+.is--wrapper > * {
+  inline-size: 100%;
+  max-inline-size: min(100%, var(--contentSize));
+  margin-inline: auto;
+}
+```
+
+- `inline-size: 100%` により、自然幅が `--contentSize` 未満の要素（短い段落、`<table>` など）も常に親幅まで広げてから `max-inline-size` で制限される。これにより `l--stack` などの flex 縦並び配下でも横幅が揃い、ガタつきが起きない
+- `<table>` を直下に置くと内容依存の自然幅にはならず、常に wrapper 幅まで広がる。テーブルの自然幅を保ちたい場合は `is--wrapper` を直接の親にしないように、間に別の要素を挟む
+
 ## 関連プリミティブ
 
 - [is--container](./is--container.md) — コンテナクエリ基準（`isContainer` と併用可）


### PR DESCRIPTION
## Summary

`is--wrapper` と `l--stack` を併用した際、`is--wrapper` 直下に置かれた「100% 未満の自然幅を持つ要素」（短い段落、`<table>` など）が中央寄せされ、Stack 配下で横幅が揃わずガタついて見える問題を修正します。

`.is--wrapper > *` に `inline-size: 100%` を追加し、子要素を一旦親幅いっぱいに広げてから `max-inline-size: min(100%, var(--contentSize))` で制限する形に変更しました。

合わせて、上記が `-max-sz:full`（`has--gutter` 内の hang）と `-max-sz:container`（中央配置）と干渉するため、それぞれに `inline-size: auto` を追加してリセットしています。

Closes #355

## Changes

- `packages/lism-css/src/scss/trait/is/_wrapper.scss`: `> *` に `inline-size: 100%` を追加
- `packages/lism-css/src/scss/props/_size.scss`:
  - `-max-sz:full`（`has--gutter` 直下）に `inline-size: auto` を追加
  - `-max-sz:container` に `inline-size: auto` を追加
- `skills/lism-css-guide/trait-class/is--wrapper.md`: 「直下の子要素の挙動」節を追加
- `skills/lism-css-guide/property-class/max-sz.md`: SCSS コード例を最新に更新
- `apps/docs/src/content/{ja,en}/trait-class/is--wrapper.mdx`: 挙動補足と `<table>` の注意書きを追加
- `apps/docs/src/content/{ja,en}/changelog.mdx`: v.0.16.2 エントリを追加

## 副作用

`is--wrapper` 直下の `<table>` は内容依存の自然幅にはならず、常に wrapper 幅まで広がります（changelog / docs に明記）。

## Test plan

- [ ] ドキュメントサイトで `is--wrapper` + `l--stack` 配下の要素が横幅揃って表示されること
- [ ] `has--gutter` 内の `-max-sz:full` 要素が従来通り gutter 分まで hang すること
- [ ] `is--wrapper` 内に置いた `-max-sz:container` 要素が container 基準で中央配置されること
- [ ] `/demo/container`, `/demo/content-size` のデモページで挙動確認