### PR TITLE
feat(templates/blog/techlog): 見出し(h2/h3)に自動アンカーリンクを追加

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,6 +542,9 @@ importers:
 
   templates/blog/astro/techlog:
     dependencies:
+      '@astrojs/markdown-remark':
+        specifier: ^7.1.2
+        version: 7.1.2
       '@astrojs/mdx':
         specifier: ^5.0.3
         version: 5.0.3(astro@6.1.9(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.1)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
@@ -569,6 +572,10 @@ importers:
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
+    devDependencies:
+      rehype-autolink-headings:
+        specifier: ^7.1.0
+        version: 7.1.0
 
   templates/lp/astro:
     dependencies:
@@ -715,6 +722,9 @@ packages:
   '@astrojs/internal-helpers@0.9.0':
     resolution: { integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg== }
 
+  '@astrojs/internal-helpers@0.9.1':
+    resolution: { integrity: sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ== }
+
   '@astrojs/language-server@2.16.6':
     resolution: { integrity: sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug== }
     hasBin: true
@@ -733,6 +743,9 @@ packages:
   '@astrojs/markdown-remark@7.1.1':
     resolution: { integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA== }
 
+  '@astrojs/markdown-remark@7.1.2':
+    resolution: { integrity: sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q== }
+
   '@astrojs/mdx@5.0.3':
     resolution: { integrity: sha512-zv/OlM5sZZvyjHqJjR3FjJvoCgbxdqj3t4jO/gSEUNcck3BjdtMgNQw8UgPfAGe4yySdG4vjZ3OC5wUxhu7ckg== }
     engines: { node: '>=22.12.0' }
@@ -741,6 +754,10 @@ packages:
 
   '@astrojs/prism@4.0.1':
     resolution: { integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ== }
+    engines: { node: '>=22.12.0' }
+
+  '@astrojs/prism@4.0.2':
+    resolution: { integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA== }
     engines: { node: '>=22.12.0' }
 
   '@astrojs/react@5.0.2':
@@ -3165,6 +3182,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: { integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g== }
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react-swc@3.11.0':
     resolution: { integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w== }
@@ -4477,6 +4495,9 @@ packages:
 
   hast-util-has-property@3.0.0:
     resolution: { integrity: sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA== }
+
+  hast-util-heading-rank@3.0.0:
+    resolution: { integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA== }
 
   hast-util-is-body-ok-link@3.0.1:
     resolution: { integrity: sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ== }
@@ -5907,6 +5928,9 @@ packages:
   regjsparser@0.13.0:
     resolution: { integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q== }
     hasBin: true
+
+  rehype-autolink-headings@7.1.0:
+    resolution: { integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw== }
 
   rehype-expressive-code@0.41.7:
     resolution: { integrity: sha512-25f8ZMSF1d9CMscX7Cft0TSQIqdwjce2gDOvQ+d/w0FovsMwrSt3ODP4P3Z7wO1jsIJ4eYyaDRnIR/27bd/EMQ== }
@@ -7429,6 +7453,10 @@ snapshots:
     dependencies:
       picomatch: 4.0.4
 
+  '@astrojs/internal-helpers@0.9.1':
+    dependencies:
+      picomatch: 4.0.4
+
   '@astrojs/language-server@2.16.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.2)':
     dependencies:
       '@astrojs/compiler': 2.13.1
@@ -7507,6 +7535,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@astrojs/markdown-remark@7.1.2':
+    dependencies:
+      '@astrojs/internal-helpers': 0.9.1
+      '@astrojs/prism': 4.0.2
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-to-text: 4.0.2
+      js-yaml: 4.1.1
+      mdast-util-definitions: 6.0.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-smartypants: 3.0.2
+      retext-smartypants: 6.2.0
+      shiki: 4.0.2
+      smol-toml: 1.6.1
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@astrojs/mdx@5.0.3(astro@6.1.9(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.1)(sass-embedded@1.98.0)(sass@1.98.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
@@ -7546,6 +7600,10 @@ snapshots:
       - supports-color
 
   '@astrojs/prism@4.0.1':
+    dependencies:
+      prismjs: 1.30.0
+
+  '@astrojs/prism@4.0.2':
     dependencies:
       prismjs: 1.30.0
 
@@ -11688,6 +11746,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-is-body-ok-link@3.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -13516,6 +13578,15 @@ snapshots:
   regjsparser@0.13.0:
     dependencies:
       jsesc: 3.1.0
+
+  rehype-autolink-headings@7.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-is-element: 3.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
 
   rehype-expressive-code@0.41.7:
     dependencies:

--- a/templates/blog/astro/techlog/astro.config.mjs
+++ b/templates/blog/astro/techlog/astro.config.mjs
@@ -42,7 +42,12 @@ export default defineConfig({
             class: 'c--headingAnchor',
             ariaLabel: 'Link to this section',
           },
-          content: { type: 'text', value: '#' },
+          content: {
+            type: 'element',
+            tagName: 'span',
+            properties: { ariaHidden: 'true', dataPagefindIgnore: '' },
+            children: [{ type: 'text', value: '#' }],
+          },
           test: (node) => ['h2', 'h3'].includes(node.tagName),
         },
       ],

--- a/templates/blog/astro/techlog/astro.config.mjs
+++ b/templates/blog/astro/techlog/astro.config.mjs
@@ -2,6 +2,8 @@ import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import expressiveCode from 'astro-expressive-code';
 import remarkDirective from 'remark-directive';
+import { rehypeHeadingIds } from '@astrojs/markdown-remark';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import { remarkDirectiveHandler } from './src/lib/remark-directive.mjs';
 import { remarkLinkCard } from './src/lib/remark-link-card.mjs';
 import { remarkWikiLink } from './src/lib/remark-wiki-link.mjs';
@@ -28,6 +30,24 @@ export default defineConfig({
     // :::note などの directive 記法を <Callout> に変換
     // URL単独段落/[[slug]]単独段落 → <LinkCard />、文中の[[slug]] → <WikiLink />
     remarkPlugins: [remarkDirective, remarkDirectiveHandler, remarkLinkCard, remarkWikiLink],
+    // h2/h3 見出しに #アンカーリンクを追加
+    // MDX integration の rehypeHeadingIds はユーザープラグインより後に走るため、明示的に先に追加
+    rehypePlugins: [
+      rehypeHeadingIds,
+      [
+        rehypeAutolinkHeadings,
+        {
+          behavior: 'append',
+          properties: {
+            class: 'c--heading-anchor',
+            ariaHidden: 'true',
+            tabIndex: -1,
+          },
+          content: { type: 'text', value: '#' },
+          test: (node) => ['h2', 'h3'].includes(node.tagName),
+        },
+      ],
+    ],
   },
   vite: {
     resolve: {

--- a/templates/blog/astro/techlog/astro.config.mjs
+++ b/templates/blog/astro/techlog/astro.config.mjs
@@ -42,12 +42,9 @@ export default defineConfig({
             class: 'c--headingAnchor',
             ariaLabel: 'Link to this section',
           },
-          content: {
-            type: 'element',
-            tagName: 'span',
-            properties: { ariaHidden: 'true', dataPagefindIgnore: '' },
-            children: [{ type: 'text', value: '#' }],
-          },
+          // "#" は CSS の ::after で描画する。アンカー本体にテキストを入れないことで、
+          // MDX integration が後段で再実行する rehypeHeadingIds の text 抽出に "#" が混入するのを防ぐ
+          content: [],
           test: (node) => ['h2', 'h3'].includes(node.tagName),
         },
       ],

--- a/templates/blog/astro/techlog/astro.config.mjs
+++ b/templates/blog/astro/techlog/astro.config.mjs
@@ -39,9 +39,8 @@ export default defineConfig({
         {
           behavior: 'append',
           properties: {
-            class: 'c--heading-anchor',
-            ariaHidden: 'true',
-            tabIndex: -1,
+            class: 'c--headingAnchor',
+            ariaLabel: 'Link to this section',
           },
           content: { type: 'text', value: '#' },
           test: (node) => ['h2', 'h3'].includes(node.tagName),

--- a/templates/blog/astro/techlog/package.json
+++ b/templates/blog/astro/techlog/package.json
@@ -10,6 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.1.2",
     "@astrojs/mdx": "^5.0.3",
     "@lism-css/ui": "workspace:*",
     "@pagefind/default-ui": "^1.4.0",
@@ -19,5 +20,8 @@
     "pagefind": "^1.4.0",
     "remark-directive": "^4.0.0",
     "unist-util-visit": "^5.1.0"
+  },
+  "devDependencies": {
+    "rehype-autolink-headings": "^7.1.0"
   }
 }

--- a/templates/blog/astro/techlog/src/styles/global.css
+++ b/templates/blog/astro/techlog/src/styles/global.css
@@ -111,6 +111,7 @@
     }
 
     /* === 見出しアンカーリンク === */
+    /* "#" は ::after で描画する。（目次に拾われるのを回避するため） */
     .c--headingAnchor {
       color: var(--text-2);
       font-family: var(--ff--mono);
@@ -119,6 +120,9 @@
       margin-inline-start: 0.25em;
       opacity: 0;
       transition: opacity 0.15s;
+    }
+    .c--headingAnchor::after {
+      content: '#';
     }
     *:hover > .c--headingAnchor,
     .c--headingAnchor:focus-visible {

--- a/templates/blog/astro/techlog/src/styles/global.css
+++ b/templates/blog/astro/techlog/src/styles/global.css
@@ -111,15 +111,15 @@
     }
 
     /* === 見出しアンカーリンク === */
-    .c--heading-anchor {
+    .c--headingAnchor {
       margin-inline-start: 0.3em;
       color: var(--text-2);
       text-decoration: none;
       opacity: 0;
       transition: opacity 0.15s;
     }
-    :is(h2, h3):hover .c--heading-anchor,
-    .c--heading-anchor:focus-visible {
+    *:hover > .c--headingAnchor,
+    .c--headingAnchor:focus-visible {
       opacity: 1;
     }
   }

--- a/templates/blog/astro/techlog/src/styles/global.css
+++ b/templates/blog/astro/techlog/src/styles/global.css
@@ -112,9 +112,11 @@
 
     /* === 見出しアンカーリンク === */
     .c--headingAnchor {
-      margin-inline-start: 0.3em;
       color: var(--text-2);
+      font-family: var(--ff--mono);
+      font-weight: 400;
       text-decoration: none;
+      margin-inline-start: 0.25em;
       opacity: 0;
       transition: opacity 0.15s;
     }

--- a/templates/blog/astro/techlog/src/styles/global.css
+++ b/templates/blog/astro/techlog/src/styles/global.css
@@ -109,6 +109,19 @@
     thead {
       border-block-end: solid 2px;
     }
+
+    /* === 見出しアンカーリンク === */
+    .c--heading-anchor {
+      margin-inline-start: 0.3em;
+      color: var(--text-2);
+      text-decoration: none;
+      opacity: 0;
+      transition: opacity 0.15s;
+    }
+    :is(h2, h3):hover .c--heading-anchor,
+    .c--heading-anchor:focus-visible {
+      opacity: 1;
+    }
   }
 }
 .-lts\:xl {


### PR DESCRIPTION
## Summary

`templates/blog/astro/techlog` の記事ページで、h2/h3 見出しに自動でアンカーリンク (`#`) を付与するようにします（minimal/personal には適用しません）。

## 変更内容

- `rehype-autolink-headings` を devDependencies に追加
- `astro.config.mjs` の `markdown.rehypePlugins` に `rehype-autolink-headings` を設定（`behavior: 'append'`、h2/h3 のみ）
- `global.css` に `.c--heading-anchor` のスタイルを追加（ホバー / focus-visible 時にフェードイン）

## 実装メモ

Astro 6 の MDX integration では、ユーザーの `rehypePlugins` が標準の `rehypeHeadingIds` **より先**に実行されるため、何もしないと id 未付与のヘディングに対して autolink が動かない問題があった。
→ `@astrojs/markdown-remark` から `rehypeHeadingIds` を import して、明示的に先頭に追加することで解決。

## Test plan

- [x] `astro build` でビルドエラーが出ないこと
- [x] 生成された HTML で h2/h3 に `<a class="c--heading-anchor" href="#…">#</a>` が追加されていること
- [x] toc-label など他の h2 にはアンカーリンクが付かないこと（記事本文の見出しのみ）
- [ ] ブラウザでホバー時にアンカーが表示されることを確認
- [ ] ダーク/ライトテーマ両方で見た目を確認

Closes #388
