### PR TITLE
feat(lism-css)!: AutoColumns のデフォルトモードを auto-fill に変更

### DIFF
--- a/apps/docs/src/components/templates/TemplatesIndex.astro
+++ b/apps/docs/src/components/templates/TemplatesIndex.astro
@@ -167,7 +167,7 @@ const buildCategoryDetailUrl = (category: string) => getLocalizedUrl(`/templates
                 }));
 
             return (
-              <AutoColumns cols="20em" autoFill g="30">
+              <AutoColumns cols="20em" g="30">
                 {cards.map((card) => (
                   <Stack as="article" id={card.id} g="0" bd bdrs="20" bgc="base" ov="hidden" class="p--templates_card">
                     <BoxLink

--- a/apps/docs/src/content/en/changelog.mdx
+++ b/apps/docs/src/content/en/changelog.mdx
@@ -9,6 +9,19 @@ Breaking changes may continue until v1.0, so all notable changes are documented 
 
 <Divider bds="dashed" my="40" />
 
+## lism-css v.0.22.0 (Unreleased)
+
+This release contains **breaking changes**.
+
+### Changed default mode of `AutoColumns`
+
+- Changed the default value of `--autoMode` in `l--autoColumns` from `auto-fit` to `auto-fill`
+- Renamed the Lism component prop from `autoFill` to `autoFit` (the meaning is inverted accordingly)
+- Existing code that used `autoFill` should now drop the prop, since `auto-fill` is now the default
+- If you need the previous `auto-fit` behavior, set `autoFit` explicitly
+
+<Divider bds="dashed" my="40" />
+
 ## lism-css v.0.21.0 (2026.05.26)
 
 This release contains **breaking changes**.

--- a/apps/docs/src/content/en/primitives.mdx
+++ b/apps/docs/src/content/en/primitives.mdx
@@ -68,7 +68,7 @@ Use `cols={3}` for a fixed column count. Pass `cols` as an array to declarativel
 
 **Recommended**: <ModLink slug="l--autoColumns" />
 
-Independent of breakpoints. Lets you concisely express `auto-fit` / `auto-fill` behavior based on a minimum column width. Suitable for card lists, product lists, logo grids, etc.
+Independent of breakpoints. Lets you concisely express `auto-fill` / `auto-fit` behavior based on a minimum column width. Suitable for card lists, product lists, logo grids, etc.
 
 ```jsx
 <AutoColumns cols="20rem" g="20">...</AutoColumns>

--- a/apps/docs/src/content/en/primitives/l--autoColumns.mdx
+++ b/apps/docs/src/content/en/primitives/l--autoColumns.mdx
@@ -26,7 +26,7 @@ import { AutoColumns, Lism } from 'lism-css/astro';
 | Prop | Description |
 |---|---|
 | `cols` <PropBadge type="cssvar">`--cols`</PropBadge> | Specifies the minimum width each column should maintain.
-| `autoFill` <PropBadge type="cssvar">`--autoMode`</PropBadge> | Switches the repeat mode to `auto-fill` (default is `auto-fit`).
+| `autoFit` <PropBadge type="cssvar">`--autoMode`</PropBadge> | Switches the repeat mode to `auto-fit` (default is `auto-fill`).
 
 
 ## Usage
@@ -70,44 +70,44 @@ import { AutoColumns, Lism } from 'lism-css/astro';
   </PreviewCode>
 </Preview>
 
-### Using `auto-fill`
+### Using `auto-fit`
 
-In `l--autoColumns`, you can control the first argument of the `repeat()` function in `grid-template-columns` via `--autoMode`. (The default is `auto-fit`.)
+In `l--autoColumns`, you can control the first argument of the `repeat()` function in `grid-template-columns` via `--autoMode`. (The default is `auto-fill`.)
 
-Setting `--autoMode: auto-fill` (`autoFill`) changes the behavior when there are only a few items.
+Setting `--autoMode: auto-fit` (`autoFit`) changes the behavior when there are only a few items.
 
 
 <Preview>
-  <PreviewTitle>Using `cols=12em` with `auto-fill`</PreviewTitle>
+  <PreviewTitle>Using `cols=12em` with `auto-fit`</PreviewTitle>
   <PreviewArea resize p="20">
-    <AutoColumns cols="12em" autoFill g="20" fz="s">
+    <AutoColumns cols="12em" g="20" fz="s">
       <Lism as="div" p="20" bd>auto-fill</Lism>
       <Lism as="div" p="20" bd>auto-fill</Lism>
     </AutoColumns>
-    <AutoColumns cols="12em" g="20" fz="s">
+    <AutoColumns cols="12em" autoFit g="20" fz="s">
       <Lism as="div" p="20" bd>auto-fit</Lism>
       <Lism as="div" p="20" bd>auto-fit</Lism>
     </AutoColumns>
   </PreviewArea>
   <PreviewCode slot="tab" label="JSX">
-    ```jsx 'autoFill'
-    <AutoColumns cols="12em" autoFill g="20" fz="s">
+    ```jsx 'autoFit'
+    <AutoColumns cols="12em" g="20" fz="s">
       <Lism as="div" p="20" bd>auto-fill</Lism>
       <Lism as="div" p="20" bd>auto-fill</Lism>
     </AutoColumns>
-    <AutoColumns cols="12em" g="20" fz="s">
+    <AutoColumns cols="12em" autoFit g="20" fz="s">
       <Lism as="div" p="20" bd>auto-fit</Lism>
       <Lism as="div" p="20" bd>auto-fit</Lism>
     </AutoColumns>
     ```
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
-    ```html "--autoMode:auto-fill"
-    <div class="l--autoColumns -g:20 -fz:s" style="--cols:12em; --autoMode:auto-fill">
+    ```html "--autoMode:auto-fit"
+    <div class="l--autoColumns -g:20 -fz:s" style="--cols:12em">
       <div class="-p:20 -bd">auto-fill</div>
       <div class="-p:20 -bd">auto-fill</div>
     </div>
-    <div class="l--autoColumns -g:20 -fz:s" style="--cols:12em">
+    <div class="l--autoColumns -g:20 -fz:s" style="--cols:12em; --autoMode:auto-fit">
       <div class="-p:20 -bd">auto-fit</div>
       <div class="-p:20 -bd">auto-fit</div>
     </div>

--- a/apps/docs/src/content/en/primitives/l--tileGrid.mdx
+++ b/apps/docs/src/content/en/primitives/l--tileGrid.mdx
@@ -128,5 +128,5 @@ Both `cols` and `rows` support breakpoint-specific values.
 {/* ## Related
 
 - [`<Columns>`](/en/docs/primitives/l--columns): Column layout with equal widths (1D)
-- [`<AutoColumns>`](/en/docs/primitives/l--autoColumns/): Fluid column count with auto-fit / auto-fill
+- [`<AutoColumns>`](/en/docs/primitives/l--autoColumns/): Fluid column count with auto-fill / auto-fit
 - [`<Grid>`](/en/docs/primitives/l--grid): General-purpose CSS Grid layout */}

--- a/apps/docs/src/content/ja/changelog.mdx
+++ b/apps/docs/src/content/ja/changelog.mdx
@@ -9,6 +9,19 @@ v.1.0リリースまでしばらく激しい変更が続く可能性があるた
 
 <Divider bds="dashed" my="40" />
 
+## lism-css v.0.22.0 (Unreleased)
+
+**破壊的変更**を含むリリースです。
+
+### `AutoColumns` のデフォルトモード変更
+
+- `l--autoColumns` の `--autoMode` の初期値を `auto-fit` から `auto-fill` に変更
+- Lismコンポーネントの専用 Prop を `autoFill` から `autoFit` にリネーム（意味も反転）
+- 既存コードで `autoFill` を指定していた箇所は、新しいデフォルト挙動と同じため Prop を削除
+- 旧デフォルトの `auto-fit` 挙動が必要な場合は `autoFit` を明示指定
+
+<Divider bds="dashed" my="40" />
+
 ## lism-css v.0.21.0 (2026.05.26)
 
 **破壊的変更**を含むリリースです。

--- a/apps/docs/src/content/ja/primitives.mdx
+++ b/apps/docs/src/content/ja/primitives.mdx
@@ -68,7 +68,7 @@ Lism では、レイアウトを組み立てる小さな積み木として **Pri
 
 **推奨**: <ModLink slug="l--autoColumns" />
 
-ブレイクポイントに依存せず、カラムの最小幅基準で `auto-fit` / `auto-fill` の挙動を簡潔に書けます。カード一覧、商品リスト、ロゴ並びなどに向いています。
+ブレイクポイントに依存せず、カラムの最小幅基準で `auto-fill` / `auto-fit` の挙動を簡潔に書けます。カード一覧、商品リスト、ロゴ並びなどに向いています。
 
 ```jsx
 <AutoColumns cols="20rem" g="20">...</AutoColumns>

--- a/apps/docs/src/content/ja/primitives/l--autoColumns.mdx
+++ b/apps/docs/src/content/ja/primitives/l--autoColumns.mdx
@@ -26,7 +26,7 @@ import { AutoColumns, Lism } from 'lism-css/astro';
 | プロパティ | 説明 |
 |---|---|
 | `cols` <PropBadge type="cssvar">`--cols`</PropBadge> | カラムが維持する最小幅を指定します。
-| `autoFill` <PropBadge type="cssvar">`--autoMode`</PropBadge> | 自動折り返しのモードを`auto-fill`に切り替えます。
+| `autoFit` <PropBadge type="cssvar">`--autoMode`</PropBadge> | 自動折り返しのモードを`auto-fit`に切り替えます。（デフォルトは `auto-fill`）
 
 
 ## Usage
@@ -70,44 +70,44 @@ import { AutoColumns, Lism } from 'lism-css/astro';
   </PreviewCode>
 </Preview>
 
-### `auto-fill`を使用する
+### `auto-fit`を使用する
 
-`l--autoColumns`では、`grid-template-columns`の`repeat`関数の第一引数を`--autoMode` で指定することができます。（デフォルトは `auto-fit` です。）
+`l--autoColumns`では、`grid-template-columns`の`repeat`関数の第一引数を`--autoMode` で指定することができます。（デフォルトは `auto-fill` です。）
 
-`--autoMode:auto-fill` (`autoFill`) を指定することで、要素数が少ない時の挙動が代わります。
+`--autoMode:auto-fit` (`autoFit`) を指定することで、要素数が少ない時の挙動が変わります。
 
 
 <Preview>
-  <PreviewTitle>`cols=12em`, `auto-fill` を使用する</PreviewTitle>
+  <PreviewTitle>`cols=12em`, `auto-fit` を使用する</PreviewTitle>
   <PreviewArea resize p="20">
-    <AutoColumns cols="12em" autoFill g="20" fz="s">
+    <AutoColumns cols="12em" g="20" fz="s">
       <Lism as="div" p="20" bd>auto-fill</Lism>
       <Lism as="div" p="20" bd>auto-fill</Lism>
     </AutoColumns>
-    <AutoColumns cols="12em" g="20" fz="s">
+    <AutoColumns cols="12em" autoFit g="20" fz="s">
       <Lism as="div" p="20" bd>auto-fit</Lism>
       <Lism as="div" p="20" bd>auto-fit</Lism>
     </AutoColumns>
   </PreviewArea>
   <PreviewCode slot="tab" label="JSX">
-    ```jsx 'autoFill'
-    <AutoColumns cols="12em" autoFill g="20" fz="s">
+    ```jsx 'autoFit'
+    <AutoColumns cols="12em" g="20" fz="s">
       <Lism as="div" p="20" bd>auto-fill</Lism>
       <Lism as="div" p="20" bd>auto-fill</Lism>
     </AutoColumns>
-    <AutoColumns cols="12em" g="20" fz="s">
+    <AutoColumns cols="12em" autoFit g="20" fz="s">
       <Lism as="div" p="20" bd>auto-fit</Lism>
       <Lism as="div" p="20" bd>auto-fit</Lism>
     </AutoColumns>
     ```
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
-    ```html "--autoMode:auto-fill"
-    <div class="l--autoColumns -g:20 -fz:s" style="--cols:12em; --autoMode:auto-fill">
+    ```html "--autoMode:auto-fit"
+    <div class="l--autoColumns -g:20 -fz:s" style="--cols:12em">
       <div class="-p:20 -bd">auto-fill</div>
       <div class="-p:20 -bd">auto-fill</div>
     </div>
-    <div class="l--autoColumns -g:20 -fz:s" style="--cols:12em">
+    <div class="l--autoColumns -g:20 -fz:s" style="--cols:12em; --autoMode:auto-fit">
       <div class="-p:20 -bd">auto-fit</div>
       <div class="-p:20 -bd">auto-fit</div>
     </div>

--- a/apps/docs/src/content/ja/primitives/l--tileGrid.mdx
+++ b/apps/docs/src/content/ja/primitives/l--tileGrid.mdx
@@ -128,5 +128,5 @@ import { TileGrid, Box, Center } from 'lism-css/astro';
 {/* ## 関連
 
 - [`<Columns>`](/docs/primitives/l--columns): 均等列のみ（1D）のカラムレイアウト
-- [`<AutoColumns>`](/docs/primitives/l--autoColumns/): auto-fit / auto-fill による流動的列数
+- [`<AutoColumns>`](/docs/primitives/l--autoColumns/): auto-fill / auto-fit による流動的列数
 - [`<Grid>`](/docs/primitives/l--grid): 汎用の CSS Grid レイアウト */}

--- a/apps/docs/src/pages/[lang]/page-layouts/index.astro
+++ b/apps/docs/src/pages/[lang]/page-layouts/index.astro
@@ -53,7 +53,7 @@ if (!isValidLang(lang)) {
                 </Inline>
               </Heading>
 
-              <AutoColumns autoFill cols="24rem" g="20" mbs="20" class="pageLayoutList">
+              <AutoColumns cols="24rem" g="20" mbs="20" class="pageLayoutList">
                 {items.map((item) => (
                   <BoxLink class="pageLayoutList_link" layout="stack" href={`/${lang}/page-layouts/${categoryId}/${item.id}`} p="10" g="20" set="hov">
                     <Frame ar="3/2" bd bdrs="20" ov="hidden">

--- a/apps/docs/src/pages/[lang]/patterns/index.astro
+++ b/apps/docs/src/pages/[lang]/patterns/index.astro
@@ -51,7 +51,7 @@ if (!isValidLang(lang)) {
                 </Inline>
               </Heading>
 
-              <AutoColumns autoFill cols="24rem" g="20" mbs="20" class="patternList">
+              <AutoColumns cols="24rem" g="20" mbs="20" class="patternList">
                 {items.map((item) => (
                   <BoxLink class="patternList_link" layout="stack" href={`/${lang}/patterns/${categoryId}/${item.id}`} p="10" g="20" set="hov">
                     <Frame ar="3/2" bd bdrs="20" ov="hidden">

--- a/apps/docs/src/pages/page-layouts/index.astro
+++ b/apps/docs/src/pages/page-layouts/index.astro
@@ -38,7 +38,7 @@ import { filterDraftItems } from '@/lib/page-layouts';
                 </Inline>
               </Heading>
 
-              <AutoColumns autoFill cols="24rem" g="20" mbs="20" class="pageLayoutList">
+              <AutoColumns cols="24rem" g="20" mbs="20" class="pageLayoutList">
                 {items.map((item) => (
                   <BoxLink class="pageLayoutList_link" layout="stack" href={`/page-layouts/${categoryId}/${item.id}`} p="10" g="20" set="hov">
                     {/* スクリーンショット画像をサムネイルとして表示（画像未配置でもページは壊れない） */}

--- a/apps/docs/src/pages/patterns/index.astro
+++ b/apps/docs/src/pages/patterns/index.astro
@@ -32,7 +32,7 @@ import { filterDraftItems } from '@/lib/patterns';
                 </Inline>
               </Heading>
 
-              <AutoColumns autoFill cols="24rem" g="20" mbs="20" class="patternList">
+              <AutoColumns cols="24rem" g="20" mbs="20" class="patternList">
                 {items.map((item) => (
                   <BoxLink class="patternList_link" layout="stack" href={`/patterns/${categoryId}/${item.id}`} p="10" g="20" set="hov">
                     {/* スクリーンショット画像をサムネイルとして表示 */}

--- a/packages/lism-css/src/components/layout/AutoColumns/AutoColumns.stories.tsx
+++ b/packages/lism-css/src/components/layout/AutoColumns/AutoColumns.stories.tsx
@@ -7,9 +7,9 @@ const meta: Meta<typeof AutoColumns> = {
   tags: ['autodocs'],
   argTypes: {
     children: { control: false },
-    autoFill: {
+    autoFit: {
       control: 'boolean',
-      description: 'auto-fill を使用するかどうか',
+      description: 'auto-fit を使用するかどうか（デフォルトは auto-fill）',
     },
   },
 };
@@ -33,11 +33,11 @@ export const Default: Story = {
   },
 };
 
-export const WithAutoFill: Story = {
-  name: 'autoFill: true',
+export const WithAutoFit: Story = {
+  name: 'autoFit: true',
   args: {
     g: '20',
-    autoFill: true,
+    autoFit: true,
     children: <DemoItems />,
   },
 };

--- a/packages/lism-css/src/lib/getLayoutProps.test.ts
+++ b/packages/lism-css/src/lib/getLayoutProps.test.ts
@@ -85,38 +85,38 @@ describe('getLayoutProps', () => {
   });
 
   describe('autoColumns レイアウト', () => {
-    test('autoFill が true の場合、style に --autoMode が設定される', () => {
-      const result = getLayoutProps('autoColumns', { autoFill: true });
+    test('autoFit が true の場合、style に --autoMode が設定される', () => {
+      const result = getLayoutProps('autoColumns', { autoFit: true });
       expect(result.style).toBeDefined();
-      expect(result.style?.['--autoMode']).toBe('auto-fill');
+      expect(result.style?.['--autoMode']).toBe('auto-fit');
     });
 
-    test('autoFill が false の場合、--autoMode は設定されない', () => {
-      const result = getLayoutProps('autoColumns', { autoFill: false });
+    test('autoFit が false の場合、--autoMode は設定されない', () => {
+      const result = getLayoutProps('autoColumns', { autoFit: false });
       expect(result.style?.['--autoMode']).toBeUndefined();
     });
 
-    test('autoFill が未定義の場合、--autoMode は設定されない', () => {
+    test('autoFit が未定義の場合、--autoMode は設定されない', () => {
       const result = getLayoutProps('autoColumns', {});
       expect(result.style?.['--autoMode']).toBeUndefined();
     });
 
     test('既存の style がある場合、マージされる', () => {
       const result = getLayoutProps('autoColumns', {
-        autoFill: true,
+        autoFit: true,
         style: { color: 'blue' },
       });
       expect(result.style?.color).toBe('blue');
-      expect(result.style?.['--autoMode']).toBe('auto-fill');
+      expect(result.style?.['--autoMode']).toBe('auto-fit');
     });
 
-    test('autoFill 以外のpropsは維持される', () => {
+    test('autoFit 以外のpropsは維持される', () => {
       const result = getLayoutProps('autoColumns', {
-        autoFill: true,
+        autoFit: true,
         otherProp: 'value',
       });
       expect(result.otherProp).toBe('value');
-      expect((result as unknown as Record<string, unknown>).autoFill).toBeUndefined();
+      expect((result as unknown as Record<string, unknown>).autoFit).toBeUndefined();
     });
   });
 

--- a/packages/lism-css/src/lib/getLayoutProps.ts
+++ b/packages/lism-css/src/lib/getLayoutProps.ts
@@ -13,7 +13,7 @@ interface PropConfig {
 // Layout固有 props（消費して除去される）
 interface LayoutOwnProps {
   flow?: CssValue;
-  autoFill?: boolean;
+  autoFit?: boolean;
   sideW?: CssValue;
   mainW?: CssValue;
   breakSize?: CssValue;
@@ -63,8 +63,8 @@ function getWithSideProps({ sideW, mainW, style, ...props }: InputProps): BasePr
   return { ...props, style: newStyle };
 }
 
-function getAutoColumnsProps({ autoFill, style, ...props }: InputProps): BaseProps {
-  if (autoFill) return { ...props, style: { ...style, '--autoMode': 'auto-fill' } as StyleWithCustomProps };
+function getAutoColumnsProps({ autoFit, style, ...props }: InputProps): BaseProps {
+  if (autoFit) return { ...props, style: { ...style, '--autoMode': 'auto-fit' } as StyleWithCustomProps };
   return { ...props, style };
 }
 

--- a/packages/lism-css/src/lib/types/LayoutProps.ts
+++ b/packages/lism-css/src/lib/types/LayoutProps.ts
@@ -45,7 +45,7 @@ export interface FlowLayoutProps {
 }
 export interface AutoColumnsProps {
   layout: 'autoColumns';
-  autoFill?: boolean;
+  autoFit?: boolean;
 }
 
 export interface WithSideProps {

--- a/packages/lism-css/src/scss/primitives/layout/_autoColumns.scss
+++ b/packages/lism-css/src/scss/primitives/layout/_autoColumns.scss
@@ -3,7 +3,7 @@
 */
 .l--autoColumns {
   --cols: 20rem;
-  --autoMode: auto-fit;
+  --autoMode: auto-fill;
   display: grid;
   grid-template-columns: repeat(var(--autoMode), minmax(min(var(--cols), 100%), 1fr));
 }

--- a/packages/mcp/src/data/docs-index.json
+++ b/packages/mcp/src/data/docs-index.json
@@ -860,6 +860,8 @@
       "AutoColumns",
       "流動カラム",
       "auto-fill",
+      "auto-fit",
+      "autoFit",
       "fluid",
       "l--autoColumns",
       "display",

--- a/skills/lism-css-guide/primitive-class.md
+++ b/skills/lism-css-guide/primitive-class.md
@@ -81,10 +81,10 @@ Lism CSS では、レイアウトを組み立てる小さな積み木として *
 ##### 2. カラム幅が指定値を下回ったら自動で折り返したい
 
 - **推奨**: `l--autoColumns` (`<AutoColumns cols="20rem" />`)
-- **理由**: BP に依存せず、カラム最小幅基準で `auto-fit` / `auto-fill` の挙動を簡潔に書ける
+- **理由**: BP に依存せず、カラム最小幅基準で `auto-fill` / `auto-fit` の挙動を簡潔に書ける
 - **典型例**: カード一覧、商品リスト、ロゴ並び等
 - **代替**:
-  - `l--grid`: `gtc="repeat(auto-fit, minmax(20rem, 1fr))"` を直書きできるが冗長
+  - `l--grid`: `gtc="repeat(auto-fill, minmax(20rem, 1fr))"` を直書きできるが冗長
 
 ##### 3. 「横並び」と「縦 1 列」を一括で切り替えたい（多段階の列数変化が不要）
 

--- a/skills/lism-css-guide/primitives/l--autoColumns.md
+++ b/skills/lism-css-guide/primitives/l--autoColumns.md
@@ -1,6 +1,6 @@
 # l--autoColumns / `<AutoColumns>`
 
-カラム要素が指定した幅より小さくならないように自動で折り返す、**ブレイクポイント非依存の段組みクラス**。`auto-fit` / `auto-fill` を使った流動カラムを簡潔に記述できます。
+カラム要素が指定した幅より小さくならないように自動で折り返す、**ブレイクポイント非依存の段組みクラス**。`auto-fill` / `auto-fit` を使った流動カラムを簡潔に記述できます。
 
 ## 基本情報
 
@@ -14,7 +14,7 @@
 | Prop | CSS変数 | デフォルト | 説明 |
 |------|--------|-----------|------|
 | `cols` | `--cols` | `20rem` | カラムが維持する最小幅を指定（`16em`, `320px` など） |
-| `autoFill` | `--autoMode` | `auto-fit` | `auto-fill` モードに切り替え |
+| `autoFit` | `--autoMode` | `auto-fill` | `auto-fit` モードに切り替え |
 
 ## Usage
 
@@ -38,27 +38,27 @@
 </div>
 ```
 
-### `auto-fill`を使用する
+### `auto-fit`を使用する
 
-`l--autoColumns` では、`grid-template-columns` の `repeat()` 関数の第一引数を `--autoMode` で指定できます（デフォルトは `auto-fit`）。`--autoMode:auto-fill`（`autoFill`）を指定することで、要素数が少ない時の挙動が変わります。
+`l--autoColumns` では、`grid-template-columns` の `repeat()` 関数の第一引数を `--autoMode` で指定できます（デフォルトは `auto-fill`）。`--autoMode:auto-fit`（`autoFit`）を指定することで、要素数が少ない時の挙動が変わります。
 
 ```jsx
-<AutoColumns cols="12em" autoFill g="20" fz="s">
+<AutoColumns cols="12em" g="20" fz="s">
   <Lism as="div" p="20" bd>auto-fill</Lism>
   <Lism as="div" p="20" bd>auto-fill</Lism>
 </AutoColumns>
-<AutoColumns cols="12em" g="20" fz="s">
+<AutoColumns cols="12em" autoFit g="20" fz="s">
   <Lism as="div" p="20" bd>auto-fit</Lism>
   <Lism as="div" p="20" bd>auto-fit</Lism>
 </AutoColumns>
 ```
 
 ```html
-<div class="l--autoColumns -g:20 -fz:s" style="--cols:12em; --autoMode:auto-fill">
+<div class="l--autoColumns -g:20 -fz:s" style="--cols:12em">
   <div class="-p:20 -bd">auto-fill</div>
   <div class="-p:20 -bd">auto-fill</div>
 </div>
-<div class="l--autoColumns -g:20 -fz:s" style="--cols:12em">
+<div class="l--autoColumns -g:20 -fz:s" style="--cols:12em; --autoMode:auto-fit">
   <div class="-p:20 -bd">auto-fit</div>
   <div class="-p:20 -bd">auto-fit</div>
 </div>

--- a/templates/blog/astro/techlog/src/components/PostList.astro
+++ b/templates/blog/astro/techlog/src/components/PostList.astro
@@ -16,7 +16,7 @@ interface Props {
 const { posts, showCategory = true } = Astro.props;
 ---
 
-<AutoColumns cols="20rem" g="30" as="ul" autoFill class="c--postList">
+<AutoColumns cols="20rem" g="30" as="ul" class="c--postList">
   {
     posts.map((post, index) => {
       const { category } = parsePostId(post.id);


### PR DESCRIPTION
## 概要

`<AutoColumns>` (`l--autoColumns`) のデフォルトモードを `auto-fit` から `auto-fill` に変更します。**破壊的変更**を含みます。

## 変更内容

- `l--autoColumns` の `--autoMode` 初期値を `auto-fit` → `auto-fill` に変更（`packages/lism-css/src/scss/primitives/layout/_autoColumns.scss`）
- 専用 Prop を `autoFill` → `autoFit` にリネーム（意味も反転）
  - `getLayoutProps.ts` / `LayoutProps.ts` / `getLayoutProps.test.ts`
  - `AutoColumns.stories.tsx`
- 既存コードで `autoFill` を指定していた箇所は新デフォルトと同じため Prop を削除
  - `templates/blog/astro/techlog/src/components/PostList.astro`
  - `apps/docs/src/components/templates/TemplatesIndex.astro`
  - `apps/docs/src/pages/{,[lang]/}{page-layouts,patterns}/index.astro`
- ドキュメント・スキル・MCP インデックス・changelog を更新

## モチベーション

アイテム数が少ない場合、`auto-fit` は空トラックを潰してアイテムを引き伸ばすため、想定外の見た目（横にビヨンと広がる）になりやすい。`auto-fill`（最小幅で詰めて余りを空トラックとして残す）の方が「自動カラム」として直感的なため、デフォルトを反転。

## マイグレーション

```diff
- <AutoColumns cols="20rem" autoFill>...</AutoColumns>
+ <AutoColumns cols="20rem">...</AutoColumns>

- <AutoColumns cols="20rem">...</AutoColumns>  {/* 旧 auto-fit 挙動が必要 */}
+ <AutoColumns cols="20rem" autoFit>...</AutoColumns>
```

## チェック

- [x] `nr typecheck` 通過
- [x] `nr test` 通過
- [x] `nr lint` 通過
- [x] `apps/docs` の autoColumns 関連ページの記述・サンプル整合
- [x] `skills/lism-css-guide` の autoColumns 関連記述更新
- [x] changelog (ja/en) に v0.22.0 (Unreleased) 破壊的変更として追記
