### PR TITLE
fix(lism-cli): macOSの表示言語が日本語ならCLIを日本語表示にする

### DIFF
--- a/packages/lism-cli/src/i18n.test.ts
+++ b/packages/lism-cli/src/i18n.test.ts
@@ -60,7 +60,7 @@ describe('detectLang', () => {
     setPlatform('darwin');
     mockedExecFileSync.mockReturnValue('(\n    "ja-JP",\n    "en-JP"\n)\n');
     expect(detectLang()).toBe('ja');
-    expect(mockedExecFileSync).toHaveBeenCalledWith('defaults', ['read', '-g', 'AppleLanguages'], expect.anything());
+    expect(mockedExecFileSync).toHaveBeenCalledWith('/usr/bin/defaults', ['read', '-g', 'AppleLanguages'], expect.anything());
   });
 
   it('macOS で AppleLanguages 先頭が en* なら ja にはしない', () => {

--- a/packages/lism-cli/src/i18n.test.ts
+++ b/packages/lism-cli/src/i18n.test.ts
@@ -1,15 +1,35 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { detectLang, getLang, setLang, preScanLang, t, tOf } from './i18n';
 import type { MessageKey } from './messages';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+const originalPlatform = process.platform;
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+function mockIntlLocale(locale: string) {
+  return vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => ({ resolvedOptions: () => ({ locale }) }) as unknown as Intl.DateTimeFormat);
+}
 
 describe('detectLang', () => {
   beforeEach(() => {
     vi.stubEnv('LC_ALL', '');
     vi.stubEnv('LANG', '');
+    mockedExecFileSync.mockReset();
+    // 既定では macOS 以外として AppleLanguages 経路を無効化する
+    setPlatform('linux');
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    setPlatform(originalPlatform);
   });
 
   it('override が "ja" のときはそのまま返す', () => {
@@ -35,11 +55,56 @@ describe('detectLang', () => {
     expect(detectLang()).toBe('ja');
   });
 
+  it('macOS で LANG が英語でも AppleLanguages 先頭が ja* なら ja', () => {
+    vi.stubEnv('LC_ALL', 'en_US.UTF-8');
+    setPlatform('darwin');
+    mockedExecFileSync.mockReturnValue('(\n    "ja-JP",\n    "en-JP"\n)\n');
+    expect(detectLang()).toBe('ja');
+    expect(mockedExecFileSync).toHaveBeenCalledWith('defaults', ['read', '-g', 'AppleLanguages'], expect.anything());
+  });
+
+  it('macOS で AppleLanguages 先頭が en* なら ja にはしない', () => {
+    vi.stubEnv('LC_ALL', 'en_US.UTF-8');
+    setPlatform('darwin');
+    mockedExecFileSync.mockReturnValue('(\n    "en-US",\n    "ja-JP"\n)\n');
+    const spy = mockIntlLocale('en-US');
+    try {
+      expect(detectLang()).toBe('en');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('macOS で defaults コマンドが失敗しても Intl 判定にフォールバックする', () => {
+    vi.stubEnv('LC_ALL', 'en_US.UTF-8');
+    setPlatform('darwin');
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error('defaults: command not found');
+    });
+    const spy = mockIntlLocale('ja-JP');
+    try {
+      expect(detectLang()).toBe('ja');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('macOS 以外では AppleLanguages を参照しない', () => {
+    vi.stubEnv('LC_ALL', 'en_US.UTF-8');
+    setPlatform('linux');
+    mockedExecFileSync.mockReturnValue('(\n    "ja-JP"\n)\n');
+    const spy = mockIntlLocale('en-US');
+    try {
+      expect(detectLang()).toBe('en');
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('LC_ALL / LANG が英語でも Intl が ja* ならフォールバックで ja', () => {
     vi.stubEnv('LC_ALL', 'en_US.UTF-8');
-    const spy = vi
-      .spyOn(Intl, 'DateTimeFormat')
-      .mockImplementation(() => ({ resolvedOptions: () => ({ locale: 'ja-JP' }) }) as unknown as Intl.DateTimeFormat);
+    const spy = mockIntlLocale('ja-JP');
     try {
       expect(detectLang()).toBe('ja');
     } finally {
@@ -49,9 +114,7 @@ describe('detectLang', () => {
 
   it('どこからも ja が引けない場合は en', () => {
     vi.stubEnv('LC_ALL', 'en_US.UTF-8');
-    const spy = vi
-      .spyOn(Intl, 'DateTimeFormat')
-      .mockImplementation(() => ({ resolvedOptions: () => ({ locale: 'en-US' }) }) as unknown as Intl.DateTimeFormat);
+    const spy = mockIntlLocale('en-US');
     try {
       expect(detectLang()).toBe('en');
     } finally {

--- a/packages/lism-cli/src/i18n.ts
+++ b/packages/lism-cli/src/i18n.ts
@@ -20,7 +20,8 @@ export type Lang = 'ja' | 'en';
 function detectAppleLanguage(): string | null {
   if (process.platform !== 'darwin') return null;
   try {
-    const out = execFileSync('defaults', ['read', '-g', 'AppleLanguages'], {
+    // PATH 探索による意図しないバイナリ起動を避けるため macOS 標準の絶対パスを指定する
+    const out = execFileSync('/usr/bin/defaults', ['read', '-g', 'AppleLanguages'], {
       encoding: 'utf8',
       timeout: 1000,
       stdio: ['ignore', 'pipe', 'ignore'],

--- a/packages/lism-cli/src/i18n.ts
+++ b/packages/lism-cli/src/i18n.ts
@@ -5,18 +5,56 @@
  * - `--lang <code>` オプションで明示上書き可能。
  * - メッセージ辞書は `messages.ts` に集約。
  */
+import { execFileSync } from 'node:child_process';
 import { messages, type MessageKey } from './messages.js';
 
 export type Lang = 'ja' | 'en';
 
 /**
- * 環境変数 / Intl から現在のロケールを検出する。
+ * macOS の OS 表示言語（`AppleLanguages` の先頭）を取得する。
+ *
+ * macOS では、OS 表示言語が日本語でもターミナルに渡る `LANG` が英語（例: `en_US.UTF-8`）
+ * になる環境があるため、`defaults read -g AppleLanguages` を fallback として参照する。
+ * macOS 以外・コマンド失敗時は `null` を返す。
+ */
+function detectAppleLanguage(): string | null {
+  if (process.platform !== 'darwin') return null;
+  try {
+    const out = execFileSync('defaults', ['read', '-g', 'AppleLanguages'], {
+      encoding: 'utf8',
+      timeout: 1000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    // 出力例:
+    //   (
+    //       "ja-JP",
+    //       "en-JP"
+    //   )
+    // 先頭の言語コードを取り出す。
+    const match = out.match(/"?([A-Za-z]{2,}[-_A-Za-z]*)"?/);
+    return match ? match[1].toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 環境変数 / OS 表示言語 / Intl から現在のロケールを検出する。
  * `override` に `ja` / `en` が渡された場合はそれを優先。
+ *
+ * 判定順:
+ * 1. `override`（`--lang ja|en` の明示指定）
+ * 2. `LC_ALL` / `LANG` が `ja*`
+ * 3. macOS の `AppleLanguages` 先頭が `ja*`
+ * 4. `Intl` のロケールが `ja*`
+ * 5. それ以外は `en`
  */
 export function detectLang(override?: string): Lang {
   if (override === 'ja' || override === 'en') return override;
   const raw = (process.env.LC_ALL || process.env.LANG || '').toLowerCase();
   if (raw.startsWith('ja')) return 'ja';
+  // macOS: ターミナルのロケールが英語でも OS 表示言語が日本語なら ja に倒す
+  if (detectAppleLanguage()?.startsWith('ja')) return 'ja';
   try {
     const locale = Intl.DateTimeFormat().resolvedOptions().locale.toLowerCase();
     if (locale.startsWith('ja')) return 'ja';


### PR DESCRIPTION
## 概要

macOS で OS の表示言語が日本語でも、ターミナルに渡る locale が英語（例: `LANG=en_US.UTF-8`）の場合に CLI が英語表示になる問題を修正します。

`detectLang()` に macOS 限定の fallback を追加し、`AppleLanguages` の先頭が `ja*` のときは日本語に自動切替するようにしました。

Closes #414

## 変更内容

`packages/lism-cli/src/i18n.ts`

- `detectAppleLanguage()` を追加。`process.platform === 'darwin'` のときのみ `defaults read -g AppleLanguages` を実行し、先頭の言語コードを取り出す（macOS 以外・コマンド失敗時は `null`）。
- `detectLang()` の判定順を以下に変更（`LC_ALL`/`LANG` と `Intl` の間に挿入）:
  1. `--lang ja|en` の明示指定
  2. `LC_ALL` / `LANG` が `ja*`
  3. **macOS の `AppleLanguages` 先頭が `ja*`** ← 今回追加
  4. `Intl` のロケールが `ja*`
  5. それ以外は `en`

`execFileSync` には `timeout: 1000` と stderr 抑制（`stdio: ['ignore', 'pipe', 'ignore']`）を設定し、コマンド失敗時も安全に `null` フォールバックします。

## テスト

`packages/lism-cli/src/i18n.test.ts` に macOS 経路のテストを追加。`node:child_process` の `execFileSync` と `process.platform` をモックし、ハーミティックに検証しています。

- macOS で `LANG` が英語でも `AppleLanguages` 先頭が `ja*` なら `ja`
- macOS で `AppleLanguages` 先頭が `en*` なら `ja` にしない
- macOS で `defaults` が失敗しても `Intl` 判定にフォールバック
- macOS 以外では `AppleLanguages` を参照しない

## 動作確認

`LANG=en_US.UTF-8`・`AppleLanguages` 先頭 `ja-JP` の macOS 実機で確認:

- `lism --help` → 日本語表示になることを確認
- `create-lism --help`（バンドル版）→ 日本語表示になることを確認
- `--lang en` → 英語強制が維持されることを確認
- `LANG=ja_JP.UTF-8` → 従来通り日本語表示

`nr test` / `nr typecheck` / `nr lint` いずれも通過（既存の docs/lism-css の warning は本変更と無関係）。
