### PR TITLE
fix: docs devでcore CSS更新を反映

### DIFF
--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'astro/config';
+import { fileURLToPath } from 'node:url';
 import sitemap from '@astrojs/sitemap';
 import react from '@astrojs/react';
 import mdx from '@astrojs/mdx';
@@ -38,7 +39,7 @@ function normalizeFsPath(filePath: string): string {
 }
 
 function watchLismCoreDistCss() {
-  const cssDirRaw = new URL('../../packages/lism-css/dist/css/', import.meta.url).pathname;
+  const cssDirRaw = fileURLToPath(new URL('../../packages/lism-css/dist/css/', import.meta.url));
   const cssDir = normalizeFsPath(cssDirRaw);
   let timer: ReturnType<typeof setTimeout> | undefined;
 
@@ -88,13 +89,13 @@ export default defineConfig({
       alias: {
         '@': '/src',
         '@ui': '/src/components/ui',
-        '@templates': new URL('../../templates', import.meta.url).pathname,
+        '@templates': fileURLToPath(new URL('../../templates', import.meta.url)),
       },
     },
     server: {
       fs: {
         // monorepo ルートの templates 配下を許可
-        allow: [new URL('../../', import.meta.url).pathname],
+        allow: [fileURLToPath(new URL('../../', import.meta.url))],
       },
     },
     plugins: [

--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -19,6 +19,51 @@ import { lismCss } from '@lism-css/plugin/astro';
 const isBuild = process.argv.includes('build');
 const lastmodMap = isBuild ? loadLastmodMap() : new Map<string, string>();
 
+type DevServerLike = {
+  watcher: {
+    add(paths: string | string[]): void;
+    on(event: 'change', callback: (file: string) => void): void;
+  };
+  moduleGraph: {
+    getModulesByFile(file: string): Set<unknown> | undefined;
+    invalidateModule(mod: unknown): void;
+  };
+  ws: {
+    send(payload: { type: 'full-reload'; path?: string; triggeredBy?: string }): void;
+  };
+};
+
+function normalizeFsPath(filePath: string): string {
+  return filePath.replace(/\\/g, '/');
+}
+
+function watchLismCoreDistCss() {
+  const cssDirRaw = new URL('../../packages/lism-css/dist/css/', import.meta.url).pathname;
+  const cssDir = normalizeFsPath(cssDirRaw);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  return {
+    name: 'docs:watch-lism-core-dist-css',
+    apply: 'serve' as const,
+    configureServer(server: DevServerLike) {
+      server.watcher.add(cssDirRaw);
+      server.watcher.on('change', (file) => {
+        const normalized = normalizeFsPath(file);
+        if (!normalized.startsWith(cssDir) || !normalized.endsWith('.css')) return;
+
+        const modules = server.moduleGraph.getModulesByFile(file) ?? server.moduleGraph.getModulesByFile(normalized);
+        modules?.forEach((mod) => server.moduleGraph.invalidateModule(mod));
+
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+          server.ws.send({ type: 'full-reload', path: '*', triggeredBy: file });
+        }, 50);
+        timer.unref?.();
+      });
+    },
+  };
+}
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://lism-css.com/',
@@ -53,6 +98,7 @@ export default defineConfig({
       },
     },
     plugins: [
+      watchLismCoreDistCss(),
       {
         // __で始まるディレクトリ/ファイルをビルドから除外するプラグイン
         name: 'ignore-underscore-prefix',

--- a/packages/plugin/src/builder/compile-entry.ts
+++ b/packages/plugin/src/builder/compile-entry.ts
@@ -28,13 +28,19 @@ import { writePropConfigFiles } from './compile';
  */
 export async function listCssEntries(scssDir: string): Promise<Map<string, string>> {
   const { globSync } = await import('glob');
-  const files = globSync('**/*.scss', { cwd: scssDir, ignore: ['**/_*.scss'] });
+  const files = globSync('**/*.scss', { cwd: scssDir, ignore: ['**/_*.scss'] }).sort();
   const map = new Map<string, string>();
   for (const rel of files) {
     const entry = rel.replace(/\.scss$/, '').replace(/\/index$/, '');
     map.set(entry, rel);
   }
   return map;
+}
+
+/** Sass が参照し得る全 SCSS ファイル。partial も含めて dev の watch 対象に登録する。 */
+export async function listCssSourceFiles(scssDir: string): Promise<string[]> {
+  const { globSync } = await import('glob');
+  return globSync('**/*.scss', { cwd: scssDir, absolute: true }).sort();
 }
 
 /** main / full の prop-config 直列化結果から作業ディレクトリの一意な署名を作る。 */
@@ -65,6 +71,8 @@ export interface CssCompiler {
   hasEntry(entry: string): Promise<boolean>;
   /** 全エントリ名。 */
   entries(): Promise<string[]>;
+  /** watch 対象に登録する SCSS ソースファイル一覧。 */
+  sourceFiles(): Promise<string[]>;
   /** 作業ディレクトリとキャッシュを破棄する（dev 終了時に呼ぶ）。 */
   dispose(): void;
 }
@@ -110,6 +118,9 @@ export function createCssCompiler({ scssDir, minify = false, log }: CssCompilerO
   return {
     async entries() {
       return [...(await getEntryMap()).keys()];
+    },
+    async sourceFiles() {
+      return listCssSourceFiles(scssDir);
     },
     async hasEntry(entry) {
       return (await getEntryMap()).has(entry);

--- a/packages/plugin/src/builder/dynamic-css.test.ts
+++ b/packages/plugin/src/builder/dynamic-css.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
 import { lismDynamicCss } from './dynamic-css';
 
@@ -9,6 +10,20 @@ function getResolveId(plugin: ReturnType<typeof lismDynamicCss>) {
   if (!fn) throw new Error('resolveId hook not found');
   // resolveId は this（PluginContext）を参照しないため、空オブジェクトで呼べる。
   return (source: string) => (fn as (this: unknown, s: string) => unknown).call({}, source);
+}
+
+function getLoad(plugin: ReturnType<typeof lismDynamicCss>) {
+  const hook = plugin.load;
+  const fn = typeof hook === 'function' ? hook : hook?.handler;
+  if (!fn) throw new Error('load hook not found');
+  return (id: string, ctx: { addWatchFile(file: string): void }) => (fn as (this: typeof ctx, id: string) => unknown).call(ctx, id);
+}
+
+function getHandleHotUpdate(plugin: ReturnType<typeof lismDynamicCss>) {
+  const hook = plugin.handleHotUpdate;
+  const fn = typeof hook === 'function' ? hook : hook?.handler;
+  if (!fn) throw new Error('handleHotUpdate hook not found');
+  return (ctx: unknown) => (fn as (ctx: unknown) => unknown)(ctx);
 }
 
 describe('lismDynamicCss resolveId', () => {
@@ -40,5 +55,47 @@ describe('lismDynamicCss resolveId', () => {
     expect(await resolveId('react')).toBeNull();
     expect(await resolveId('lism-css/main.js')).toBeNull();
     expect(await resolveId('./local.css')).toBeNull();
+  });
+});
+
+describe('lismDynamicCss watch / hot update', () => {
+  test('load 時に core の SCSS と default config を watch 対象へ登録する', async () => {
+    const plugin = lismDynamicCss();
+    const resolveId = getResolveId(plugin);
+    const load = getLoad(plugin);
+    const id = (await resolveId('lism-css/main.css')) as string;
+    const watched: string[] = [];
+
+    await load(id, { addWatchFile: (file) => watched.push(file) });
+
+    expect(watched.some((file) => file.endsWith('/packages/lism-css/src/scss/main.scss'))).toBe(true);
+    expect(watched.some((file) => file.endsWith('/packages/lism-css/config/defaults/tokens.ts'))).toBe(true);
+    expect(watched.some((file) => file.endsWith('/packages/lism-css/dist/config/defaults/tokens.js'))).toBe(true);
+  });
+
+  test('core の SCSS 変更時に CSS モジュールを更新対象にして full reload する', async () => {
+    const plugin = lismDynamicCss();
+    const resolveId = getResolveId(plugin);
+    const load = getLoad(plugin);
+    const handleHotUpdate = getHandleHotUpdate(plugin);
+    const id = (await resolveId('lism-css/main.css')) as string;
+    await load(id, { addWatchFile: () => {} });
+
+    const mod = { id };
+    const sent: unknown[] = [];
+    const affected = await handleHotUpdate({
+      file: fileURLToPath(new URL('../../../lism-css/src/scss/main.scss', import.meta.url)),
+      server: {
+        moduleGraph: {
+          getModuleById: (moduleId: string) => (moduleId === id ? mod : null),
+        },
+        ws: {
+          send: (payload: unknown) => sent.push(payload),
+        },
+      },
+    });
+
+    expect(affected).toEqual([mod]);
+    expect(sent).toContainEqual({ type: 'full-reload' });
   });
 });

--- a/packages/plugin/src/builder/dynamic-css.test.ts
+++ b/packages/plugin/src/builder/dynamic-css.test.ts
@@ -70,7 +70,9 @@ describe('lismDynamicCss watch / hot update', () => {
 
     expect(watched.some((file) => file.endsWith('/packages/lism-css/src/scss/main.scss'))).toBe(true);
     expect(watched.some((file) => file.endsWith('/packages/lism-css/config/defaults/tokens.ts'))).toBe(true);
+    expect(watched.some((file) => file.endsWith('/packages/lism-css/config/defaults/token-scope.ts'))).toBe(true);
     expect(watched.some((file) => file.endsWith('/packages/lism-css/dist/config/defaults/tokens.js'))).toBe(true);
+    expect(watched.some((file) => file.endsWith('/packages/lism-css/dist/config/defaults/token-scope.js'))).toBe(true);
   });
 
   test('core の SCSS 変更時に CSS モジュールを更新対象にして full reload する', async () => {

--- a/packages/plugin/src/builder/dynamic-css.ts
+++ b/packages/plugin/src/builder/dynamic-css.ts
@@ -31,27 +31,33 @@ const distConfigDir = `${distDir}/config`;
 const BARE_CSS_RE = /^lism-css\/(.+)\.css$/;
 const CONFIG_FILE_RE = /\.(?:js|mjs|ts)$/;
 
-const CORE_CONFIG_WATCH_RELS = [
-  'package.json',
-  'config/default-config.ts',
-  'config/helper.ts',
-  'config/index.ts',
-  'config/defaults/breakpoints.ts',
-  'config/defaults/props.ts',
-  'config/defaults/tokens.ts',
-  'config/defaults/traits.ts',
-  'config/presets/props-full.ts',
-  'dist/config/default-config.js',
-  'dist/config/helper.js',
-  'dist/config/defaults/breakpoints.js',
-  'dist/config/defaults/props.js',
-  'dist/config/defaults/tokens.js',
-  'dist/config/defaults/traits.js',
-  'dist/config/presets/props-full.js',
-];
+const CORE_CONFIG_WATCH_FILES = [path.join(packageRootRaw, 'package.json')];
+const CORE_CONFIG_WATCH_DIRS = [path.join(packageRootRaw, 'config'), path.join(distDirRaw, 'config')];
+
+function isConfigModuleFile(file: string): boolean {
+  return CONFIG_FILE_RE.test(file) && !file.endsWith('.d.ts');
+}
+
+function collectConfigFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const filePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectConfigFiles(filePath));
+    } else if (entry.isFile() && isConfigModuleFile(filePath)) {
+      files.push(filePath);
+    }
+  }
+  return files;
+}
 
 function coreConfigWatchFiles(): string[] {
-  return CORE_CONFIG_WATCH_RELS.map((rel) => path.join(packageRootRaw, rel)).filter((filePath) => fs.existsSync(filePath));
+  return [
+    ...CORE_CONFIG_WATCH_FILES.filter((filePath) => fs.existsSync(filePath)),
+    ...CORE_CONFIG_WATCH_DIRS.flatMap((dir) => collectConfigFiles(dir)),
+  ];
 }
 
 function isCoreCssSourceFile(file: string): boolean {
@@ -62,8 +68,8 @@ function isCoreCssSourceFile(file: string): boolean {
 function isCoreConfigFile(file: string): boolean {
   const normalized = normalizePath(file);
   return (
-    (normalized.startsWith(`${sourceConfigDir}/`) && CONFIG_FILE_RE.test(normalized)) ||
-    (normalized.startsWith(`${distConfigDir}/`) && CONFIG_FILE_RE.test(normalized))
+    (normalized.startsWith(`${sourceConfigDir}/`) && isConfigModuleFile(normalized)) ||
+    (normalized.startsWith(`${distConfigDir}/`) && isConfigModuleFile(normalized))
   );
 }
 

--- a/packages/plugin/src/builder/dynamic-css.ts
+++ b/packages/plugin/src/builder/dynamic-css.ts
@@ -6,12 +6,14 @@
  *
  * NOTE: 本プラグインは Vite/Astro 統合エントリの `lismCss()` が内部で使う低レベル部品。
  */
-import type { Plugin } from 'vite';
+import type { ModuleNode, Plugin, ViteDevServer } from 'vite';
+import path from 'node:path';
+import fs from 'node:fs';
 
 import { createCssCompiler, type CssCompiler } from './compile-entry';
 import { loadBuildConfigs, type LoadedBuildConfigs } from './load-config';
 import { normalizePath } from './normalize-path';
-import { scssDir, cssDistDir as cssDistDirRaw } from './paths';
+import { scssDir, cssDistDir as cssDistDirRaw, distDir as distDirRaw, packageRoot as packageRootRaw } from './paths';
 
 export interface LismDynamicCssOptions {
   /** lism.config の明示パス。未指定時は Vite root から探索する。 */
@@ -20,9 +22,55 @@ export interface LismDynamicCssOptions {
 
 // id 比較は posix 区切りで行うため normalize しておく。
 const cssDistDir = normalizePath(cssDistDirRaw);
+const distDir = normalizePath(distDirRaw);
+const packageRoot = normalizePath(packageRootRaw);
+const sourceConfigDir = `${packageRoot}/config`;
+const distConfigDir = `${distDir}/config`;
 
 // `lism-css/<entry>.css`（bare specifier）を捕捉する。<entry> は base/set のようなスラッシュ入りも許す。
 const BARE_CSS_RE = /^lism-css\/(.+)\.css$/;
+const CONFIG_FILE_RE = /\.(?:js|mjs|ts)$/;
+
+const CORE_CONFIG_WATCH_RELS = [
+  'package.json',
+  'config/default-config.ts',
+  'config/helper.ts',
+  'config/index.ts',
+  'config/defaults/breakpoints.ts',
+  'config/defaults/props.ts',
+  'config/defaults/tokens.ts',
+  'config/defaults/traits.ts',
+  'config/presets/props-full.ts',
+  'dist/config/default-config.js',
+  'dist/config/helper.js',
+  'dist/config/defaults/breakpoints.js',
+  'dist/config/defaults/props.js',
+  'dist/config/defaults/tokens.js',
+  'dist/config/defaults/traits.js',
+  'dist/config/presets/props-full.js',
+];
+
+function coreConfigWatchFiles(): string[] {
+  return CORE_CONFIG_WATCH_RELS.map((rel) => path.join(packageRootRaw, rel)).filter((filePath) => fs.existsSync(filePath));
+}
+
+function isCoreCssSourceFile(file: string): boolean {
+  const normalized = normalizePath(file);
+  return normalized.startsWith(`${normalizePath(scssDir)}/`) && normalized.endsWith('.scss');
+}
+
+function isCoreConfigFile(file: string): boolean {
+  const normalized = normalizePath(file);
+  return (
+    (normalized.startsWith(`${sourceConfigDir}/`) && CONFIG_FILE_RE.test(normalized)) ||
+    (normalized.startsWith(`${distConfigDir}/`) && CONFIG_FILE_RE.test(normalized))
+  );
+}
+
+function isCoreDistCssFile(file: string): boolean {
+  const normalized = normalizePath(file);
+  return normalized.startsWith(`${cssDistDir}/`) && normalized.endsWith('.css');
+}
 
 export function lismDynamicCss(options: LismDynamicCssOptions = {}): Plugin {
   let root = '';
@@ -32,6 +80,12 @@ export function lismDynamicCss(options: LismDynamicCssOptions = {}): Plugin {
   function getCompiler(): CssCompiler {
     if (!compiler) compiler = createCssCompiler({ scssDir });
     return compiler;
+  }
+
+  function resetDynamicCssState(): void {
+    configs = null;
+    compiler?.dispose();
+    compiler = null;
   }
 
   async function getConfigs(): Promise<LoadedBuildConfigs> {
@@ -49,6 +103,21 @@ export function lismDynamicCss(options: LismDynamicCssOptions = {}): Plugin {
     const filePath = normalizePath(id.split('?')[0]);
     if (!filePath.startsWith(`${cssDistDir}/`) || !filePath.endsWith('.css')) return null;
     return filePath.slice(cssDistDir.length + 1, -'.css'.length);
+  }
+
+  async function watchCoreSources(ctx: { addWatchFile(file: string): void }, c: CssCompiler, cfg: LoadedBuildConfigs): Promise<void> {
+    if (cfg.userConfigPath) ctx.addWatchFile(cfg.userConfigPath);
+    for (const file of coreConfigWatchFiles()) ctx.addWatchFile(file);
+    for (const file of await c.sourceFiles()) ctx.addWatchFile(file);
+  }
+
+  async function collectAffectedCssModules(server: ViteDevServer): Promise<ModuleNode[]> {
+    const affected: ModuleNode[] = [];
+    for (const entry of await getCompiler().entries()) {
+      const mod = server.moduleGraph.getModuleById(idForEntry(entry));
+      if (mod) affected.push(mod);
+    }
+    return affected;
   }
 
   return {
@@ -75,22 +144,19 @@ export function lismDynamicCss(options: LismDynamicCssOptions = {}): Plugin {
       const c = getCompiler();
       if (!(await c.hasEntry(entry))) return null;
       const cfg = await getConfigs();
-      // lism.config.js を watch 対象に加える（build の watch / dev の HMR 双方）。
-      if (cfg.userConfigPath) this.addWatchFile(cfg.userConfigPath);
+      // core 開発中の SCSS / default config 変更も dev サーバー再起動なしで反映させる。
+      await watchCoreSources(this, c, cfg);
       return c.compile(entry, cfg.mainConfig, cfg.fullConfig);
     },
 
     async handleHotUpdate(ctx) {
       const cfgPath = configs?.userConfigPath;
-      if (!cfgPath || normalizePath(ctx.file) !== normalizePath(cfgPath)) return;
-      // lism.config.js が変わった: 設定を破棄して次回 load で再読込（mtime バストで新値を取得）。
-      // 作業ディレクトリは config 署名の変化に応じて compile 内で作り直される。
-      configs = null;
-      const affected = [];
-      for (const entry of await getCompiler().entries()) {
-        const mod = ctx.server.moduleGraph.getModuleById(idForEntry(entry));
-        if (mod) affected.push(mod);
-      }
+      const isUserConfig = !!cfgPath && normalizePath(ctx.file) === normalizePath(cfgPath);
+      if (!isUserConfig && !isCoreCssSourceFile(ctx.file) && !isCoreConfigFile(ctx.file) && !isCoreDistCssFile(ctx.file)) return;
+
+      const affected = await collectAffectedCssModules(ctx.server);
+      // 設定・SCSS・dist CSS のどれが変わっても、次回 load で必ず読み直す。
+      resetDynamicCssState();
       ctx.server.ws.send({ type: 'full-reload' });
       return affected;
     },

--- a/packages/plugin/src/builder/load-config.ts
+++ b/packages/plugin/src/builder/load-config.ts
@@ -9,10 +9,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
-import defaultConfig from 'lism-css/default-config';
-import propsFull from 'lism-css/config/presets/props-full';
-import { objDeepMerge } from 'lism-css/config/helper';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { BuildConfig, PropConfig } from './serialize';
 
 export type ObjDeepMerge = (origin: Record<string, unknown>, source: Record<string, unknown>) => Record<string, unknown>;
@@ -23,6 +20,44 @@ const FULL_CSS_DEFAULTS = {
   // userConfig はこの後にマージするため、lism.config.js の breakpoints.xs が最後に勝つ。
   breakpoints: { xs: '360px' },
 } satisfies Record<string, unknown>;
+
+type DefaultModule<T> = { default: T };
+type HelperModule = { objDeepMerge: ObjDeepMerge };
+
+async function importFreshModule<T>(specifier: string): Promise<T> {
+  const resolved = import.meta.resolve(specifier);
+  if (!resolved.startsWith('file:')) return (await import(specifier)) as T;
+
+  const filePath = fileURLToPath(resolved);
+  const mtime = fs.statSync(filePath).mtimeMs;
+  return (await import(`${pathToFileURL(filePath).href}?v=${mtime}`)) as T;
+}
+
+async function loadCoreBuildDeps(): Promise<{
+  defaultConfig: BuildConfig;
+  propsFull: Record<string, PropConfig>;
+  objDeepMerge: ObjDeepMerge;
+}> {
+  const [tokens, props, traits, breakpoints, propsFullMod, helper] = await Promise.all([
+    importFreshModule<DefaultModule<BuildConfig['tokens']>>('lism-css/config/defaults/tokens'),
+    importFreshModule<DefaultModule<BuildConfig['props']>>('lism-css/config/defaults/props'),
+    importFreshModule<DefaultModule<BuildConfig['traits']>>('lism-css/config/defaults/traits'),
+    importFreshModule<DefaultModule<BuildConfig['breakpoints']>>('lism-css/config/defaults/breakpoints'),
+    importFreshModule<DefaultModule<Record<string, PropConfig>>>('lism-css/config/presets/props-full'),
+    importFreshModule<HelperModule>('lism-css/config/helper'),
+  ]);
+
+  return {
+    defaultConfig: {
+      tokens: tokens.default,
+      props: props.default,
+      traits: traits.default,
+      breakpoints: breakpoints.default,
+    },
+    propsFull: propsFullMod.default,
+    objDeepMerge: helper.objDeepMerge,
+  };
+}
 
 export interface LoadedBuildConfigs {
   /** main 系（main.css / 個別レイヤ）が読む prop-config の元 CONFIG。isFullMode 時は fullConfig と同一。 */
@@ -102,9 +137,10 @@ export async function loadBuildConfigs(projectRoot: string, opts: LoadBuildConfi
     userConfig = userMod.default ?? {};
   }
 
+  const { defaultConfig, propsFull, objDeepMerge } = await loadCoreBuildDeps();
   const { mainConfig, fullConfig, isFullMode } = computeBuildConfigs({
-    defaultConfig: defaultConfig as unknown as BuildConfig,
-    propsFull: propsFull as Record<string, PropConfig>,
+    defaultConfig,
+    propsFull,
     userConfig,
     objDeepMerge,
   });

--- a/turbo.json
+++ b/turbo.json
@@ -4,10 +4,29 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!src/scss/_prop-config.gen.scss",
+        "!src/scss/_prop-config-full.gen.scss",
+        "!src/scss/base/tokens/_tokens.gen.scss"
+      ],
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "dist/**",
+        "src/scss/_prop-config.gen.scss",
+        "src/scss/_prop-config-full.gen.scss",
+        "src/scss/base/tokens/_tokens.gen.scss"
+      ]
     },
     "build:css": {
-      "outputs": ["dist/css/**"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!src/scss/_prop-config.gen.scss",
+        "!src/scss/_prop-config-full.gen.scss",
+        "!src/scss/base/tokens/_tokens.gen.scss"
+      ],
+      "outputs": ["dist/css/**", "src/scss/_prop-config.gen.scss", "src/scss/_prop-config-full.gen.scss", "src/scss/base/tokens/_tokens.gen.scss"]
     },
     "test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Problem
`apps/docs`では`lism-css/main.css`を読み込んでいますが、dev中の更新経路が2つに分かれていました。

`lismCss()`有効時は、`@lism-css/plugin`の`dynamic-css`が`lism-css/main.css`を横取りしてオンザフライ生成CSSを返します。この経路では`lism.config.js`以外のcore SCSS/default config変更をwatchしておらず、CSS生成結果もキャッシュされていたため、`tokens.ts`変更や`build:core`後のCSS更新がdev再起動まで反映されませんでした。

`lismCss()`無効時は、`dist/css/main.css`の実ファイルを読む状態になりますが、`packages/lism-css/dist/css`がdocs devの通常watch対象外だったため、`build:core`でCSSが更新されてもVite側のCSSモジュールがinvalidateされませんでした。別のSCSSファイルを触ると反映されたのは、その変更が偶然キャッシュ破棄のトリガーになっていたためです。

## Summary
- `lismCss()`有効時にcore SCSS/default config/dist CSS変更をwatchし、動的CSSキャッシュを破棄してfull reloadするようにしました。
- `lismCss()`無効時でもdocs devが`packages/lism-css/dist/css`更新を拾ってreloadするwatchを追加しました。
- default config読み込みをmtime付きdynamic importへ変更し、`tokens.ts`変更後の`build:core`結果がdev再起動なしで反映されるようにしました。

## Verification
- `nr --filter @lism-css/plugin typecheck`
- `cd packages/plugin && nr test src/builder/load-config.test.ts src/builder/dynamic-css.test.ts`
- `nr --filter lism-docs typecheck`
- `nr build:plugin`

対象テスト・typecheckは通過、`nr build:plugin`も成功しています。

## Notes
`nr --filter @lism-css/plugin test`全体は既存の`fs.watch`系テスト2件（`config-watcher.test.ts`・`next.test.ts`）で失敗する可能性があります。これらは今回の変更対象外で、変更対象テストとtypecheckは通過しています。

---

## 実装後確認した挙動
  - lismCss()使っている時: tokens.ts編集時→build:core ですぐに反映される。.scss編集時→すぐに反映される
  - lismCss()使っていない時: どちらでもbuild:core 後にリロードで反映される


🤖 Generated with [Claude Code](https://claude.com/claude-code)
