### PR TITLE
feat(types): isFullMode の型レベル対応（FullModeRegistry で opt-in）#425

### DIFF
--- a/apps/docs/src/content/en/customize.mdx
+++ b/apps/docs/src/content/en/customize.mdx
@@ -50,8 +50,22 @@ With `isFullMode: true`, the full preset is also applied to the component props 
 :::warning
 - `isFullMode` assumes the corresponding styles are loaded via `full.css` (or a CLI rebuild with `isFullMode` enabled). If you keep the default `main.css`, the output classes will have no matching styles.
 - `isFullMode` is a build-time setting. It cannot be toggled at runtime via `window._LISM_CSS_CONFIG_`.
-- TypeScript types do not follow the full configuration, so some usages (such as breakpoint arrays for `pl`) cause type errors even with `isFullMode` (they still work at runtime).
 :::
+
+Types and completion can follow `isFullMode` as well. If you use the integrated plugin from `lism-css/vite`, `lism-env.d.ts` is generated automatically when `isFullMode: true`, so breakpoint usages (array / object notation) for props like `pl` no longer cause type errors. No hand-written extension is needed (commit `lism-env.d.ts` to git).
+
+If you do not use the integrated plugin, extend the type in a type definition file at your project root (e.g. `src/lism-env.d.ts`) like this:
+
+```ts
+// src/lism-env.d.ts
+import 'lism-css';
+
+declare module 'lism-css' {
+  interface FullModeRegistry {
+    enabled: true; // The key name is arbitrary; any single key switches to the full type variant.
+  }
+}
+```
 
 Note that running the [CLI build described below](#build-css-using-the-lism-css-cli-command) with `isFullMode` enabled also applies the full preset to `main.css`.
 

--- a/apps/docs/src/content/ja/customize.mdx
+++ b/apps/docs/src/content/ja/customize.mdx
@@ -50,8 +50,22 @@ export default {
 :::warning
 - `isFullMode` は、`full.css`（または `isFullMode` の状態での CLI 再ビルド）でスタイルが読み込まれていることが前提です。デフォルトの `main.css` のまま有効にすると、出力されたクラスに対応するスタイルが存在しない状態になります。
 - `isFullMode` はビルド時の設定です。ランタイムの `window._LISM_CSS_CONFIG_` では切り替えられません。
-- TypeScript の型は full 設定に追従していないため、`isFullMode` でも一部の指定（`pl` へのブレイクポイント配列指定など）は型エラーになります（ランタイムでは動作します）。
 :::
+
+型・補完も `isFullMode` に追従させられます。`lism-css/vite` の統合プラグインを使っている場合は、`isFullMode: true` のとき `lism-env.d.ts` が自動生成され、`pl` などへのブレイクポイント指定（配列・オブジェクト記法）も型エラーになりません。手書き拡張は不要です（`lism-env.d.ts` は git にコミットしてください）。
+
+統合プラグインを使わない場合は、プロジェクト直下の型定義ファイル（例: `src/lism-env.d.ts`）で次のように拡張してください。
+
+```ts
+// src/lism-env.d.ts
+import 'lism-css';
+
+declare module 'lism-css' {
+  interface FullModeRegistry {
+    enabled: true; // キー名は任意。1つでもキーがあれば full 版の型に切り替わる
+  }
+}
+```
 
 なお、[後述の CLI ビルド](#lism-css-のcliコマンドでcssビルドする)を `isFullMode` が有効の状態で実行すると、`main.css` にも full 用の設定が適用された状態でビルドされます。
 

--- a/packages/lism-css/src/builder/gen-types.test.ts
+++ b/packages/lism-css/src/builder/gen-types.test.ts
@@ -118,6 +118,39 @@ describe('generateLismEnvDts', () => {
     ).toBeNull();
     expect(generateLismEnvDts({ breakpoints: undefined, props: {} }, DEFAULT_PROP_KEYS)).toBeNull();
   });
+
+  test('isFullMode: true なら FullModeRegistry 拡張を生成する（追加キーが他に無くても null にしない）', () => {
+    const dts = generateLismEnvDts(
+      { breakpoints: { sm: '480px', md: '800px', lg: '1120px' }, props: {} },
+      DEFAULT_PROP_KEYS,
+      DEFAULT_TRAIT_KEYS,
+      true
+    );
+    expect(dts).not.toBeNull();
+    expect(dts).toContain('interface FullModeRegistry');
+    expect(dts).toContain('enabled: true;');
+    expect(dts?.match(/declare module 'lism-css'/g)).toHaveLength(1);
+  });
+
+  test('isFullMode: false（既定）では FullModeRegistry 拡張を含めない', () => {
+    const dts = generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_PROP_KEYS);
+    expect(dts).not.toBeNull();
+    expect(dts).not.toContain('FullModeRegistry');
+  });
+
+  test('isFullMode と追加 breakpoints / props を同じ declare module に並べて生成する', () => {
+    const dts = generateLismEnvDts(
+      { breakpoints: { xs: '360px' }, props: { filter: { prop: 'filter' } } },
+      DEFAULT_PROP_KEYS,
+      DEFAULT_TRAIT_KEYS,
+      true
+    );
+    expect(dts).not.toBeNull();
+    expect(dts).toContain('interface BreakpointRegistry');
+    expect(dts).toContain('interface CustomPropRegistry');
+    expect(dts).toContain('interface FullModeRegistry');
+    expect(dts?.match(/declare module 'lism-css'/g)).toHaveLength(1);
+  });
 });
 
 describe('writeLismEnvDts', () => {

--- a/packages/lism-css/src/builder/gen-types.ts
+++ b/packages/lism-css/src/builder/gen-types.ts
@@ -1,10 +1,11 @@
 /**
- * lism.config.js の breakpoints / props から module augmentation の `.d.ts` を生成する純粋関数（#427 / P4-P5）。
+ * lism.config.js の breakpoints / props / traits / isFullMode から module augmentation の `.d.ts` を生成する純粋関数（#427 / P4-P5）。
  *
  * 型のデフォルト広告は sm/md/lg（`lib/types/ResponsiveProps.ts` の `BreakpointRegistry`）。
  * config で xs/xl にサイズ（≠0）を与えて有効化した分を、プロジェクト直下の `.d.ts` で
  * `declare module 'lism-css'` 拡張して型側にも解禁する。これにより #428 の手書き augmentation を不要にする。
- * さらに、lism.config.js で追加された props / traits は `CustomPropRegistry` / `CustomTraitRegistry` 拡張として並べて出力する。
+ * さらに、lism.config.js で追加された props / traits は `CustomPropRegistry` / `CustomTraitRegistry` 拡張として並べて出力し、
+ * `isFullMode: true` のときは `FullModeRegistry` 拡張で型を full 版に切り替える（#425）。
  *
  * 副作用（ファイル書き出し）は `vite-typegen.ts` 側に分離し、ここは入力 → 文字列の純粋変換に限定する。
  */
@@ -88,19 +89,37 @@ ${lines}
 }
 
 /**
- * breakpoints / props / traits から `.d.ts` の内容を生成する。追加解禁キーが無ければ `null`（= ファイル不要）を返す。
+ * isFullMode 時は FullModeRegistry を拡張し、型側でも full 版（isVar 系を除く全 props が responsive）に切り替える。
+ * キー名・値は任意（PropValueTypes 側は `keyof` の有無だけを見る）。
+ */
+function generateFullModeBlock(isFullMode: boolean): string | null {
+  if (!isFullMode) return null;
+  return `  interface FullModeRegistry {
+    enabled: true;
+  }`;
+}
+
+/**
+ * breakpoints / props / traits / isFullMode から `.d.ts` の内容を生成する。
+ * 追加解禁キーも isFullMode も無ければ `null`（= ファイル不要）を返す。
  */
 export function generateLismEnvDts(
   mainConfig: Pick<BuildConfig, 'breakpoints' | 'props' | 'traits'>,
   defaultPropKeys: Iterable<string>,
-  defaultTraitKeys: Iterable<string> = []
+  defaultTraitKeys: Iterable<string> = [],
+  isFullMode = false
 ): string | null {
   const bpKeys = extraAdvertisedBpKeys(mainConfig.breakpoints);
   const propKeys = extraCustomPropKeys(mainConfig.props, defaultPropKeys);
   const traitKeys = extraCustomTraitKeys(mainConfig.traits, defaultTraitKeys);
-  if (bpKeys.length === 0 && propKeys.length === 0 && traitKeys.length === 0) return null;
+  if (bpKeys.length === 0 && propKeys.length === 0 && traitKeys.length === 0 && !isFullMode) return null;
 
-  const blocks = [generateBreakpointBlock(bpKeys), generateCustomPropBlock(propKeys), generateCustomTraitBlock(traitKeys)]
+  const blocks = [
+    generateBreakpointBlock(bpKeys),
+    generateCustomPropBlock(propKeys),
+    generateCustomTraitBlock(traitKeys),
+    generateFullModeBlock(isFullMode),
+  ]
     .filter((block): block is string => block !== null)
     .join('\n\n');
 

--- a/packages/lism-css/src/builder/vite-typegen.ts
+++ b/packages/lism-css/src/builder/vite-typegen.ts
@@ -59,11 +59,11 @@ export function writeLismEnvDts(projectRoot: string, content: string | null, log
  * projectRoot の lism.config を読み、breakpoints / props / traits から `.d.ts` を生成 / 更新 / 削除する。
  */
 export async function syncLismEnvDts(projectRoot: string, opts: SyncTypesOptions = {}): Promise<void> {
-  const { mainConfig, defaultPropKeys, defaultTraitKeys } = await loadBuildConfigs(projectRoot, {
+  const { mainConfig, defaultPropKeys, defaultTraitKeys, isFullMode } = await loadBuildConfigs(projectRoot, {
     distDir: opts.distDir,
     configPath: opts.configPath,
   });
-  writeLismEnvDts(projectRoot, generateLismEnvDts(mainConfig, defaultPropKeys, defaultTraitKeys), opts.log);
+  writeLismEnvDts(projectRoot, generateLismEnvDts(mainConfig, defaultPropKeys, defaultTraitKeys, isFullMode), opts.log);
 }
 
 export interface LismTypegenOptions {

--- a/packages/lism-css/src/index.ts
+++ b/packages/lism-css/src/index.ts
@@ -1,3 +1,4 @@
 export type { BreakpointRegistry, MakeResponsive, Responsive, ResponsiveFor } from './lib/types/ResponsiveProps';
 export type { CustomPropRegistry, CustomPropValue } from './lib/types/CustomPropRegistry';
 export type { CustomTraitRegistry, CustomTraitValue } from './lib/types/CustomTraitRegistry';
+export type { FullModeRegistry } from './lib/types/FullModeRegistry';

--- a/packages/lism-css/src/lib/types/FullModeRegistry.ts
+++ b/packages/lism-css/src/lib/types/FullModeRegistry.ts
@@ -1,0 +1,26 @@
+/**
+ * lism.config.js の `isFullMode: true`（full preset をコンポーネント側にも適用するモード）を
+ * 型側へ反映するための拡張ポイント。
+ *
+ * full モードでは isVar 系を除く全 props が responsive になる（`props-full.ts` のランタイム挙動と一致）が、
+ * 静的型は lism.config.js の `.js` の値を読めないため、デフォルトでは defaults 由来のまま追従しない。
+ * このレジストリを `declare module 'lism-css'` で拡張（= 何らかのキーを1つ以上付与）すると、
+ * {@link import('./PropValueTypes').PropValueTypes} が full 版に切り替わり、
+ * `pl` 等の本来 bp:0 の props でも BP 指定（配列・オブジェクト記法）が型エラーにならなくなる。
+ *
+ * ランタイム側の有効化はあくまで lism.config.js の `isFullMode` で行う。ここで切り替えるのは
+ * 「型が提示・許可する範囲」だけで、両者を一致させるのはユーザーの責務（`BreakpointRegistry` と同じ設計）。
+ *
+ * @example プロジェクト直下の型定義ファイル（例: `src/lism-env.d.ts`）で full モードを型に反映する
+ * ```ts
+ * import 'lism-css';
+ *
+ * declare module 'lism-css' {
+ *   interface FullModeRegistry {
+ *     enabled: true; // キー名は任意。1つでもキーがあれば full 版の型に切り替わる
+ *   }
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface FullModeRegistry {}

--- a/packages/lism-css/src/lib/types/PropValueTypes.ts
+++ b/packages/lism-css/src/lib/types/PropValueTypes.ts
@@ -1,6 +1,7 @@
 import { TOKENS, PROPS } from '../../../config/index';
 import type { WithArbitraryString, ArrayElement, ExtractArrayValues, ExtractObjectKeys, ExtractPropertyValue } from './utils';
 import type { MakeResponsive } from './ResponsiveProps';
+import type { FullModeRegistry } from './FullModeRegistry';
 
 type PropsConfig = typeof PROPS;
 type TokensConfig = typeof TOKENS;
@@ -115,11 +116,58 @@ export type NonResponsivePropValueTypes = {
   [K in PropsWithoutBreakpoint]?: PropValueType<PropsConfig[K]>;
 };
 
+/** defaults 由来の Props 型（full モード未適用時のデフォルト） */
+type DefaultPropValueTypes = MakeResponsive<ResponsivePropValueTypes> & NonResponsivePropValueTypes;
+
+// ============================================================
+// full モード（isFullMode）の型対応
+// ============================================================
+//
+// lism.config.js の isFullMode では、isVar 系を除く全 props が responsive 化する
+// （config/presets/props-full.ts のランタイム挙動）。これを型側にも反映する。
+// 静的型は .js の値を読めないため、FullModeRegistry の module augmentation で opt-in する。
+
+/**
+ * isVar 系（state 変数扱い・full preset の対象外）の prop かを判定。
+ * isVar 未設定の prop は `ExtractPropertyValue` が never を返す。`1 extends X` の向きで
+ * 判定することで、X が never でも 1 でもない（= false）になり、tuple ラップ時の
+ * `[never] extends [1]` が true に化ける罠を避ける。
+ */
+type IsVarProp<T> = 1 extends ExtractPropertyValue<T, 'isVar'> ? true : false;
+
+/**
+ * full モードでレスポンシブになる prop のキー。
+ * - isVar 系以外: full preset が bp:1 にするため常にレスポンシブ
+ * - isVar 系: props-full.ts の対象外なのでデフォルトの bp 判定のまま
+ */
+type FullPropsWithBreakpoint = {
+  [K in AllPropKeys]: IsVarProp<PropsConfig[K]> extends true ? (HasBreakpointSupport<PropsConfig[K]> extends true ? K : never) : K;
+}[AllPropKeys];
+
+type FullPropsWithoutBreakpoint = Exclude<AllPropKeys, FullPropsWithBreakpoint>;
+
+/** full モード適用時の Props 型（isVar 系を除く全 props がレスポンシブ） */
+type FullPropValueTypes = MakeResponsive<{
+  [K in FullPropsWithBreakpoint]?: PropValueType<PropsConfig[K]>;
+}> & {
+  [K in FullPropsWithoutBreakpoint]?: PropValueType<PropsConfig[K]>;
+};
+
+/**
+ * FullModeRegistry が module augmentation で拡張されている（= キーが1つ以上ある）か。
+ * 空 interface の `keyof` は never。`[never] extends [never]` の tuple ラップで
+ * naked never の分配（条件型が never に潰れる）を回避している（HasBreakpointSupport と同手法）。
+ */
+type IsFullModeAdvertised = [keyof FullModeRegistry] extends [never] ? false : true;
+
 /**
  * PROPS 設定から生成される Props 型（レスポンシブ対応含む）
  * - bp が有効なプロパティ: レスポンシブ対応（配列・オブジェクト形式可）
  * - bp なしのプロパティ: 単一値のみ
  * - presets/utils/token なしのプロパティ: string | number（フォールバック）
+ *
+ * {@link FullModeRegistry} が拡張されている場合は full 版に切り替わり、isVar 系を除く
+ * 全 props がレスポンシブになる（lism.config.js の isFullMode に型を追従させるための opt-in）。
  *
  * @example
  * ```ts
@@ -133,4 +181,4 @@ export type NonResponsivePropValueTypes = {
  * bg?: Responsive<string | number>
  * ```
  */
-export type PropValueTypes = MakeResponsive<ResponsivePropValueTypes> & NonResponsivePropValueTypes;
+export type PropValueTypes = IsFullModeAdvertised extends true ? FullPropValueTypes : DefaultPropValueTypes;

--- a/packages/lism-css/src/lib/types/ResponsiveProps.module-augmentation.spec-d.ts
+++ b/packages/lism-css/src/lib/types/ResponsiveProps.module-augmentation.spec-d.ts
@@ -16,6 +16,10 @@ declare module 'lism-css' {
   interface CustomTraitRegistry {
     isHoge?: CustomTraitValue;
   }
+
+  interface FullModeRegistry {
+    enabled: true;
+  }
 }
 
 describe('BreakpointRegistry module augmentation', () => {
@@ -49,5 +53,18 @@ describe('BreakpointRegistry module augmentation', () => {
     };
 
     expectTypeOf(withTrait).toExtend<LismPropsBase>();
+  });
+
+  it('FullModeRegistry 拡張で bp:0 だった props も responsive 指定が解禁される（#425）', () => {
+    // defaults では pl/ml/cg は bp:0、bg は bp 未設定（いずれも非レスポンシブ）。
+    // full モードを型に反映すると、配列・オブジェクト記法が型エラーにならなくなる。
+    const value: PropValueTypes = {
+      pl: ['10', '20'], // paddingLeft（space トークン値はそのまま）
+      ml: { base: '10', md: '20' }, // marginLeft
+      cg: ['10', '20'], // columnGap
+      bg: { base: 'red', lg: 'blue' }, // フォールバック型でも responsive 化
+    };
+
+    expectTypeOf(value).toExtend<PropValueTypes>();
   });
 });


### PR DESCRIPTION
## 概要

`isFullMode` の型レベル対応（#425）。`isFullMode: true` ではランタイムで `pl` などの `bp:0` props も BP 指定（配列・オブジェクト記法）が機能するが、静的型は defaults 由来のままで型エラーになっていた。これを module augmentation で opt-in できるようにした。

Closes #425

## 方針

既存の `BreakpointRegistry` / `CustomPropRegistry` / `CustomTraitRegistry` と同じ module augmentation パターンを採用。新たに `FullModeRegistry` を公開し、拡張（キーを1つ以上付与）されると `PropValueTypes` が full 版に切り替わる。

```ts
// src/lism-env.d.ts
import 'lism-css';
declare module 'lism-css' {
  interface FullModeRegistry { enabled: true; }
}
```

```tsx
<Box pl={['10', '20']} />  // ✅ 型OK（従来は型エラー）
```

## 変更点

- **`FullModeRegistry`（新規）**: 型側 full 化の opt-in ポイント。`src/index.ts` から re-export。
- **`PropValueTypes`**: `FullModeRegistry` が拡張されていれば full 版（isVar 系を除く全 props が responsive）に切り替え。未拡張時はデフォルト挙動を完全維持。
- **型生成（`gen-types` / `vite-typegen`）**: 統合プラグイン（`lism-css/vite`）利用時、`isFullMode: true` で `lism-env.d.ts` に `FullModeRegistry` 拡張を自動 emit。プラグイン利用者は手書き不要。
- **docs（ja/en `customize.mdx`）**: 「型が full に追従しない」旨の注記を、opt-in 手順の説明に差し替え。

## 設計メモ（型の罠）

- `IsFullModeAdvertised = [keyof FullModeRegistry] extends [never] ? false : true`：naked never の分配回避に tuple ラップ（既存 `HasBreakpointSupport` と同手法）。
- `IsVarProp<T> = 1 extends ExtractPropertyValue<T, 'isVar'> ? true : false`：`[never] extends [1]` が true に化ける罠を避けるため、`1 extends X` の向きで判定。

## テスト

- `gen-types.test.ts`: `isFullMode` での `FullModeRegistry` 自動 emit を追加検証。
- `ResponsiveProps.module-augmentation.spec-d.ts`: `FullModeRegistry` 拡張で `pl`/`ml`/`cg`/`bg` が responsive 化することを隔離コンパイルで検証。
- デフォルト挙動（非拡張時の非レスポンシブ）は既存 spec-d がそのまま担保。
- `pnpm test` 838 passed / Type Errors 0、`tsc --noEmit` クリーン、`build:core` 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
