### PR TITLE
Modal: open時のスクロールバー消失による横がたつき対策

### DIFF
--- a/packages/lism-ui/src/components/Modal/setModal.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.ts
@@ -2,15 +2,11 @@ import { waitAnimation } from '../../helper/animation';
 
 /*
  * dialog を showModal() で開くと背景スクロールがロックされ、ページのスクロールバーが消える。
- * スクロールバーが実幅を持つ環境では、その分 viewport幅が広がってレイアウトが横にがたつく。
- * これを防ぐため、開いている dialog の数を数え、必要なときだけ html に
- * scrollbar-gutter: stable を一時適用してスクロールバー分のスペースを予約しておく。
- *
- * 複数 dialog の同時表示や連打でも復元処理が破綻しないよう、状態はモジュール単位で共有する。
+ * スクロールバーが実幅を持つ環境では、その幅分 viewport が広がってレイアウトが横にがたつく。
+ * これを防ぐため、開いている間だけ html に scrollbar-gutter: stable を当ててスクロールバー幅を予約する。
+ * Modal は同時に1つだけ開く前提なので、状態は「適用前の値」1つだけ保持する（null = 未適用）。
  */
-let scrollbarGutterLockCount = 0;
-let isScrollbarGutterApplied = false;
-let previousScrollbarGutter = '';
+let savedScrollbarGutter: string | null = null;
 
 /**
  * dialog を showModal() する直前に呼ぶ。
@@ -18,17 +14,13 @@ let previousScrollbarGutter = '';
  *          clientWidth が変わり、スクロールバーの有無を正しく判定できなくなる。
  */
 const lockScrollbarGutter = (): void => {
-  // 最初の dialog を開くときだけ、スクロールバーの有無を判定して適用する
-  if (scrollbarGutterLockCount === 0) {
-    const root = document.documentElement;
-    // window幅 > html の表示幅 → スクロールバーが実幅を持っている
-    if (window.innerWidth > root.clientWidth) {
-      previousScrollbarGutter = root.style.scrollbarGutter; // 既存の inline style を保持して後で復元する
-      root.style.scrollbarGutter = 'stable';
-      isScrollbarGutterApplied = true;
-    }
+  if (savedScrollbarGutter !== null) return; // すでに適用中
+  const root = document.documentElement;
+  // window幅 > html の表示幅 → スクロールバーが実幅を持っている場合だけ適用する
+  if (window.innerWidth > root.clientWidth) {
+    savedScrollbarGutter = root.style.scrollbarGutter; // 元の inline style を保持して後で復元する
+    root.style.scrollbarGutter = 'stable';
   }
-  scrollbarGutterLockCount += 1;
 };
 
 /**
@@ -37,13 +29,9 @@ const lockScrollbarGutter = (): void => {
  *          gutter を外すことになり、close() 直後のスクロールバー復活と二重にがたつく。
  */
 const unlockScrollbarGutter = (): void => {
-  if (scrollbarGutterLockCount === 0) return;
-  scrollbarGutterLockCount -= 1;
-  // すべての dialog が閉じたら、保持しておいた元の値へ復元する
-  if (scrollbarGutterLockCount === 0 && isScrollbarGutterApplied) {
-    document.documentElement.style.scrollbarGutter = previousScrollbarGutter;
-    isScrollbarGutterApplied = false;
-  }
+  if (savedScrollbarGutter === null) return; // 未適用なら何もしない
+  document.documentElement.style.scrollbarGutter = savedScrollbarGutter;
+  savedScrollbarGutter = null;
 };
 
 /**
@@ -57,9 +45,6 @@ export function setEvent(modal: HTMLElement): void {
 
   // オープンした時のトリガー要素を記憶する（data属性を戻すため）
   let theTrigger: HTMLElement | null = null;
-
-  // この dialog が scrollbar-gutter のロックに寄与しているか（lock / unlock を必ず対にして連打でもズレないようにする）
-  let hasLockedScrollbarGutter = false;
 
   // モーダルを開くトリガーと閉じるトリガーを取得
   const openTriggers = document.querySelectorAll<HTMLElement>(`[data-modal-open="${modal.id}"]`);
@@ -75,11 +60,7 @@ export function setEvent(modal: HTMLElement): void {
 
     // dialog 要素なら showModal()、それ以外は open 属性を付与
     if (isDialog) {
-      // showModal() でスクロールバーが消える前に、必要ならスクロールバー分のスペースを予約しておく
-      if (!hasLockedScrollbarGutter) {
-        lockScrollbarGutter();
-        hasLockedScrollbarGutter = true;
-      }
+      lockScrollbarGutter(); // showModal() でスクロールバーが消える前にスクロールバー幅を予約する
       modal.showModal();
     } else {
       modal.setAttribute('open', '');
@@ -110,14 +91,9 @@ export function setEvent(modal: HTMLElement): void {
     // アニメーション終了後、dialog を閉じる（open属性の削除）
     if (isDialog) {
       modal.close();
+      unlockScrollbarGutter(); // close() の後に scrollbar-gutter を復元する
     } else {
       modal.removeAttribute('open');
-    }
-
-    // close() の後に scrollbar-gutter を復元する（hasLockedScrollbarGutter は dialog のときのみ true）
-    if (hasLockedScrollbarGutter) {
-      unlockScrollbarGutter();
-      hasLockedScrollbarGutter = false;
     }
   };
 

--- a/packages/lism-ui/src/components/Modal/setModal.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.ts
@@ -1,5 +1,51 @@
 import { waitAnimation } from '../../helper/animation';
 
+/*
+ * dialog を showModal() で開くと背景スクロールがロックされ、ページのスクロールバーが消える。
+ * スクロールバーが実幅を持つ環境では、その分 viewport幅が広がってレイアウトが横にがたつく。
+ * これを防ぐため、開いている dialog の数を数え、必要なときだけ html に
+ * scrollbar-gutter: stable を一時適用してスクロールバー分のスペースを予約しておく。
+ *
+ * 複数 dialog の同時表示や連打でも復元処理が破綻しないよう、状態はモジュール単位で共有する。
+ */
+let scrollbarGutterLockCount = 0;
+let isScrollbarGutterApplied = false;
+let previousScrollbarGutter = '';
+
+/**
+ * dialog を showModal() する直前に呼ぶ。
+ *   Point: 判定・適用は showModal() の前に行う。showModal() 後はスクロールがロックされて
+ *          clientWidth が変わり、スクロールバーの有無を正しく判定できなくなる。
+ */
+const lockScrollbarGutter = (): void => {
+  // 最初の dialog を開くときだけ、スクロールバーの有無を判定して適用する
+  if (scrollbarGutterLockCount === 0) {
+    const root = document.documentElement;
+    // window幅 > html の表示幅 → スクロールバーが実幅を持っている
+    if (window.innerWidth > root.clientWidth) {
+      previousScrollbarGutter = root.style.scrollbarGutter; // 既存の inline style を保持して後で復元する
+      root.style.scrollbarGutter = 'stable';
+      isScrollbarGutterApplied = true;
+    }
+  }
+  scrollbarGutterLockCount += 1;
+};
+
+/**
+ * dialog を close() した直後に呼ぶ。
+ *   Point: 復元は close() の後に行う。close() 前に戻すと、まだスクロールバーが無い状態で
+ *          gutter を外すことになり、close() 直後のスクロールバー復活と二重にがたつく。
+ */
+const unlockScrollbarGutter = (): void => {
+  if (scrollbarGutterLockCount === 0) return;
+  scrollbarGutterLockCount -= 1;
+  // すべての dialog が閉じたら、保持しておいた元の値へ復元する
+  if (scrollbarGutterLockCount === 0 && isScrollbarGutterApplied) {
+    document.documentElement.style.scrollbarGutter = previousScrollbarGutter;
+    isScrollbarGutterApplied = false;
+  }
+};
+
 /**
  * モーダルの開閉イベントを設定する
  */
@@ -11,6 +57,9 @@ export function setEvent(modal: HTMLElement): void {
 
   // オープンした時のトリガー要素を記憶する（data属性を戻すため）
   let theTrigger: HTMLElement | null = null;
+
+  // この dialog が scrollbar-gutter のロックに寄与しているか（lock / unlock を必ず対にして連打でもズレないようにする）
+  let hasLockedScrollbarGutter = false;
 
   // モーダルを開くトリガーと閉じるトリガーを取得
   const openTriggers = document.querySelectorAll<HTMLElement>(`[data-modal-open="${modal.id}"]`);
@@ -26,6 +75,11 @@ export function setEvent(modal: HTMLElement): void {
 
     // dialog 要素なら showModal()、それ以外は open 属性を付与
     if (isDialog) {
+      // showModal() でスクロールバーが消える前に、必要ならスクロールバー分のスペースを予約しておく
+      if (!hasLockedScrollbarGutter) {
+        lockScrollbarGutter();
+        hasLockedScrollbarGutter = true;
+      }
       modal.showModal();
     } else {
       modal.setAttribute('open', '');
@@ -58,6 +112,12 @@ export function setEvent(modal: HTMLElement): void {
       modal.close();
     } else {
       modal.removeAttribute('open');
+    }
+
+    // close() の後に scrollbar-gutter を復元する（hasLockedScrollbarGutter は dialog のときのみ true）
+    if (hasLockedScrollbarGutter) {
+      unlockScrollbarGutter();
+      hasLockedScrollbarGutter = false;
     }
   };
 


### PR DESCRIPTION
## 概要

Modal（`dialog`）を `showModal()` で開くと背景スクロールがロックされ、ページのスクロールバーが消える。スクロールバーが実幅を持つ環境では、その分 viewport 幅が広がってレイアウトが横にがたつく問題への対策。

スクロールバーが無い短いページで逆方向にがたつかないよう、**スクロールバーが実幅を持つ場合だけ** `html` に `scrollbar-gutter: stable` を一時適用する。

Closes #398

## 対応内容

`packages/lism-ui/src/components/Modal/setModal.ts` のみ変更。

- モジュールスコープに「開いている dialog 数」のカウンタと適用フラグ・元の値保持を追加
- `lockScrollbarGutter()`: 最初の dialog を開くときだけ `window.innerWidth > documentElement.clientWidth` でスクロールバーの有無を判定し、ある場合のみ既存 inline style を保持してから `scrollbar-gutter: stable` を適用
- `unlockScrollbarGutter()`: すべての dialog が閉じたときだけ、保持しておいた元の値へ復元
- `dialog`（`isDialog`）のときのみ適用。`as` で別要素にした非 dialog Modal は背景スクロールをロックしないため対象外

## Issue「確認したいこと」への回答

- **複数 Modal / 連打時の復元破綻**: モジュール単位のカウンタ + Modal 単位の `hasLockedScrollbarGutter` フラグで lock / unlock を必ず対にした。最初の open でのみ適用判定、最後の close でのみ復元するため、同時表示・連打でもズレない
- **`showModal()` 前後どちらで判定・適用するか**: **前**。`showModal()` 後はスクロールがロックされて `clientWidth` が変化し、スクロールバーの有無を正しく判定できなくなるため。復元は `close()` の**後**（前に外すと close 直後のスクロールバー復活と二重にがたつく）
- **判定式 `window.innerWidth > documentElement.clientWidth`**: Issue 案どおり採用
- **inline style 方式**: Issue 案どおり、元の値を保持してライブラリ内部に閉じ込める方針を採用

## 確認

- `pnpm --filter @lism-css/ui typecheck`: 0 errors
- `pnpm --filter @lism-css/ui lint:eslint`: pass

> [!NOTE]
> 元 Issue は「将来的に検討」ラベル付きの検討段階だったため、設計判断（適用範囲を dialog 限定にする点など）も含めてレビューでの確認をお願いします。
