### PR TITLE
test(ui): Accordion / Modal / Tabs の実装本体に Vitest ユニットテストを追加

### DIFF
--- a/packages/lism-ui/package.json
+++ b/packages/lism-ui/package.json
@@ -29,7 +29,13 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "!**/*.test.ts",
+    "!**/*.test.tsx",
+    "!**/*.test.d.ts",
+    "!**/*.stories.ts",
+    "!**/*.stories.tsx",
+    "!**/*.stories.d.ts"
   ],
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/lism-ui/package.json
+++ b/packages/lism-ui/package.json
@@ -153,18 +153,19 @@
     "lism-css": "workspace:*"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.9.1",
     "@babel/cli": "^7.28.6",
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.0",
     "@babel/preset-react": "^7.28.5",
     "@rollup/plugin-babel": "^6.1.0",
     "@storybook/react-vite": "^10.3.3",
+    "@testing-library/jest-dom": "^6.9.1",
     "@types/node": "^25.5.0",
     "@vitejs/plugin-react-swc": "^3.11.0",
     "astro": "^6.1.9",
     "eslint": "^9.39.4",
     "glob": "^13.0.6",
+    "jsdom": "^27.4.0",
     "rollup": "^4.59.0",
     "rollup-plugin-preserve-directives": "^0.4.0",
     "storybook": "^10.3.3",
@@ -174,7 +175,6 @@
     "unplugin-dts": "1.0.0-beta.6",
     "vite": "^7.3.1",
     "vite-plugin-lib-inject-css": "^2.2.2",
-    "jsdom": "^27.4.0",
     "vitest": "^4.1.0"
   },
   "peerDependencies": {

--- a/packages/lism-ui/package.json
+++ b/packages/lism-ui/package.json
@@ -147,6 +147,7 @@
     "lism-css": "workspace:*"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
     "@babel/cli": "^7.28.6",
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.0",
@@ -166,7 +167,9 @@
     "typescript": "^5.8.3",
     "unplugin-dts": "1.0.0-beta.6",
     "vite": "^7.3.1",
-    "vite-plugin-lib-inject-css": "^2.2.2"
+    "vite-plugin-lib-inject-css": "^2.2.2",
+    "jsdom": "^27.4.0",
+    "vitest": "^4.1.0"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/lism-ui/src/components/Accordion/setAccordion.test.ts
+++ b/packages/lism-ui/src/components/Accordion/setAccordion.test.ts
@@ -106,12 +106,17 @@ describe('setEvent', () => {
   it('クリーンアップ後はクリックしてもトグルされない', async () => {
     const item = document.querySelector<HTMLElement>('.c--accordion_item')!;
     const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
+    const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
     const cleanup = setEvent(item);
 
     cleanup();
     button.click();
 
-    await Promise.resolve();
+    // リスナーが残っていれば hidden は同期的に外れるため、まず同期状態を検証する
+    expect(panel).toHaveAttribute('hidden', 'until-found');
+
+    // data-opened の付与はマイクロタスク数周後のため、setTimeout で全消化してから検証する
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(item).not.toHaveAttribute('data-opened');
   });
 

--- a/packages/lism-ui/src/components/Accordion/setAccordion.test.ts
+++ b/packages/lism-ui/src/components/Accordion/setAccordion.test.ts
@@ -9,42 +9,28 @@ vi.mock('../../helper/animation', () => ({
 
 import { waitAnimation } from '../../helper/animation';
 
-function createAccordionItem(opts: { opened?: boolean; hiddenValue?: string } = {}): HTMLElement {
-  const wrapper = document.createElement('div');
-  wrapper.innerHTML = `
-    <div class="c--accordion_item"${opts.opened ? ' data-opened' : ''}>
-      <div class="c--accordion_heading">
-        <button class="c--accordion_button" aria-expanded="${opts.opened ? 'true' : 'false'}"></button>
-      </div>
-      <div class="c--accordion_panel"${!opts.opened ? ` hidden="${opts.hiddenValue ?? 'until-found'}"` : ''}>
-        <div class="c--accordion_content"></div>
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div>
+      <div class="c--accordion_item">
+        <div class="c--accordion_heading">
+          <button class="c--accordion_button" aria-expanded="false"></button>
+        </div>
+        <div class="c--accordion_panel" hidden="until-found">
+          <div class="c--accordion_content"></div>
+        </div>
       </div>
     </div>
   `;
-  return wrapper.firstElementChild as HTMLElement;
-}
-
-function createParent(items: HTMLElement[], opts: { allowMultiple?: boolean } = {}): HTMLElement {
-  const wrapper = document.createElement('div');
-  wrapper.innerHTML = `<div${opts.allowMultiple ? ' data-allow-multiple' : ''}></div>`;
-  const parent = wrapper.firstElementChild as HTMLElement;
-  items.forEach((item) => parent.appendChild(item));
-  return parent;
-}
-
-beforeEach(() => {
-  document.body.innerHTML = '';
   vi.mocked(waitAnimation).mockResolvedValue('finished');
 });
 
 describe('setEvent', () => {
   it('クリックで item が開く（aria-expanded, data-opened, hidden 解除）', async () => {
-    const item = createAccordionItem();
-    createParent([item]);
-
-    const cleanup = setEvent(item);
+    const item = document.querySelector<HTMLElement>('.c--accordion_item')!;
     const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
     const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+    const cleanup = setEvent(item);
 
     button.click();
     await vi.waitFor(() => {
@@ -57,13 +43,22 @@ describe('setEvent', () => {
   });
 
   it('開いた状態で再クリックすると閉じる', async () => {
-    const item = createAccordionItem({ opened: true });
-    const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
-    panel.removeAttribute('hidden');
-    createParent([item]);
-
-    const cleanup = setEvent(item);
+    document.body.innerHTML = `
+      <div>
+        <div class="c--accordion_item" data-opened>
+          <div class="c--accordion_heading">
+            <button class="c--accordion_button" aria-expanded="true"></button>
+          </div>
+          <div class="c--accordion_panel">
+            <div class="c--accordion_content"></div>
+          </div>
+        </div>
+      </div>
+    `;
+    const item = document.querySelector<HTMLElement>('.c--accordion_item')!;
     const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
+    const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+    const cleanup = setEvent(item);
 
     button.click();
     await vi.waitFor(() => {
@@ -76,11 +71,9 @@ describe('setEvent', () => {
   });
 
   it('beforematch イベントでもトグルする', async () => {
-    const item = createAccordionItem();
-    createParent([item]);
-
-    const cleanup = setEvent(item);
+    const item = document.querySelector<HTMLElement>('.c--accordion_item')!;
     const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+    const cleanup = setEvent(item);
 
     panel.dispatchEvent(new Event('beforematch'));
     await vi.waitFor(() => {
@@ -91,12 +84,10 @@ describe('setEvent', () => {
   });
 
   it('hidden 属性値を保存・復元する（until-found）', async () => {
-    const item = createAccordionItem({ hiddenValue: 'until-found' });
-    const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
-    createParent([item]);
-
-    const cleanup = setEvent(item);
+    const item = document.querySelector<HTMLElement>('.c--accordion_item')!;
     const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
+    const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+    const cleanup = setEvent(item);
 
     button.click();
     await vi.waitFor(() => {
@@ -113,16 +104,13 @@ describe('setEvent', () => {
   });
 
   it('クリーンアップ後はクリックしてもトグルされない', async () => {
-    const item = createAccordionItem();
-    createParent([item]);
-
-    const cleanup = setEvent(item);
+    const item = document.querySelector<HTMLElement>('.c--accordion_item')!;
     const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
+    const cleanup = setEvent(item);
 
     cleanup();
     button.click();
 
-    // 変化しないことの確認なので waitFor は使わず、Promise を一度だけ消化して確認
     await Promise.resolve();
     expect(item).not.toHaveAttribute('data-opened');
   });
@@ -131,11 +119,10 @@ describe('setEvent', () => {
     vi.mocked(waitAnimation).mockResolvedValueOnce('finished');
     vi.mocked(waitAnimation).mockResolvedValueOnce('canceled');
 
-    const item = createAccordionItem();
-    createParent([item]);
-    const cleanup = setEvent(item);
+    const item = document.querySelector<HTMLElement>('.c--accordion_item')!;
     const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
     const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+    const cleanup = setEvent(item);
 
     button.click();
     await vi.waitFor(() => {
@@ -155,16 +142,31 @@ describe('setEvent', () => {
 
 describe('排他制御', () => {
   it('data-allow-multiple がない時、別 item を開くと前の item が閉じる', async () => {
-    const item1 = createAccordionItem({ opened: true });
-    item1.querySelector('.c--accordion_panel')!.removeAttribute('hidden');
-    const item2 = createAccordionItem();
-    createParent([item1, item2]);
-
+    document.body.innerHTML = `
+      <div>
+        <div class="c--accordion_item" data-opened>
+          <div class="c--accordion_heading">
+            <button class="c--accordion_button" aria-expanded="true"></button>
+          </div>
+          <div class="c--accordion_panel">
+            <div class="c--accordion_content"></div>
+          </div>
+        </div>
+        <div class="c--accordion_item">
+          <div class="c--accordion_heading">
+            <button class="c--accordion_button" aria-expanded="false"></button>
+          </div>
+          <div class="c--accordion_panel" hidden="until-found">
+            <div class="c--accordion_content"></div>
+          </div>
+        </div>
+      </div>
+    `;
+    const [item1, item2] = document.querySelectorAll<HTMLElement>('.c--accordion_item');
     setEvent(item1);
     setEvent(item2);
 
-    const btn2 = item2.querySelector<HTMLElement>('.c--accordion_button')!;
-    btn2.click();
+    item2.querySelector<HTMLElement>('.c--accordion_button')!.click();
     await vi.waitFor(() => {
       expect(item2).toHaveAttribute('data-opened');
       expect(item1).not.toHaveAttribute('data-opened');
@@ -172,16 +174,31 @@ describe('排他制御', () => {
   });
 
   it('data-allow-multiple がある時、両方開いたまま保てる', async () => {
-    const item1 = createAccordionItem({ opened: true });
-    item1.querySelector('.c--accordion_panel')!.removeAttribute('hidden');
-    const item2 = createAccordionItem();
-    createParent([item1, item2], { allowMultiple: true });
-
+    document.body.innerHTML = `
+      <div data-allow-multiple>
+        <div class="c--accordion_item" data-opened>
+          <div class="c--accordion_heading">
+            <button class="c--accordion_button" aria-expanded="true"></button>
+          </div>
+          <div class="c--accordion_panel">
+            <div class="c--accordion_content"></div>
+          </div>
+        </div>
+        <div class="c--accordion_item">
+          <div class="c--accordion_heading">
+            <button class="c--accordion_button" aria-expanded="false"></button>
+          </div>
+          <div class="c--accordion_panel" hidden="until-found">
+            <div class="c--accordion_content"></div>
+          </div>
+        </div>
+      </div>
+    `;
+    const [item1, item2] = document.querySelectorAll<HTMLElement>('.c--accordion_item');
     setEvent(item1);
     setEvent(item2);
 
-    const btn2 = item2.querySelector<HTMLElement>('.c--accordion_button')!;
-    btn2.click();
+    item2.querySelector<HTMLElement>('.c--accordion_button')!.click();
     await vi.waitFor(() => {
       expect(item1).toHaveAttribute('data-opened');
       expect(item2).toHaveAttribute('data-opened');
@@ -191,21 +208,36 @@ describe('排他制御', () => {
 
 describe('setAccordion (default export)', () => {
   it('document 内の全 .c--accordion_item に登録される', async () => {
-    const item1 = createAccordionItem();
-    const item2 = createAccordionItem();
-    const parent = createParent([item1, item2], { allowMultiple: true });
-    document.body.appendChild(parent);
-
+    document.body.innerHTML = `
+      <div data-allow-multiple>
+        <div class="c--accordion_item">
+          <div class="c--accordion_heading">
+            <button class="c--accordion_button" aria-expanded="false"></button>
+          </div>
+          <div class="c--accordion_panel" hidden="until-found">
+            <div class="c--accordion_content"></div>
+          </div>
+        </div>
+        <div class="c--accordion_item">
+          <div class="c--accordion_heading">
+            <button class="c--accordion_button" aria-expanded="false"></button>
+          </div>
+          <div class="c--accordion_panel" hidden="until-found">
+            <div class="c--accordion_content"></div>
+          </div>
+        </div>
+      </div>
+    `;
     setAccordion();
 
-    const btn1 = item1.querySelector<HTMLElement>('.c--accordion_button')!;
-    btn1.click();
+    const [item1, item2] = document.querySelectorAll<HTMLElement>('.c--accordion_item');
+
+    item1.querySelector<HTMLElement>('.c--accordion_button')!.click();
     await vi.waitFor(() => {
       expect(item1).toHaveAttribute('data-opened');
     });
 
-    const btn2 = item2.querySelector<HTMLElement>('.c--accordion_button')!;
-    btn2.click();
+    item2.querySelector<HTMLElement>('.c--accordion_button')!.click();
     await vi.waitFor(() => {
       expect(item2).toHaveAttribute('data-opened');
     });

--- a/packages/lism-ui/src/components/Accordion/setAccordion.test.ts
+++ b/packages/lism-ui/src/components/Accordion/setAccordion.test.ts
@@ -10,36 +10,24 @@ vi.mock('../../helper/animation', () => ({
 import { waitAnimation } from '../../helper/animation';
 
 function createAccordionItem(opts: { opened?: boolean; hiddenValue?: string } = {}): HTMLElement {
-  const item = document.createElement('div');
-  item.className = 'c--accordion_item';
-  if (opts.opened) item.setAttribute('data-opened', '');
-
-  const heading = document.createElement('div');
-  heading.className = 'c--accordion_heading';
-
-  const button = document.createElement('button');
-  button.className = 'c--accordion_button';
-  button.setAttribute('aria-expanded', opts.opened ? 'true' : 'false');
-  heading.appendChild(button);
-
-  const panel = document.createElement('div');
-  panel.className = 'c--accordion_panel';
-  if (!opts.opened) {
-    panel.setAttribute('hidden', opts.hiddenValue ?? 'until-found');
-  }
-
-  const content = document.createElement('div');
-  content.className = 'c--accordion_content';
-  panel.appendChild(content);
-
-  item.appendChild(heading);
-  item.appendChild(panel);
-  return item;
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = `
+    <div class="c--accordion_item"${opts.opened ? ' data-opened' : ''}>
+      <div class="c--accordion_heading">
+        <button class="c--accordion_button" aria-expanded="${opts.opened ? 'true' : 'false'}"></button>
+      </div>
+      <div class="c--accordion_panel"${!opts.opened ? ` hidden="${opts.hiddenValue ?? 'until-found'}"` : ''}>
+        <div class="c--accordion_content"></div>
+      </div>
+    </div>
+  `;
+  return wrapper.firstElementChild as HTMLElement;
 }
 
 function createParent(items: HTMLElement[], opts: { allowMultiple?: boolean } = {}): HTMLElement {
-  const parent = document.createElement('div');
-  if (opts.allowMultiple) parent.setAttribute('data-allow-multiple', '');
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = `<div${opts.allowMultiple ? ' data-allow-multiple' : ''}></div>`;
+  const parent = wrapper.firstElementChild as HTMLElement;
   items.forEach((item) => parent.appendChild(item));
   return parent;
 }

--- a/packages/lism-ui/src/components/Accordion/setAccordion.test.ts
+++ b/packages/lism-ui/src/components/Accordion/setAccordion.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import setAccordion, { setEvent } from './setAccordion';
+
+vi.mock('../../helper/animation', () => ({
+  waitFrame: vi.fn(() => Promise.resolve(0)),
+  waitAnimation: vi.fn(() => Promise.resolve('finished' as const)),
+  maybePauseAnimation: vi.fn(),
+}));
+
+import { waitAnimation } from '../../helper/animation';
+
+function createAccordionItem(opts: { opened?: boolean; hiddenValue?: string } = {}): HTMLElement {
+  const item = document.createElement('div');
+  item.className = 'c--accordion_item';
+  if (opts.opened) item.setAttribute('data-opened', '');
+
+  const heading = document.createElement('div');
+  heading.className = 'c--accordion_heading';
+
+  const button = document.createElement('button');
+  button.className = 'c--accordion_button';
+  button.setAttribute('aria-expanded', opts.opened ? 'true' : 'false');
+  heading.appendChild(button);
+
+  const panel = document.createElement('div');
+  panel.className = 'c--accordion_panel';
+  if (!opts.opened) {
+    panel.setAttribute('hidden', opts.hiddenValue ?? 'until-found');
+  }
+
+  const content = document.createElement('div');
+  content.className = 'c--accordion_content';
+  panel.appendChild(content);
+
+  item.appendChild(heading);
+  item.appendChild(panel);
+  return item;
+}
+
+function createParent(items: HTMLElement[], opts: { allowMultiple?: boolean } = {}): HTMLElement {
+  const parent = document.createElement('div');
+  if (opts.allowMultiple) parent.setAttribute('data-allow-multiple', '');
+  items.forEach((item) => parent.appendChild(item));
+  return parent;
+}
+
+async function flushPromises(times = 3): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.mocked(waitAnimation).mockResolvedValue('finished');
+});
+
+describe('setEvent', () => {
+  it('クリックで item が開く（aria-expanded, data-opened, hidden 解除）', async () => {
+    const item = createAccordionItem();
+    createParent([item]);
+
+    const cleanup = setEvent(item);
+    const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
+    const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+
+    button.click();
+    await flushPromises();
+
+    expect(item).toHaveAttribute('data-opened');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(panel).not.toHaveAttribute('hidden');
+
+    cleanup();
+  });
+
+  it('開いた状態で再クリックすると閉じる', async () => {
+    const item = createAccordionItem({ opened: true });
+    const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+    panel.removeAttribute('hidden');
+    createParent([item]);
+
+    const cleanup = setEvent(item);
+    const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
+
+    button.click();
+    await flushPromises();
+
+    expect(item).not.toHaveAttribute('data-opened');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(panel).toHaveAttribute('hidden');
+
+    cleanup();
+  });
+
+  it('beforematch イベントでもトグルする', async () => {
+    const item = createAccordionItem();
+    createParent([item]);
+
+    const cleanup = setEvent(item);
+    const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+
+    panel.dispatchEvent(new Event('beforematch'));
+    await flushPromises();
+
+    expect(item).toHaveAttribute('data-opened');
+
+    cleanup();
+  });
+
+  it('hidden 属性値を保存・復元する（until-found）', async () => {
+    const item = createAccordionItem({ hiddenValue: 'until-found' });
+    const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+    createParent([item]);
+
+    const cleanup = setEvent(item);
+    const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
+
+    // 開く
+    button.click();
+    await flushPromises();
+    expect(panel).not.toHaveAttribute('hidden');
+
+    // 閉じる
+    button.click();
+    await flushPromises();
+    expect(panel.getAttribute('hidden')).toBe('until-found');
+
+    cleanup();
+  });
+
+  it('クリーンアップ後はクリックしてもトグルされない', async () => {
+    const item = createAccordionItem();
+    createParent([item]);
+
+    const cleanup = setEvent(item);
+    const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
+
+    cleanup();
+    button.click();
+    await flushPromises();
+
+    expect(item).not.toHaveAttribute('data-opened');
+  });
+
+  it('waitAnimation が canceled を返した時、closed 後も --_panel-h が残る', async () => {
+    vi.mocked(waitAnimation).mockResolvedValueOnce('finished'); // open 時は通常
+    vi.mocked(waitAnimation).mockResolvedValueOnce('canceled'); // close 時に canceled
+
+    const item = createAccordionItem();
+    createParent([item]);
+    const cleanup = setEvent(item);
+    const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
+
+    // 開く
+    button.click();
+    await flushPromises();
+
+    // 閉じる（canceled）
+    button.click();
+    await flushPromises();
+
+    // canceled の場合 hidden は付与されない
+    const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+    expect(panel).not.toHaveAttribute('hidden');
+
+    cleanup();
+  });
+});
+
+describe('排他制御', () => {
+  it('data-allow-multiple がない時、別 item を開くと前の item が閉じる', async () => {
+    const item1 = createAccordionItem({ opened: true });
+    item1.querySelector('.c--accordion_panel')!.removeAttribute('hidden');
+    const item2 = createAccordionItem();
+    createParent([item1, item2]);
+
+    setEvent(item1);
+    setEvent(item2);
+
+    const btn2 = item2.querySelector<HTMLElement>('.c--accordion_button')!;
+    btn2.click();
+    await flushPromises();
+
+    expect(item2).toHaveAttribute('data-opened');
+    expect(item1).not.toHaveAttribute('data-opened');
+  });
+
+  it('data-allow-multiple がある時、両方開いたまま保てる', async () => {
+    const item1 = createAccordionItem({ opened: true });
+    item1.querySelector('.c--accordion_panel')!.removeAttribute('hidden');
+    const item2 = createAccordionItem();
+    createParent([item1, item2], { allowMultiple: true });
+
+    setEvent(item1);
+    setEvent(item2);
+
+    const btn2 = item2.querySelector<HTMLElement>('.c--accordion_button')!;
+    btn2.click();
+    await flushPromises();
+
+    expect(item1).toHaveAttribute('data-opened');
+    expect(item2).toHaveAttribute('data-opened');
+  });
+});
+
+describe('setAccordion (default export)', () => {
+  it('document 内の全 .c--accordion_item に登録される', async () => {
+    const item1 = createAccordionItem();
+    const item2 = createAccordionItem();
+    const parent = createParent([item1, item2], { allowMultiple: true });
+    document.body.appendChild(parent);
+
+    setAccordion();
+
+    const btn1 = item1.querySelector<HTMLElement>('.c--accordion_button')!;
+    btn1.click();
+    await flushPromises();
+
+    expect(item1).toHaveAttribute('data-opened');
+
+    const btn2 = item2.querySelector<HTMLElement>('.c--accordion_button')!;
+    btn2.click();
+    await flushPromises();
+
+    expect(item2).toHaveAttribute('data-opened');
+  });
+});

--- a/packages/lism-ui/src/components/Accordion/setAccordion.test.ts
+++ b/packages/lism-ui/src/components/Accordion/setAccordion.test.ts
@@ -32,12 +32,6 @@ function createParent(items: HTMLElement[], opts: { allowMultiple?: boolean } = 
   return parent;
 }
 
-async function flushPromises(times = 3): Promise<void> {
-  for (let i = 0; i < times; i++) {
-    await new Promise((r) => setTimeout(r, 0));
-  }
-}
-
 beforeEach(() => {
   document.body.innerHTML = '';
   vi.mocked(waitAnimation).mockResolvedValue('finished');
@@ -53,11 +47,11 @@ describe('setEvent', () => {
     const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
 
     button.click();
-    await flushPromises();
-
-    expect(item).toHaveAttribute('data-opened');
-    expect(button).toHaveAttribute('aria-expanded', 'true');
-    expect(panel).not.toHaveAttribute('hidden');
+    await vi.waitFor(() => {
+      expect(item).toHaveAttribute('data-opened');
+      expect(button).toHaveAttribute('aria-expanded', 'true');
+      expect(panel).not.toHaveAttribute('hidden');
+    });
 
     cleanup();
   });
@@ -72,11 +66,11 @@ describe('setEvent', () => {
     const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
 
     button.click();
-    await flushPromises();
-
-    expect(item).not.toHaveAttribute('data-opened');
-    expect(button).toHaveAttribute('aria-expanded', 'false');
-    expect(panel).toHaveAttribute('hidden');
+    await vi.waitFor(() => {
+      expect(item).not.toHaveAttribute('data-opened');
+      expect(button).toHaveAttribute('aria-expanded', 'false');
+      expect(panel).toHaveAttribute('hidden');
+    });
 
     cleanup();
   });
@@ -89,9 +83,9 @@ describe('setEvent', () => {
     const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
 
     panel.dispatchEvent(new Event('beforematch'));
-    await flushPromises();
-
-    expect(item).toHaveAttribute('data-opened');
+    await vi.waitFor(() => {
+      expect(item).toHaveAttribute('data-opened');
+    });
 
     cleanup();
   });
@@ -104,15 +98,16 @@ describe('setEvent', () => {
     const cleanup = setEvent(item);
     const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
 
-    // 開く
     button.click();
-    await flushPromises();
-    expect(panel).not.toHaveAttribute('hidden');
+    await vi.waitFor(() => {
+      expect(item).toHaveAttribute('data-opened');
+      expect(panel).not.toHaveAttribute('hidden');
+    });
 
-    // 閉じる
     button.click();
-    await flushPromises();
-    expect(panel.getAttribute('hidden')).toBe('until-found');
+    await vi.waitFor(() => {
+      expect(panel.getAttribute('hidden')).toBe('until-found');
+    });
 
     cleanup();
   });
@@ -126,30 +121,32 @@ describe('setEvent', () => {
 
     cleanup();
     button.click();
-    await flushPromises();
 
+    // 変化しないことの確認なので waitFor は使わず、Promise を一度だけ消化して確認
+    await Promise.resolve();
     expect(item).not.toHaveAttribute('data-opened');
   });
 
-  it('waitAnimation が canceled を返した時、closed 後も --_panel-h が残る', async () => {
-    vi.mocked(waitAnimation).mockResolvedValueOnce('finished'); // open 時は通常
-    vi.mocked(waitAnimation).mockResolvedValueOnce('canceled'); // close 時に canceled
+  it('waitAnimation が canceled を返した時、closed 後も hidden が付与されない', async () => {
+    vi.mocked(waitAnimation).mockResolvedValueOnce('finished');
+    vi.mocked(waitAnimation).mockResolvedValueOnce('canceled');
 
     const item = createAccordionItem();
     createParent([item]);
     const cleanup = setEvent(item);
     const button = item.querySelector<HTMLElement>('.c--accordion_button')!;
-
-    // 開く
-    button.click();
-    await flushPromises();
-
-    // 閉じる（canceled）
-    button.click();
-    await flushPromises();
-
-    // canceled の場合 hidden は付与されない
     const panel = item.querySelector<HTMLElement>('.c--accordion_panel')!;
+
+    button.click();
+    await vi.waitFor(() => {
+      expect(item).toHaveAttribute('data-opened');
+    });
+
+    button.click();
+    await vi.waitFor(() => {
+      expect(item).not.toHaveAttribute('data-opened');
+    });
+
     expect(panel).not.toHaveAttribute('hidden');
 
     cleanup();
@@ -168,10 +165,10 @@ describe('排他制御', () => {
 
     const btn2 = item2.querySelector<HTMLElement>('.c--accordion_button')!;
     btn2.click();
-    await flushPromises();
-
-    expect(item2).toHaveAttribute('data-opened');
-    expect(item1).not.toHaveAttribute('data-opened');
+    await vi.waitFor(() => {
+      expect(item2).toHaveAttribute('data-opened');
+      expect(item1).not.toHaveAttribute('data-opened');
+    });
   });
 
   it('data-allow-multiple がある時、両方開いたまま保てる', async () => {
@@ -185,10 +182,10 @@ describe('排他制御', () => {
 
     const btn2 = item2.querySelector<HTMLElement>('.c--accordion_button')!;
     btn2.click();
-    await flushPromises();
-
-    expect(item1).toHaveAttribute('data-opened');
-    expect(item2).toHaveAttribute('data-opened');
+    await vi.waitFor(() => {
+      expect(item1).toHaveAttribute('data-opened');
+      expect(item2).toHaveAttribute('data-opened');
+    });
   });
 });
 
@@ -203,14 +200,14 @@ describe('setAccordion (default export)', () => {
 
     const btn1 = item1.querySelector<HTMLElement>('.c--accordion_button')!;
     btn1.click();
-    await flushPromises();
-
-    expect(item1).toHaveAttribute('data-opened');
+    await vi.waitFor(() => {
+      expect(item1).toHaveAttribute('data-opened');
+    });
 
     const btn2 = item2.querySelector<HTMLElement>('.c--accordion_button')!;
     btn2.click();
-    await flushPromises();
-
-    expect(item2).toHaveAttribute('data-opened');
+    await vi.waitFor(() => {
+      expect(item2).toHaveAttribute('data-opened');
+    });
   });
 });

--- a/packages/lism-ui/src/components/Modal/setModal.test.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.test.ts
@@ -104,6 +104,22 @@ describe('setEvent (dialog 要素)', () => {
 
     expect(showModalSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('連打防止: 同一フレーム内（data-is-open 付与前）の連続 click でも showModal は 1 回のみ', async () => {
+    const modal = document.querySelector<HTMLDialogElement>('#m1')!;
+    const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;
+    const showModalSpy = vi.spyOn(modal, 'showModal');
+    setEvent(modal);
+
+    trigger.click();
+    trigger.click();
+
+    expect(showModalSpy).toHaveBeenCalledTimes(1);
+
+    await vi.waitFor(() => {
+      expect(modal.dataset.isOpen).toBe('1');
+    });
+  });
 });
 
 describe('setEvent (非 dialog 要素)', () => {

--- a/packages/lism-ui/src/components/Modal/setModal.test.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.test.ts
@@ -14,33 +14,29 @@ async function flushPromises(times = 3): Promise<void> {
 }
 
 function createDialogModal(id: string): HTMLDialogElement {
-  const modal = document.createElement('dialog');
-  modal.id = id;
-  modal.className = 'c--modal';
-
-  const closeBtn = document.createElement('button');
-  closeBtn.setAttribute('data-modal-close', id);
-  modal.appendChild(closeBtn);
-
-  return modal;
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = `
+    <dialog id="${id}" class="c--modal">
+      <button data-modal-close="${id}"></button>
+    </dialog>
+  `;
+  return wrapper.firstElementChild as HTMLDialogElement;
 }
 
 function createDivModal(id: string): HTMLElement {
-  const modal = document.createElement('div');
-  modal.id = id;
-  modal.className = 'c--modal';
-
-  const closeBtn = document.createElement('button');
-  closeBtn.setAttribute('data-modal-close', id);
-  modal.appendChild(closeBtn);
-
-  return modal;
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = `
+    <div id="${id}" class="c--modal">
+      <button data-modal-close="${id}"></button>
+    </div>
+  `;
+  return wrapper.firstElementChild as HTMLElement;
 }
 
 function createOpenTrigger(targetId: string): HTMLElement {
-  const btn = document.createElement('button');
-  btn.setAttribute('data-modal-open', targetId);
-  return btn;
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = `<button data-modal-open="${targetId}"></button>`;
+  return wrapper.firstElementChild as HTMLElement;
 }
 
 beforeEach(() => {

--- a/packages/lism-ui/src/components/Modal/setModal.test.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.test.ts
@@ -7,44 +7,20 @@ vi.mock('../../helper/animation', () => ({
 
 import { waitAnimation } from '../../helper/animation';
 
-function createDialogModal(id: string): HTMLDialogElement {
-  const wrapper = document.createElement('div');
-  wrapper.innerHTML = `
-    <dialog id="${id}" class="c--modal">
-      <button data-modal-close="${id}"></button>
-    </dialog>
-  `;
-  return wrapper.firstElementChild as HTMLDialogElement;
-}
-
-function createDivModal(id: string): HTMLElement {
-  const wrapper = document.createElement('div');
-  wrapper.innerHTML = `
-    <div id="${id}" class="c--modal">
-      <button data-modal-close="${id}"></button>
-    </div>
-  `;
-  return wrapper.firstElementChild as HTMLElement;
-}
-
-function createOpenTrigger(targetId: string): HTMLElement {
-  const wrapper = document.createElement('div');
-  wrapper.innerHTML = `<button data-modal-open="${targetId}"></button>`;
-  return wrapper.firstElementChild as HTMLElement;
-}
-
 beforeEach(() => {
-  document.body.innerHTML = '';
+  document.body.innerHTML = `
+    <dialog id="m1" class="c--modal">
+      <button data-modal-close="m1"></button>
+    </dialog>
+    <button data-modal-open="m1"></button>
+  `;
   vi.mocked(waitAnimation).mockResolvedValue('finished');
 });
 
 describe('setEvent (dialog 要素)', () => {
   it('open トリガーで showModal が呼ばれ open 属性が付き、次フレームで data-is-open が付く', async () => {
-    const modal = createDialogModal('m1');
-    const trigger = createOpenTrigger('m1');
-    document.body.appendChild(modal);
-    document.body.appendChild(trigger);
-
+    const modal = document.querySelector<HTMLDialogElement>('#m1')!;
+    const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;
     const showModalSpy = vi.spyOn(modal, 'showModal');
     setEvent(modal);
 
@@ -59,11 +35,8 @@ describe('setEvent (dialog 要素)', () => {
   });
 
   it('close トリガーで data-is-open が消え、waitAnimation 後に閉じる', async () => {
-    const modal = createDialogModal('m1');
-    const trigger = createOpenTrigger('m1');
-    document.body.appendChild(modal);
-    document.body.appendChild(trigger);
-
+    const modal = document.querySelector<HTMLDialogElement>('#m1')!;
+    const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;
     setEvent(modal);
 
     trigger.click();
@@ -71,8 +44,7 @@ describe('setEvent (dialog 要素)', () => {
       expect(modal.dataset.isOpen).toBe('1');
     });
 
-    const closeBtn = modal.querySelector<HTMLElement>('[data-modal-close="m1"]')!;
-    closeBtn.click();
+    document.querySelector<HTMLElement>('[data-modal-close="m1"]')!.click();
     await vi.waitFor(() => {
       expect(modal).not.toHaveAttribute('data-is-open');
       expect(modal).not.toHaveAttribute('open');
@@ -81,11 +53,8 @@ describe('setEvent (dialog 要素)', () => {
   });
 
   it('余白クリック（e.target === modal）で閉じる', async () => {
-    const modal = createDialogModal('m1');
-    const trigger = createOpenTrigger('m1');
-    document.body.appendChild(modal);
-    document.body.appendChild(trigger);
-
+    const modal = document.querySelector<HTMLDialogElement>('#m1')!;
+    const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;
     setEvent(modal);
 
     trigger.click();
@@ -101,11 +70,8 @@ describe('setEvent (dialog 要素)', () => {
   });
 
   it('cancel イベントで preventDefault され、closeDialog が走る', async () => {
-    const modal = createDialogModal('m1');
-    const trigger = createOpenTrigger('m1');
-    document.body.appendChild(modal);
-    document.body.appendChild(trigger);
-
+    const modal = document.querySelector<HTMLDialogElement>('#m1')!;
+    const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;
     setEvent(modal);
 
     trigger.click();
@@ -123,11 +89,8 @@ describe('setEvent (dialog 要素)', () => {
   });
 
   it('連打防止: 既に open 中に再度 open トリガーを click しても showModal は 1 回のみ', async () => {
-    const modal = createDialogModal('m1');
-    const trigger = createOpenTrigger('m1');
-    document.body.appendChild(modal);
-    document.body.appendChild(trigger);
-
+    const modal = document.querySelector<HTMLDialogElement>('#m1')!;
+    const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;
     const showModalSpy = vi.spyOn(modal, 'showModal');
     setEvent(modal);
 
@@ -145,11 +108,14 @@ describe('setEvent (dialog 要素)', () => {
 
 describe('setEvent (非 dialog 要素)', () => {
   it('open/close が open 属性ベースで動作する', async () => {
-    const modal = createDivModal('m2');
-    const trigger = createOpenTrigger('m2');
-    document.body.appendChild(modal);
-    document.body.appendChild(trigger);
-
+    document.body.innerHTML = `
+      <div id="m2" class="c--modal">
+        <button data-modal-close="m2"></button>
+      </div>
+      <button data-modal-open="m2"></button>
+    `;
+    const modal = document.querySelector<HTMLElement>('#m2')!;
+    const trigger = document.querySelector<HTMLElement>('[data-modal-open="m2"]')!;
     setEvent(modal);
 
     trigger.click();
@@ -157,8 +123,7 @@ describe('setEvent (非 dialog 要素)', () => {
       expect(modal).toHaveAttribute('open');
     });
 
-    const closeBtn = modal.querySelector<HTMLElement>('[data-modal-close="m2"]')!;
-    closeBtn.click();
+    document.querySelector<HTMLElement>('[data-modal-close="m2"]')!.click();
     await vi.waitFor(() => {
       expect(modal).not.toHaveAttribute('open');
     });
@@ -167,9 +132,8 @@ describe('setEvent (非 dialog 要素)', () => {
 
 describe('setEvent (早期 return ケース)', () => {
   it('id が無い modal は何もしない', () => {
-    const modal = document.createElement('dialog');
-    modal.className = 'c--modal';
-    document.body.appendChild(modal);
+    document.body.innerHTML = `<dialog class="c--modal"></dialog>`;
+    const modal = document.querySelector<HTMLDialogElement>('dialog')!;
 
     setEvent(modal);
     expect(modal).not.toHaveAttribute('open');
@@ -178,25 +142,26 @@ describe('setEvent (早期 return ケース)', () => {
 
 describe('setModal (default export)', () => {
   it('document 内の .c--modal 全件に登録される', async () => {
-    const m1 = createDialogModal('m1');
-    const m2 = createDialogModal('m2');
-    const t1 = createOpenTrigger('m1');
-    const t2 = createOpenTrigger('m2');
-    document.body.appendChild(m1);
-    document.body.appendChild(m2);
-    document.body.appendChild(t1);
-    document.body.appendChild(t2);
-
+    document.body.innerHTML = `
+      <dialog id="m1" class="c--modal">
+        <button data-modal-close="m1"></button>
+      </dialog>
+      <dialog id="m2" class="c--modal">
+        <button data-modal-close="m2"></button>
+      </dialog>
+      <button data-modal-open="m1"></button>
+      <button data-modal-open="m2"></button>
+    `;
     setModal();
 
-    t1.click();
+    document.querySelector<HTMLElement>('[data-modal-open="m1"]')!.click();
     await vi.waitFor(() => {
-      expect(m1).toHaveAttribute('open');
+      expect(document.querySelector('#m1')).toHaveAttribute('open');
     });
 
-    t2.click();
+    document.querySelector<HTMLElement>('[data-modal-open="m2"]')!.click();
     await vi.waitFor(() => {
-      expect(m2).toHaveAttribute('open');
+      expect(document.querySelector('#m2')).toHaveAttribute('open');
     });
   });
 });

--- a/packages/lism-ui/src/components/Modal/setModal.test.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.test.ts
@@ -119,8 +119,11 @@ describe('setEvent (非 dialog 要素)', () => {
     setEvent(modal);
 
     trigger.click();
+    // open 属性は同期で付くが、closeDialog は data-is-open を見て早期 return するため、
+    // rAF での data-is-open 付与まで待ってから閉じる
     await vi.waitFor(() => {
       expect(modal).toHaveAttribute('open');
+      expect(modal.dataset.isOpen).toBe('1');
     });
 
     document.querySelector<HTMLElement>('[data-modal-close="m2"]')!.click();

--- a/packages/lism-ui/src/components/Modal/setModal.test.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.test.ts
@@ -7,12 +7,6 @@ vi.mock('../../helper/animation', () => ({
 
 import { waitAnimation } from '../../helper/animation';
 
-async function flushPromises(times = 3): Promise<void> {
-  for (let i = 0; i < times; i++) {
-    await new Promise((r) => setTimeout(r, 0));
-  }
-}
-
 function createDialogModal(id: string): HTMLDialogElement {
   const wrapper = document.createElement('div');
   wrapper.innerHTML = `
@@ -55,12 +49,13 @@ describe('setEvent (dialog 要素)', () => {
     setEvent(modal);
 
     trigger.click();
-    await flushPromises();
+    await vi.waitFor(() => {
+      expect(modal).toHaveAttribute('open');
+      expect(modal.dataset.isOpen).toBe('1');
+      expect(trigger.dataset.targetOpened).toBe('1');
+    });
 
     expect(showModalSpy).toHaveBeenCalledTimes(1);
-    expect(modal).toHaveAttribute('open');
-    expect(modal.dataset.isOpen).toBe('1');
-    expect(trigger.dataset.targetOpened).toBe('1');
   });
 
   it('close トリガーで data-is-open が消え、waitAnimation 後に閉じる', async () => {
@@ -71,18 +66,18 @@ describe('setEvent (dialog 要素)', () => {
 
     setEvent(modal);
 
-    // 開く
     trigger.click();
-    await flushPromises();
+    await vi.waitFor(() => {
+      expect(modal.dataset.isOpen).toBe('1');
+    });
 
-    // 閉じる
     const closeBtn = modal.querySelector<HTMLElement>('[data-modal-close="m1"]')!;
     closeBtn.click();
-    await flushPromises();
-
-    expect(modal).not.toHaveAttribute('data-is-open');
-    expect(modal).not.toHaveAttribute('open');
-    expect(trigger.dataset.targetOpened).toBeUndefined();
+    await vi.waitFor(() => {
+      expect(modal).not.toHaveAttribute('data-is-open');
+      expect(modal).not.toHaveAttribute('open');
+      expect(trigger.dataset.targetOpened).toBeUndefined();
+    });
   });
 
   it('余白クリック（e.target === modal）で閉じる', async () => {
@@ -94,13 +89,15 @@ describe('setEvent (dialog 要素)', () => {
     setEvent(modal);
 
     trigger.click();
-    await flushPromises();
+    await vi.waitFor(() => {
+      expect(modal.dataset.isOpen).toBe('1');
+    });
 
     modal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    await flushPromises();
-
-    expect(modal).not.toHaveAttribute('data-is-open');
-    expect(modal).not.toHaveAttribute('open');
+    await vi.waitFor(() => {
+      expect(modal).not.toHaveAttribute('data-is-open');
+      expect(modal).not.toHaveAttribute('open');
+    });
   });
 
   it('cancel イベントで preventDefault され、closeDialog が走る', async () => {
@@ -112,14 +109,17 @@ describe('setEvent (dialog 要素)', () => {
     setEvent(modal);
 
     trigger.click();
-    await flushPromises();
+    await vi.waitFor(() => {
+      expect(modal.dataset.isOpen).toBe('1');
+    });
 
     const cancelEvent = new Event('cancel', { cancelable: true });
     modal.dispatchEvent(cancelEvent);
-    await flushPromises();
 
     expect(cancelEvent.defaultPrevented).toBe(true);
-    expect(modal).not.toHaveAttribute('data-is-open');
+    await vi.waitFor(() => {
+      expect(modal).not.toHaveAttribute('data-is-open');
+    });
   });
 
   it('連打防止: 既に open 中に再度 open トリガーを click しても showModal は 1 回のみ', async () => {
@@ -132,9 +132,12 @@ describe('setEvent (dialog 要素)', () => {
     setEvent(modal);
 
     trigger.click();
-    await flushPromises();
+    await vi.waitFor(() => {
+      expect(modal.dataset.isOpen).toBe('1');
+    });
+
     trigger.click();
-    await flushPromises();
+    await Promise.resolve();
 
     expect(showModalSpy).toHaveBeenCalledTimes(1);
   });
@@ -150,13 +153,15 @@ describe('setEvent (非 dialog 要素)', () => {
     setEvent(modal);
 
     trigger.click();
-    await flushPromises();
-    expect(modal).toHaveAttribute('open');
+    await vi.waitFor(() => {
+      expect(modal).toHaveAttribute('open');
+    });
 
     const closeBtn = modal.querySelector<HTMLElement>('[data-modal-close="m2"]')!;
     closeBtn.click();
-    await flushPromises();
-    expect(modal).not.toHaveAttribute('open');
+    await vi.waitFor(() => {
+      expect(modal).not.toHaveAttribute('open');
+    });
   });
 });
 
@@ -167,7 +172,6 @@ describe('setEvent (早期 return ケース)', () => {
     document.body.appendChild(modal);
 
     setEvent(modal);
-    // open 属性が付かないことを確認（クリックイベントが登録されていない）
     expect(modal).not.toHaveAttribute('open');
   });
 });
@@ -186,11 +190,13 @@ describe('setModal (default export)', () => {
     setModal();
 
     t1.click();
-    await flushPromises();
-    expect(m1).toHaveAttribute('open');
+    await vi.waitFor(() => {
+      expect(m1).toHaveAttribute('open');
+    });
 
     t2.click();
-    await flushPromises();
-    expect(m2).toHaveAttribute('open');
+    await vi.waitFor(() => {
+      expect(m2).toHaveAttribute('open');
+    });
   });
 });

--- a/packages/lism-ui/src/components/Modal/setModal.test.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import setModal, { setEvent } from './setModal';
+
+vi.mock('../../helper/animation', () => ({
+  waitAnimation: vi.fn(() => Promise.resolve('finished' as const)),
+}));
+
+import { waitAnimation } from '../../helper/animation';
+
+async function flushPromises(times = 3): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+function createDialogModal(id: string): HTMLDialogElement {
+  const modal = document.createElement('dialog');
+  modal.id = id;
+  modal.className = 'c--modal';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.setAttribute('data-modal-close', id);
+  modal.appendChild(closeBtn);
+
+  return modal;
+}
+
+function createDivModal(id: string): HTMLElement {
+  const modal = document.createElement('div');
+  modal.id = id;
+  modal.className = 'c--modal';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.setAttribute('data-modal-close', id);
+  modal.appendChild(closeBtn);
+
+  return modal;
+}
+
+function createOpenTrigger(targetId: string): HTMLElement {
+  const btn = document.createElement('button');
+  btn.setAttribute('data-modal-open', targetId);
+  return btn;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.mocked(waitAnimation).mockResolvedValue('finished');
+});
+
+describe('setEvent (dialog 要素)', () => {
+  it('open トリガーで showModal が呼ばれ open 属性が付き、次フレームで data-is-open が付く', async () => {
+    const modal = createDialogModal('m1');
+    const trigger = createOpenTrigger('m1');
+    document.body.appendChild(modal);
+    document.body.appendChild(trigger);
+
+    const showModalSpy = vi.spyOn(modal, 'showModal');
+    setEvent(modal);
+
+    trigger.click();
+    await flushPromises();
+
+    expect(showModalSpy).toHaveBeenCalledTimes(1);
+    expect(modal).toHaveAttribute('open');
+    expect(modal.dataset.isOpen).toBe('1');
+    expect(trigger.dataset.targetOpened).toBe('1');
+  });
+
+  it('close トリガーで data-is-open が消え、waitAnimation 後に閉じる', async () => {
+    const modal = createDialogModal('m1');
+    const trigger = createOpenTrigger('m1');
+    document.body.appendChild(modal);
+    document.body.appendChild(trigger);
+
+    setEvent(modal);
+
+    // 開く
+    trigger.click();
+    await flushPromises();
+
+    // 閉じる
+    const closeBtn = modal.querySelector<HTMLElement>('[data-modal-close="m1"]')!;
+    closeBtn.click();
+    await flushPromises();
+
+    expect(modal).not.toHaveAttribute('data-is-open');
+    expect(modal).not.toHaveAttribute('open');
+    expect(trigger.dataset.targetOpened).toBeUndefined();
+  });
+
+  it('余白クリック（e.target === modal）で閉じる', async () => {
+    const modal = createDialogModal('m1');
+    const trigger = createOpenTrigger('m1');
+    document.body.appendChild(modal);
+    document.body.appendChild(trigger);
+
+    setEvent(modal);
+
+    trigger.click();
+    await flushPromises();
+
+    modal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flushPromises();
+
+    expect(modal).not.toHaveAttribute('data-is-open');
+    expect(modal).not.toHaveAttribute('open');
+  });
+
+  it('cancel イベントで preventDefault され、closeDialog が走る', async () => {
+    const modal = createDialogModal('m1');
+    const trigger = createOpenTrigger('m1');
+    document.body.appendChild(modal);
+    document.body.appendChild(trigger);
+
+    setEvent(modal);
+
+    trigger.click();
+    await flushPromises();
+
+    const cancelEvent = new Event('cancel', { cancelable: true });
+    modal.dispatchEvent(cancelEvent);
+    await flushPromises();
+
+    expect(cancelEvent.defaultPrevented).toBe(true);
+    expect(modal).not.toHaveAttribute('data-is-open');
+  });
+
+  it('連打防止: 既に open 中に再度 open トリガーを click しても showModal は 1 回のみ', async () => {
+    const modal = createDialogModal('m1');
+    const trigger = createOpenTrigger('m1');
+    document.body.appendChild(modal);
+    document.body.appendChild(trigger);
+
+    const showModalSpy = vi.spyOn(modal, 'showModal');
+    setEvent(modal);
+
+    trigger.click();
+    await flushPromises();
+    trigger.click();
+    await flushPromises();
+
+    expect(showModalSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('setEvent (非 dialog 要素)', () => {
+  it('open/close が open 属性ベースで動作する', async () => {
+    const modal = createDivModal('m2');
+    const trigger = createOpenTrigger('m2');
+    document.body.appendChild(modal);
+    document.body.appendChild(trigger);
+
+    setEvent(modal);
+
+    trigger.click();
+    await flushPromises();
+    expect(modal).toHaveAttribute('open');
+
+    const closeBtn = modal.querySelector<HTMLElement>('[data-modal-close="m2"]')!;
+    closeBtn.click();
+    await flushPromises();
+    expect(modal).not.toHaveAttribute('open');
+  });
+});
+
+describe('setEvent (早期 return ケース)', () => {
+  it('id が無い modal は何もしない', () => {
+    const modal = document.createElement('dialog');
+    modal.className = 'c--modal';
+    document.body.appendChild(modal);
+
+    setEvent(modal);
+    // open 属性が付かないことを確認（クリックイベントが登録されていない）
+    expect(modal).not.toHaveAttribute('open');
+  });
+});
+
+describe('setModal (default export)', () => {
+  it('document 内の .c--modal 全件に登録される', async () => {
+    const m1 = createDialogModal('m1');
+    const m2 = createDialogModal('m2');
+    const t1 = createOpenTrigger('m1');
+    const t2 = createOpenTrigger('m2');
+    document.body.appendChild(m1);
+    document.body.appendChild(m2);
+    document.body.appendChild(t1);
+    document.body.appendChild(t2);
+
+    setModal();
+
+    t1.click();
+    await flushPromises();
+    expect(m1).toHaveAttribute('open');
+
+    t2.click();
+    await flushPromises();
+    expect(m2).toHaveAttribute('open');
+  });
+});

--- a/packages/lism-ui/src/components/Modal/setModal.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.ts
@@ -21,8 +21,10 @@ export function setEvent(modal: HTMLElement): void {
    *   Point: showModal() してから、CSSアニメーション用の data-is-open属性を付与する
    */
   const openDialog = () => {
-    // すでに open & data-is-open が付いていれば何もしない（連打防止）
-    if (modal.hasAttribute('open') && modal.hasAttribute('data-is-open')) return;
+    // すでに open が付いていれば何もしない（連打防止）。
+    // data-is-open は rAF で1フレーム遅れて付与されるため、条件に含めると
+    // その間の連打で showModal() が二重に呼ばれてしまう（dialog では InvalidStateError になる）
+    if (modal.hasAttribute('open')) return;
 
     // dialog 要素なら showModal()、それ以外は open 属性を付与
     if (isDialog) {

--- a/packages/lism-ui/src/components/Tabs/setTabs.test.ts
+++ b/packages/lism-ui/src/components/Tabs/setTabs.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import setTabs from './setTabs';
 
-function createTabsDOM(): { tabs: HTMLElement; tab1: HTMLElement; tab2: HTMLElement; panel1: HTMLElement; panel2: HTMLElement } {
-  const wrapper = document.createElement('div');
-  wrapper.innerHTML = `
+beforeEach(() => {
+  document.body.innerHTML = `
     <div class="c--tabs">
       <div class="c--tabs_list">
         <div class="c--tabs_item">
@@ -17,15 +16,6 @@ function createTabsDOM(): { tabs: HTMLElement; tab1: HTMLElement; tab2: HTMLElem
       <div id="panel2" aria-hidden="true"></div>
     </div>
   `;
-  const tabs = wrapper.firstElementChild as HTMLElement;
-  const [tab1, tab2] = tabs.querySelectorAll<HTMLElement>('[role="tab"]');
-  const panel1 = tabs.querySelector<HTMLElement>('#panel1')!;
-  const panel2 = tabs.querySelector<HTMLElement>('#panel2')!;
-  return { tabs, tab1, tab2, panel1, panel2 };
-}
-
-beforeEach(() => {
-  document.body.innerHTML = '';
   history.replaceState({}, '', '/');
 });
 
@@ -36,9 +26,10 @@ afterEach(() => {
 
 describe('setTabs', () => {
   it('非選択 tab を click すると aria-selected と aria-hidden が切り替わる', () => {
-    const { tabs, tab1, tab2, panel1, panel2 } = createTabsDOM();
-    document.body.appendChild(tabs);
-
+    const tabs = document.querySelector<HTMLElement>('.c--tabs')!;
+    const [tab1, tab2] = tabs.querySelectorAll<HTMLElement>('[role="tab"]');
+    const panel1 = document.querySelector<HTMLElement>('#panel1')!;
+    const panel2 = document.querySelector<HTMLElement>('#panel2')!;
     setTabs(tabs);
 
     tab2.click();
@@ -50,9 +41,9 @@ describe('setTabs', () => {
   });
 
   it('既選択 tab を click しても状態変化なし', () => {
-    const { tabs, tab1, panel1 } = createTabsDOM();
-    document.body.appendChild(tabs);
-
+    const tabs = document.querySelector<HTMLElement>('.c--tabs')!;
+    const [tab1] = tabs.querySelectorAll<HTMLElement>('[role="tab"]');
+    const panel1 = document.querySelector<HTMLElement>('#panel1')!;
     setTabs(tabs);
 
     tab1.click();
@@ -62,14 +53,13 @@ describe('setTabs', () => {
   });
 
   it('aria-controls が無い tab を click しても例外で落ちない', () => {
-    const { tabs } = createTabsDOM();
-    document.body.appendChild(tabs);
+    const tabs = document.querySelector<HTMLElement>('.c--tabs')!;
+    setTabs(tabs);
 
     const extraItem = document.createElement('div');
     const extraBtn = document.createElement('button');
     extraBtn.setAttribute('role', 'tab');
     extraBtn.setAttribute('aria-selected', 'false');
-    // aria-controls は意図的に付与しない
     extraItem.appendChild(extraBtn);
     tabs.querySelector('.c--tabs_list')!.appendChild(extraItem);
 
@@ -81,8 +71,10 @@ describe('setTabs', () => {
   it('ディープリンク: ?lism-tab=panel2 で panel2 が選択状態になる', () => {
     vi.useFakeTimers();
 
-    const { tabs, tab1, tab2, panel1, panel2 } = createTabsDOM();
-    document.body.appendChild(tabs);
+    const tabs = document.querySelector<HTMLElement>('.c--tabs')!;
+    const [tab1, tab2] = tabs.querySelectorAll<HTMLElement>('[role="tab"]');
+    const panel1 = document.querySelector<HTMLElement>('#panel1')!;
+    const panel2 = document.querySelector<HTMLElement>('#panel2')!;
 
     history.replaceState({}, '', '/?lism-tab=panel2');
     setTabs(tabs);
@@ -98,17 +90,16 @@ describe('setTabs', () => {
   });
 
   it('?lism-tab= が無い URL では dataset.hasTabLink が触られない', () => {
-    const { tabs } = createTabsDOM();
-    document.body.appendChild(tabs);
-
+    const tabs = document.querySelector<HTMLElement>('.c--tabs')!;
     setTabs(tabs);
 
     expect(tabs.dataset.hasTabLink).toBeUndefined();
   });
 
   it('存在しない id を ?lism-tab= に指定しても何も起きない', () => {
-    const { tabs, tab1, panel1 } = createTabsDOM();
-    document.body.appendChild(tabs);
+    const tabs = document.querySelector<HTMLElement>('.c--tabs')!;
+    const [tab1] = tabs.querySelectorAll<HTMLElement>('[role="tab"]');
+    const panel1 = document.querySelector<HTMLElement>('#panel1')!;
 
     history.replaceState({}, '', '/?lism-tab=no-such-panel');
     setTabs(tabs);

--- a/packages/lism-ui/src/components/Tabs/setTabs.test.ts
+++ b/packages/lism-ui/src/components/Tabs/setTabs.test.ts
@@ -2,42 +2,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import setTabs from './setTabs';
 
 function createTabsDOM(): { tabs: HTMLElement; tab1: HTMLElement; tab2: HTMLElement; panel1: HTMLElement; panel2: HTMLElement } {
-  const tabs = document.createElement('div');
-  tabs.className = 'c--tabs';
-
-  const list = document.createElement('div');
-  list.className = 'c--tabs_list';
-  tabs.appendChild(list);
-
-  const item1 = document.createElement('div');
-  item1.className = 'c--tabs_item';
-  const tab1 = document.createElement('button');
-  tab1.setAttribute('role', 'tab');
-  tab1.setAttribute('aria-selected', 'true');
-  tab1.setAttribute('aria-controls', 'panel1');
-  item1.appendChild(tab1);
-  list.appendChild(item1);
-
-  const item2 = document.createElement('div');
-  item2.className = 'c--tabs_item';
-  const tab2 = document.createElement('button');
-  tab2.setAttribute('role', 'tab');
-  tab2.setAttribute('aria-selected', 'false');
-  tab2.setAttribute('aria-controls', 'panel2');
-  item2.appendChild(tab2);
-  list.appendChild(item2);
-
-  const panel1 = document.createElement('div');
-  panel1.id = 'panel1';
-  panel1.setAttribute('aria-hidden', 'false');
-
-  const panel2 = document.createElement('div');
-  panel2.id = 'panel2';
-  panel2.setAttribute('aria-hidden', 'true');
-
-  tabs.appendChild(panel1);
-  tabs.appendChild(panel2);
-
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = `
+    <div class="c--tabs">
+      <div class="c--tabs_list">
+        <div class="c--tabs_item">
+          <button role="tab" aria-selected="true" aria-controls="panel1"></button>
+        </div>
+        <div class="c--tabs_item">
+          <button role="tab" aria-selected="false" aria-controls="panel2"></button>
+        </div>
+      </div>
+      <div id="panel1" aria-hidden="false"></div>
+      <div id="panel2" aria-hidden="true"></div>
+    </div>
+  `;
+  const tabs = wrapper.firstElementChild as HTMLElement;
+  const [tab1, tab2] = tabs.querySelectorAll<HTMLElement>('[role="tab"]');
+  const panel1 = tabs.querySelector<HTMLElement>('#panel1')!;
+  const panel2 = tabs.querySelector<HTMLElement>('#panel2')!;
   return { tabs, tab1, tab2, panel1, panel2 };
 }
 

--- a/packages/lism-ui/src/components/Tabs/setTabs.test.ts
+++ b/packages/lism-ui/src/components/Tabs/setTabs.test.ts
@@ -54,7 +54,6 @@ describe('setTabs', () => {
 
   it('aria-controls が無い tab を click しても例外で落ちない', () => {
     const tabs = document.querySelector<HTMLElement>('.c--tabs')!;
-    setTabs(tabs);
 
     const extraItem = document.createElement('div');
     const extraBtn = document.createElement('button');

--- a/packages/lism-ui/src/components/Tabs/setTabs.test.ts
+++ b/packages/lism-ui/src/components/Tabs/setTabs.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import setTabs from './setTabs';
+
+function createTabsDOM(): { tabs: HTMLElement; tab1: HTMLElement; tab2: HTMLElement; panel1: HTMLElement; panel2: HTMLElement } {
+  const tabs = document.createElement('div');
+  tabs.className = 'c--tabs';
+
+  const list = document.createElement('div');
+  list.className = 'c--tabs_list';
+  tabs.appendChild(list);
+
+  const item1 = document.createElement('div');
+  item1.className = 'c--tabs_item';
+  const tab1 = document.createElement('button');
+  tab1.setAttribute('role', 'tab');
+  tab1.setAttribute('aria-selected', 'true');
+  tab1.setAttribute('aria-controls', 'panel1');
+  item1.appendChild(tab1);
+  list.appendChild(item1);
+
+  const item2 = document.createElement('div');
+  item2.className = 'c--tabs_item';
+  const tab2 = document.createElement('button');
+  tab2.setAttribute('role', 'tab');
+  tab2.setAttribute('aria-selected', 'false');
+  tab2.setAttribute('aria-controls', 'panel2');
+  item2.appendChild(tab2);
+  list.appendChild(item2);
+
+  const panel1 = document.createElement('div');
+  panel1.id = 'panel1';
+  panel1.setAttribute('aria-hidden', 'false');
+
+  const panel2 = document.createElement('div');
+  panel2.id = 'panel2';
+  panel2.setAttribute('aria-hidden', 'true');
+
+  tabs.appendChild(panel1);
+  tabs.appendChild(panel2);
+
+  return { tabs, tab1, tab2, panel1, panel2 };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  history.replaceState({}, '', '/');
+});
+
+afterEach(() => {
+  history.replaceState({}, '', '/');
+  vi.useRealTimers();
+});
+
+describe('setTabs', () => {
+  it('非選択 tab を click すると aria-selected と aria-hidden が切り替わる', () => {
+    const { tabs, tab1, tab2, panel1, panel2 } = createTabsDOM();
+    document.body.appendChild(tabs);
+
+    setTabs(tabs);
+
+    tab2.click();
+
+    expect(tab2).toHaveAttribute('aria-selected', 'true');
+    expect(tab1).toHaveAttribute('aria-selected', 'false');
+    expect(panel2).toHaveAttribute('aria-hidden', 'false');
+    expect(panel1).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('既選択 tab を click しても状態変化なし', () => {
+    const { tabs, tab1, panel1 } = createTabsDOM();
+    document.body.appendChild(tabs);
+
+    setTabs(tabs);
+
+    tab1.click();
+
+    expect(tab1).toHaveAttribute('aria-selected', 'true');
+    expect(panel1).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('aria-controls が無い tab を click しても例外で落ちない', () => {
+    const { tabs } = createTabsDOM();
+    document.body.appendChild(tabs);
+
+    const extraItem = document.createElement('div');
+    const extraBtn = document.createElement('button');
+    extraBtn.setAttribute('role', 'tab');
+    extraBtn.setAttribute('aria-selected', 'false');
+    // aria-controls は意図的に付与しない
+    extraItem.appendChild(extraBtn);
+    tabs.querySelector('.c--tabs_list')!.appendChild(extraItem);
+
+    setTabs(tabs);
+
+    expect(() => extraBtn.click()).not.toThrow();
+  });
+
+  it('ディープリンク: ?lism-tab=panel2 で panel2 が選択状態になる', () => {
+    vi.useFakeTimers();
+
+    const { tabs, tab1, tab2, panel1, panel2 } = createTabsDOM();
+    document.body.appendChild(tabs);
+
+    history.replaceState({}, '', '/?lism-tab=panel2');
+    setTabs(tabs);
+
+    expect(tab2).toHaveAttribute('aria-selected', 'true');
+    expect(tab1).toHaveAttribute('aria-selected', 'false');
+    expect(panel2).toHaveAttribute('aria-hidden', 'false');
+    expect(panel1).toHaveAttribute('aria-hidden', 'true');
+    expect(tabs.dataset.hasTabLink).toBe('1');
+
+    vi.advanceTimersByTime(10);
+    expect(tabs.dataset.hasTabLink).toBeUndefined();
+  });
+
+  it('?lism-tab= が無い URL では dataset.hasTabLink が触られない', () => {
+    const { tabs } = createTabsDOM();
+    document.body.appendChild(tabs);
+
+    setTabs(tabs);
+
+    expect(tabs.dataset.hasTabLink).toBeUndefined();
+  });
+
+  it('存在しない id を ?lism-tab= に指定しても何も起きない', () => {
+    const { tabs, tab1, panel1 } = createTabsDOM();
+    document.body.appendChild(tabs);
+
+    history.replaceState({}, '', '/?lism-tab=no-such-panel');
+    setTabs(tabs);
+
+    expect(tab1).toHaveAttribute('aria-selected', 'true');
+    expect(panel1).toHaveAttribute('aria-hidden', 'false');
+    expect(tabs.dataset.hasTabLink).toBeUndefined();
+  });
+});

--- a/packages/lism-ui/vite.config.js
+++ b/packages/lism-ui/vite.config.js
@@ -43,6 +43,13 @@ const entries = {
 // build.lib を設定すると でライブラリモードになる。
 // https://ja.vitejs.dev/guide/build.html#library-mode
 export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    typecheck: {
+      enabled: true,
+    },
+  },
   plugins: [
     react({ jsxRuntime: 'automatic' }),
     libInjectCss(),

--- a/packages/lism-ui/vite.config.js
+++ b/packages/lism-ui/vite.config.js
@@ -46,9 +46,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
-    typecheck: {
-      enabled: true,
-    },
   },
   plugins: [
     react({ jsxRuntime: 'automatic' }),

--- a/packages/lism-ui/vitest.setup.ts
+++ b/packages/lism-ui/vitest.setup.ts
@@ -1,11 +1,9 @@
 import '@testing-library/jest-dom/vitest';
 
-// jsdom の requestAnimationFrame はコールバックを即時実行しないため shim
+// jsdom の requestAnimationFrame は実フレームに紐づかないため setTimeout ベースの shim に差し替える。
+// 同期実行にはせず 1 tick 遅らせることで、「次フレームで実行される」という非同期境界を再現する
 Object.defineProperty(window, 'requestAnimationFrame', {
-  value: (cb: FrameRequestCallback) => {
-    cb(0);
-    return 0;
-  },
+  value: (cb: FrameRequestCallback) => window.setTimeout(() => cb(performance.now()), 0),
   writable: true,
 });
 

--- a/packages/lism-ui/vitest.setup.ts
+++ b/packages/lism-ui/vitest.setup.ts
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom/vitest';
+
+// jsdom の requestAnimationFrame はコールバックを即時実行しないため shim
+Object.defineProperty(window, 'requestAnimationFrame', {
+  value: (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  },
+  writable: true,
+});
+
+// jsdom は HTMLDialogElement.showModal / close を実装していないため最小スタブ
+if (typeof HTMLDialogElement !== 'undefined') {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+      this.setAttribute('open', '');
+    };
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
+      this.removeAttribute('open');
+      this.dispatchEvent(new Event('close'));
+    };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       '@storybook/react-vite':
         specifier: ^10.3.3
         version: 10.3.3(esbuild@0.27.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.8.3)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -527,6 +530,9 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
+      jsdom:
+        specifier: ^27.4.0
+        version: 27.4.0
       rollup:
         specifier: ^4.59.0
         version: 4.60.1
@@ -554,6 +560,9 @@ importers:
       vite-plugin-lib-inject-css:
         specifier: ^2.2.2
         version: 2.2.2(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@types/node@25.5.0)(@vitest/browser-playwright@4.1.2)(jsdom@27.4.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/mcp:
     dependencies:


### PR DESCRIPTION
## Summary

- `packages/lism-ui` に Vitest + jsdom + @testing-library/jest-dom を導入
- `setAccordion` / `setModal` / `setTabs` の DOM 操作・aria 属性更新・開閉制御・排他制御・ディープリンクなどを計 30 ケースでカバー
- `vite.config.js` に test 設定を同居（`packages/lism-css` と同形）
- `vitest.setup.ts` で `HTMLDialogElement.showModal/close` と `requestAnimationFrame` を jsdom 向けに shim
- `package.json` の `files` に negation pattern を追加し、`*.test.ts` / `*.stories.tsx` 等を npm publish 対象から除外（Copilot レビュー指摘対応）

## Test plan

- [ ] `pnpm --filter @lism-css/ui test` — 30 tests pass
- [ ] `pnpm --filter @lism-css/ui typecheck` — type errors なし
- [ ] `pnpm --filter @lism-css/ui lint` — lint エラーなし
- [ ] `pnpm pack --dry-run` — tarball に `*.test.ts` / `*.stories.tsx` が含まれないこと

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * テスト実行環境を整備し、ブラウザに近い条件でコンポーネント検証ができるようになりました。
  * Accordion、Modal、Tabs の主要な動作確認テストを追加しました。

* **Bug Fixes**
  * 画面遷移や再クリック時の状態変化、ディープリンク、アニメーション後の挙動などをより安定して検証できるようになりました。

* **Chores**
  * 公開対象ファイルの設定を見直し、不要なテスト関連ファイルが配布物に含まれないようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->