### PR TITLE
feat(lism-cli): --template でカテゴリ slug 指定を受け付ける

### DIFF
--- a/packages/create-lism/README.md
+++ b/packages/create-lism/README.md
@@ -13,6 +13,9 @@ pnpm create lism
 # テンプレート名と出力先を指定
 pnpm create lism --template minimal-astro ./my-app
 
+# カテゴリ名を指定（stack 以下の選択を対話で続行）
+pnpm create lism --template minimal ./my-app
+
 # npm
 npm create lism@latest -- --template minimal-astro my-app
 
@@ -24,7 +27,7 @@ yarn create lism --template minimal-astro my-app
 
 | オプション | 説明 |
 |-----------|------|
-| `-t, --template <name>` | 使用するテンプレート名（例: `minimal-astro`） |
+| `-t, --template <name>` | 使用するテンプレート名またはカテゴリ名（例: `minimal-astro` / `minimal`） |
 | `-f, --force` | 既存ディレクトリを確認なしで強制上書き |
 | `-h, --help` | ヘルプ表示 |
 

--- a/packages/lism-cli/README.md
+++ b/packages/lism-cli/README.md
@@ -9,9 +9,9 @@
 ## コマンド体系
 
 ```
-lism create [targetDir] [--template <name>]   # templates から新規プロジェクト
-lism ui    { init | add <names...> | list }   # Lism UI コンポーネントの追加
-lism skill { add | check | update }           # AI エージェント向け SKILL.md 配置
+lism create [targetDir] [--template <name|category>]   # templates から新規プロジェクト
+lism ui    { init | add <names...> | list }            # Lism UI コンポーネントの追加
+lism skill { add | check | update }                    # AI エージェント向け SKILL.md 配置
 ```
 
 ## 使い方
@@ -24,6 +24,9 @@ pnpm dlx lism-cli create
 
 # テンプレート名・出力先を指定
 pnpm dlx lism-cli create --template minimal-astro ./my-app
+
+# カテゴリ名を指定（stack 以下の選択を対話で続行）
+pnpm dlx lism-cli create --template minimal ./my-app
 ```
 
 同じ動作は `pnpm create lism` / `npm create lism@latest` でも呼び出せます（`create-lism` パッケージ経由）。

--- a/packages/lism-cli/src/commands/create.test.ts
+++ b/packages/lism-cli/src/commands/create.test.ts
@@ -287,6 +287,53 @@ describe('runCreate', () => {
     expect(console.log).toHaveBeenCalledWith('  Open index.html in your browser');
   });
 
+  it('--templateにカテゴリslugを指定するとstack選択へ降りる', async () => {
+    const templates: Parameters<typeof runCreateWithTemplates>[1] = [
+      {
+        slug: 'minimal-astro',
+        kind: 'project',
+        category: 'minimal',
+        stack: 'astro',
+        sourcePath: 'minimal/astro',
+        description: { ja: 'Astro minimal', en: 'Astro minimal' },
+      },
+      {
+        slug: 'minimal-vite',
+        kind: 'project',
+        category: 'minimal',
+        stack: 'vite',
+        sourcePath: 'minimal/vite',
+        description: { ja: 'Vite minimal', en: 'Vite minimal' },
+      },
+    ];
+    vi.mocked(select).mockResolvedValueOnce('vite' as never);
+
+    await runCreateWithTemplates({ template: 'minimal', targetDir: 'cat-app', force: true }, templates);
+
+    expect(select).toHaveBeenCalledTimes(1);
+    expect((vi.mocked(select).mock.calls[0][0] as { message: string }).message).toBe('Select a stack (2 options):');
+    expect(downloadTemplate).toHaveBeenCalledWith('github:lism-css/lism-css/templates/minimal/vite#main', {
+      dir: path.join(tmpDir, 'cat-app'),
+      force: true,
+      forceClean: true,
+    });
+  });
+
+  it('--templateにカテゴリslugを指定し対象テンプレートが0件なら従来通りエラーを返す', async () => {
+    const templates: Parameters<typeof runCreateWithTemplates>[1] = [
+      {
+        slug: 'minimal-astro',
+        kind: 'project',
+        category: 'minimal',
+        stack: 'astro',
+        sourcePath: 'minimal/astro',
+        description: { ja: 'Astro minimal', en: 'Astro minimal' },
+      },
+    ];
+
+    await expect(runCreateWithTemplates({ template: 'blog', targetDir: 'x', force: true }, templates)).rejects.toThrow('Template "blog" not found');
+  });
+
   it('templateNotFoundを返す', async () => {
     await expect(runCreateWithTemplates({ template: 'missing', targetDir: 'x', force: true }, [])).rejects.toThrow('Template "missing" not found');
   });

--- a/packages/lism-cli/src/commands/create.ts
+++ b/packages/lism-cli/src/commands/create.ts
@@ -113,10 +113,15 @@ export async function createCommand(targetDir: string | undefined, options: Crea
 async function resolveTemplate(requested: string | undefined, templates: TemplateDef[]): Promise<TemplateDef> {
   if (requested) {
     const found = templates.find((t) => t.slug === requested);
-    if (!found) {
-      throw new Error(t('create.templateNotFound', { name: requested, list: templates.map((x) => x.slug).join(', ') }));
+    if (found) return found;
+
+    const matchedCategory = CATEGORIES.find((category) => category.id === requested);
+    const categoryTemplates = matchedCategory ? templates.filter((tpl) => tpl.category === matchedCategory.id) : [];
+    if (matchedCategory && categoryTemplates.length > 0) {
+      return resolveFromCategory(matchedCategory.id, categoryTemplates);
     }
-    return found;
+
+    throw new Error(t('create.templateNotFound', { name: requested, list: templates.map((x) => x.slug).join(', ') }));
   }
 
   const category = await select<CategoryId>({
@@ -127,7 +132,13 @@ async function resolveTemplate(requested: string | undefined, templates: Templat
     })),
   });
 
-  const categoryTemplates = templates.filter((tpl) => tpl.category === category);
+  return resolveFromCategory(
+    category,
+    templates.filter((tpl) => tpl.category === category)
+  );
+}
+
+async function resolveFromCategory(category: CategoryId, categoryTemplates: TemplateDef[]): Promise<TemplateDef> {
   const stack = await resolveStack(categoryTemplates);
   const stackTemplates = categoryTemplates.filter((tpl) => tpl.stack === stack);
   const variant = await resolveVariant(category, stackTemplates);

--- a/packages/lism-cli/src/messages.ts
+++ b/packages/lism-cli/src/messages.ts
@@ -40,8 +40,8 @@ export const messages = {
     en: 'Target directory',
   },
   'cli.create.opt.template': {
-    ja: '使用するテンプレート名（例: minimal-astro）',
-    en: 'Template name to use (e.g. minimal-astro)',
+    ja: '使用するテンプレート名またはカテゴリ名（例: minimal-astro / minimal）',
+    en: 'Template or category name to use (e.g. minimal-astro / minimal)',
   },
   'cli.create.opt.force': {
     ja: '既存ディレクトリを強制上書き',


### PR DESCRIPTION
## Summary

- `lism create --template <カテゴリslug>`（例: `--template minimal`）を受け付け、stack / variant 選択フローへ降りるようにした
- slug 完全一致が外れた場合のみカテゴリ判定にフォールバックするため、`--template minimal-astro` のような既存の slug 直指定挙動は維持
- カテゴリと一致しても対象テンプレートが 0 件のときは従来通り `create.templateNotFound` を返す
- ヘルプ文言（`cli.create.opt.template`）を「テンプレート名またはカテゴリ名」に更新

## Changes

- `packages/lism-cli/src/commands/create.ts`: `resolveTemplate()` で slug 完全一致が外れた場合に `CategoryId` 一致をチェック。共通化のため stack/variant 解決部を `resolveFromCategory()` に切り出し
- `packages/lism-cli/src/messages.ts`: `cli.create.opt.template` のヘルプ文言を更新
- `packages/lism-cli/src/commands/create.test.ts`:
  - `--template minimal` でカテゴリ解決され stack 選択に進むケースを追加
  - カテゴリ slug 指定でも対象 0 件なら `templateNotFound` を返すケースを追加

## Test plan

- [x] `nr test`（lism-cli: 50 tests pass）
- [x] `nr typecheck`（既存警告のみ・エラーなし）
- [x] `nr lint`（既存警告のみ・エラーなし）

Closes #379
