### PR TITLE
fix(lism-css): spec-d の pos テストを ta に置き換えて非レスポンシブ枠を維持

### DIFF
--- a/packages/lism-css/src/lib/types/PropValueTypes.spec-d.ts
+++ b/packages/lism-css/src/lib/types/PropValueTypes.spec-d.ts
@@ -98,10 +98,10 @@ describe('PropValueTypes', () => {
     expectTypeOf<PropValueTypes['td']>().toEqualTypeOf<'none' | (string & {}) | number | boolean | null | undefined>();
   });
 
-  it('pos には presets と utils の値を設定できる', () => {
-    expectTypeOf<PropValueTypes['pos']>().toEqualTypeOf<
-      'static' | 'fixed' | 'sticky' | 'relative' | 'absolute' | (string & {}) | number | boolean | null | undefined
-    >();
+  it('ta には presets の値を設定できる（bp 未設定のため非レスポンシブ）', () => {
+    // presets: ['center', 'left', 'right']
+    // bp 未設定なので Responsive でラップされない
+    expectTypeOf<PropValueTypes['ta']>().toEqualTypeOf<'center' | 'left' | 'right' | (string & {}) | number | boolean | null | undefined>();
   });
 
   it('ai には presets と utils の値を設定できる（レスポンシブ対応）', () => {


### PR DESCRIPTION
## 目的

`pos` プロパティの `spec-d` 型期待値が `dev` ブランチ上で typecheck 失敗していた問題を、テストの本来の意図を保つ形で修正する。

## 背景

[#394](https://github.com/lism-css/lism-css/pull/394) で `pos` に `bp: 1` を追加した結果、`PropValueTypes['pos']` は `Responsive<>` でラップされる型になった。一方 `PropValueTypes.spec-d.ts` の `pos` テストは旧期待値（Responsive ラップなし）のままで以下のエラーを起こしていた：

```
FAIL  src/lib/types/PropValueTypes.spec-d.ts > PropValueTypes > pos には presets と utils の値を設定できる
TypeCheckError: Type 'number | boolean | "static" | "fixed" | "sticky" | "relative" | "absolute" | (string & {}) | null | undefined' does not satisfy the constraint '"Expected boolean, Actual ..."'.
```

## 方針

単純に `pos` 期待値を `Responsive<>` 形式に書き換えるのではなく、`ta`（textAlign）に置き換える。

`PropValueTypes.spec-d.ts` のテスト並びを通読すると、各テストは型生成ロジックの代表パターン（`bp` の有無 × `presets` / `utils` / `token` の組み合わせ）を1つずつ抑える形で配置されている：

| プロパティ | bp | 構成 | 役割 |
|---|---|---|---|
| `fs` | なし | presets | 非Responsive + presets（単一値） |
| `td` | なし | utils | 非Responsive + utils |
| `pos`（旧） | **なし** | **presets（複数値）** | **非Responsive + presets（複数値）** |
| `cg` / `rg` | 0 | token | 非Responsive + token |
| `ai` | 1 | presets + utils | Responsive + 複合 |
| `bdrs` | 1 | presets + token | Responsive + 複合 |
| ...etc | | | |

`pos` は本来「**bp 未設定 × presets のみ（複数値）**」の代表例として配置されていたが、`bp: 1` 化により役割が `ai` と重複してしまう。同じ枠を担える `ta`（`presets: ['center', 'left', 'right']`、bp 未設定）に置き換えることで、テストの分担と並びの意図を保つ。

## 変更内容

- `packages/lism-css/src/lib/types/PropValueTypes.spec-d.ts` の `pos` テストを `ta` に置き換え

## 確認

```bash
pnpm --filter lism-css test
# Test Files  24 passed (24)
# Tests       670 passed (670)
# Type Errors no errors
```
