### PR TITLE
fix: lism create の workspace:* 置換を npm レジストリの latest 解決方式へ変更 (#447)

### DIFF
--- a/documents/cli-guide.md
+++ b/documents/cli-guide.md
@@ -35,7 +35,7 @@ nr publish:cli  # build → lism-cli publish → create-lism publish
 ```
 
 - `lism-cli` と `create-lism` は **同じバージョンで一緒に** publish する
-- `lism create` で生成されるプロジェクトの `lism-css: workspace:*` は tsup の `define` で埋め込んだ `__LISM_CSS_VERSION__`（`packages/lism-css/package.json` の version）に置換される。**lism-css リリース後は CLI も rebuild & publish しないと新規プロジェクトが古い lism-css を引く**
+- `lism create` で生成されるプロジェクトの `workspace:*` は npm レジストリの dist-tag `latest` を実行時に解決して `^x.y.z` へ置換される。レジストリ到達不可時だけ、tsup の `define` で埋め込んだ `LISM_PACKAGE_VERSIONS` にフォールバックする
 - `packages/lism-ui/registry-index.json` は **commit 対象**。コンポーネント増減時は `pnpm --filter @lism-css/ui build` で再生成して commit する
 - 検証目的の beta publish でも `DEFAULT_*_REF` を PR ブランチに固定しないこと（壊れる）。検証時は CLI 側の `--ref` フラグで都度指定する
 

--- a/packages/lism-cli/src/commands/create.test.ts
+++ b/packages/lism-cli/src/commands/create.test.ts
@@ -74,6 +74,35 @@ function writeFile(filePath: string, content: string): void {
   fs.writeFileSync(filePath, content);
 }
 
+/** registry の <pkg>/latest を引く URL（スコープ名はスラッシュのみ %2F にエンコード） */
+function registryLatestUrl(name: string): string {
+  return `https://registry.npmjs.org/${name.replace(/\//g, '%2F')}/latest`;
+}
+
+/** fetch モック用の最小 Response。コード側は res.ok と res.json() のみ参照する */
+function fetchResponse(ok: boolean, body: unknown): Response {
+  return { ok, status: ok ? 200 : 404, json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+/** lism-css / @lism-css/ui（deps）+ @lism-css/plugin（devDeps）を workspace:* で持つテンプレ */
+function mockTemplateWithWorkspaceDeps(): void {
+  vi.mocked(downloadTemplate).mockImplementation((_source, options) => {
+    const dir = (options as { dir: string }).dir;
+    fs.mkdirSync(dir, { recursive: true });
+    writePackageJson(dir, {
+      name: 'lp-astro',
+      dependencies: {
+        'lism-css': 'workspace:*',
+        '@lism-css/ui': 'workspace:*',
+      },
+      devDependencies: {
+        '@lism-css/plugin': 'workspace:*',
+      },
+    });
+    return Promise.resolve({} as Awaited<ReturnType<typeof downloadTemplate>>);
+  });
+}
+
 describe('runCreate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -85,6 +114,8 @@ describe('runCreate', () => {
     process.chdir(tmpDir);
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    // レジストリ取得は既定でオフライン扱い（焼き込み値フォールバック）。テストはネットワークへ出ない。
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
     vi.mocked(downloadTemplate).mockImplementation((_source, options) => {
       const dir = (options as { dir: string }).dir;
       fs.mkdirSync(dir, { recursive: true });
@@ -97,6 +128,7 @@ describe('runCreate', () => {
     process.chdir(cwd);
     fs.rmSync(tmpDir, { recursive: true, force: true });
     setStdinTTY(originalIsTTY);
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -118,22 +150,36 @@ describe('runCreate', () => {
     expect(pkg.dependencies['lism-css']).not.toBe('workspace:*');
   });
 
-  it('workspace依存は依存名ごとの公開versionへ置換する', async () => {
-    vi.mocked(downloadTemplate).mockImplementation((_source, options) => {
-      const dir = (options as { dir: string }).dir;
-      fs.mkdirSync(dir, { recursive: true });
-      writePackageJson(dir, {
-        name: 'lp-astro',
-        dependencies: {
-          'lism-css': 'workspace:*',
-          '@lism-css/ui': 'workspace:*',
-        },
-        devDependencies: {
-          '@lism-css/plugin': 'workspace:*',
-        },
-      });
-      return Promise.resolve({} as Awaited<ReturnType<typeof downloadTemplate>>);
+  it('workspace依存をnpmレジストリのlatestへ置換する', async () => {
+    mockTemplateWithWorkspaceDeps();
+    const latest: Record<string, string> = {
+      'lism-css': '9.1.0',
+      '@lism-css/ui': '9.2.0',
+      '@lism-css/plugin': '9.3.0',
+    };
+    // dist-tag latest（= 安定版）を引くので prerelease は誤って選ばれない
+    const fetchMock = vi.fn((url: string | URL) => {
+      const name = Object.keys(latest).find((n) => String(url) === registryLatestUrl(n));
+      return Promise.resolve(fetchResponse(Boolean(name), name ? { version: latest[name] } : {}));
     });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await runCreate({ template: 'minimal-astro', targetDir: 'my-app', force: true });
+
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'my-app', 'package.json'), 'utf-8')) as {
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    expect(pkg.dependencies['lism-css']).toBe('^9.1.0');
+    expect(pkg.dependencies['@lism-css/ui']).toBe('^9.2.0');
+    expect(pkg.devDependencies['@lism-css/plugin']).toBe('^9.3.0');
+    // スコープ付きはスラッシュのみ %2F にエンコードして /latest を引く
+    expect(fetchMock).toHaveBeenCalledWith('https://registry.npmjs.org/@lism-css%2Fui/latest', expect.anything());
+  });
+
+  it('レジストリ到達不可時はCLI焼き込み版へフォールバックする', async () => {
+    mockTemplateWithWorkspaceDeps();
+    // fetch は beforeEach の既定（offline 拒否）のまま
 
     await runCreate({ template: 'minimal-astro', targetDir: 'my-app', force: true });
 
@@ -144,6 +190,26 @@ describe('runCreate', () => {
     expect(pkg.dependencies['lism-css']).toBe('^1.2.3');
     expect(pkg.dependencies['@lism-css/ui']).toBe('^2.3.4');
     expect(pkg.devDependencies['@lism-css/plugin']).toBe('^3.4.5');
+  });
+
+  it('一部依存がレジストリで取得できない場合、その依存だけ焼き込み版へフォールバックする', async () => {
+    mockTemplateWithWorkspaceDeps();
+    const fetchMock = vi.fn((url: string | URL) => {
+      // lism-css は取得成功、それ以外（ui / plugin）は 404
+      if (String(url) === registryLatestUrl('lism-css')) return Promise.resolve(fetchResponse(true, { version: '9.9.9' }));
+      return Promise.resolve(fetchResponse(false, {}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await runCreate({ template: 'minimal-astro', targetDir: 'my-app', force: true });
+
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmpDir, 'my-app', 'package.json'), 'utf-8')) as {
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    expect(pkg.dependencies['lism-css']).toBe('^9.9.9'); // registry latest
+    expect(pkg.dependencies['@lism-css/ui']).toBe('^2.3.4'); // 404 → 焼き込み値
+    expect(pkg.devDependencies['@lism-css/plugin']).toBe('^3.4.5'); // 404 → 焼き込み値
   });
 
   it('stackが1件だけなら選択をスキップして自動確定する', async () => {

--- a/packages/lism-cli/src/commands/create.ts
+++ b/packages/lism-cli/src/commands/create.ts
@@ -5,7 +5,7 @@ import { downloadTemplate } from 'giget';
 import { select, input, confirm } from '@inquirer/prompts';
 import { logger } from '../logger.js';
 import { LISM_PACKAGE_VERSIONS } from '../version.js';
-import { DEFAULT_TEMPLATES_REF, SOURCE_REPO, TEMPLATES_PATH } from '../constants.js';
+import { DEFAULT_TEMPLATES_REF, NPM_REGISTRY_BASE, SOURCE_REPO, TEMPLATES_PATH } from '../constants.js';
 import { setLang, t, tOf, type Lang } from '../i18n.js';
 import type { MessageKey } from '../messages.js';
 import {
@@ -118,7 +118,7 @@ export async function runCreateWithTemplates({ template, targetDir, force = fals
 
   ensureTemplateDownloaded(outDir, tpl);
 
-  postProcessTemplate(outDir, tpl, resolvedLang);
+  await postProcessTemplate(outDir, tpl, resolvedLang);
 
   logger.success(t('create.created', { dir: outDir }));
   printNextSteps(outDir, tpl);
@@ -299,7 +299,7 @@ async function applyLangOverlay(tpl: TemplateDef, outDir: string, ref: string, l
   }
 }
 
-function postProcessTemplate(projectDir: string, tpl: TemplateDef, lang: Lang): void {
+async function postProcessTemplate(projectDir: string, tpl: TemplateDef, lang: Lang): Promise<void> {
   if (tpl.kind === 'static-html') return;
 
   if (tpl.kind === 'base-overlay' && tpl.rewritePackageName !== false) {
@@ -315,7 +315,7 @@ function postProcessTemplate(projectDir: string, tpl: TemplateDef, lang: Lang): 
   cleanupDevArtifacts(projectDir);
 
   // workspace:* を公開バージョンに書き換える
-  rewriteWorkspaceDeps(projectDir);
+  await rewriteWorkspaceDeps(projectDir);
 }
 
 /**
@@ -557,33 +557,108 @@ function rewritePackageName(projectDir: string, name: string): void {
   }
 }
 
+/** package.json 内で `workspace:*` 依存が現れ得るセクション */
+const DEP_SECTIONS = ['dependencies', 'devDependencies', 'peerDependencies'] as const;
+
+/** npm レジストリへの問い合わせタイムアウト（ms）。生成体験を遅くしないための保険。 */
+const REGISTRY_TIMEOUT_MS = 5000;
+
 /**
  * 取得後の package.json 内の `workspace:*` 依存を、依存パッケージごとの公開バージョンに書き換える。
+ *
+ * バージョンは npm レジストリの dist-tag `latest`（＝安定版）を解決して使う。これにより `lism-css` 等を
+ * publish するだけで `lism create` が最新版を取得でき、CLI 自体を再公開する必要がなくなる。
+ * レジストリへ到達できない場合（オフライン / 障害 / 404 / タイムアウト）は、CLI ビルド時に焼き込んだ
+ * `LISM_PACKAGE_VERSIONS` へ依存ごとに個別フォールバックする。いずれも書式は `^x.y.z`。
+ *
  * 失敗しても警告に留め、生成自体は続行する（Best Effort）。
  */
-function rewriteWorkspaceDeps(projectDir: string): void {
+async function rewriteWorkspaceDeps(projectDir: string): Promise<void> {
   const pkgPath = path.join(projectDir, 'package.json');
   if (!fs.existsSync(pkgPath)) return;
   try {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as PackageJson;
-    let touched = false;
-    const fallbackVersion = LISM_PACKAGE_VERSIONS['lism-css'] ?? 'unknown';
-    for (const key of ['dependencies', 'devDependencies', 'peerDependencies'] as const) {
-      const deps = pkg[key];
+
+    // 置換対象（workspace:* 依存）のパッケージ名を収集
+    const names = new Set<string>();
+    for (const section of DEP_SECTIONS) {
+      const deps = pkg[section];
       if (!deps) continue;
       for (const [name, value] of Object.entries(deps)) {
-        if (typeof value !== 'string') continue;
-        if (value.startsWith('workspace:')) {
-          deps[name] = `^${LISM_PACKAGE_VERSIONS[name] ?? fallbackVersion}`;
+        if (typeof value === 'string' && value.startsWith('workspace:')) names.add(name);
+      }
+    }
+    if (names.size === 0) return;
+
+    // 対象を並列でバージョン解決（レジストリ latest → 失敗時は焼き込み値）
+    const versions = await resolveWorkspaceVersions([...names]);
+
+    let touched = false;
+    for (const section of DEP_SECTIONS) {
+      const deps = pkg[section];
+      if (!deps) continue;
+      for (const [name, value] of Object.entries(deps)) {
+        if (typeof value === 'string' && value.startsWith('workspace:')) {
+          deps[name] = `^${versions[name]}`;
           touched = true;
         }
       }
     }
+
     if (touched) {
       fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
       logger.log(t('create.workspaceReplaced'));
     }
   } catch (err) {
     logger.warn(t('create.workspaceFailed', { reason: String(err) }));
+  }
+}
+
+/**
+ * 依存名ごとに公開バージョンを解決する（全件並列）。返り値は常に全 name を含む。
+ */
+async function resolveWorkspaceVersions(names: string[]): Promise<Record<string, string>> {
+  const entries = await Promise.all(names.map(async (name) => [name, await resolveDepVersion(name)] as const));
+  return Object.fromEntries(entries);
+}
+
+/** CLI ビルド時に焼き込んだフォールバック版数（未知依存は lism-css の版に寄せる従来挙動を踏襲）。 */
+function bakedVersion(name: string): string {
+  return LISM_PACKAGE_VERSIONS[name] ?? LISM_PACKAGE_VERSIONS['lism-css'] ?? 'unknown';
+}
+
+/**
+ * 単一依存の公開バージョンを解決する。
+ *
+ * CLI が把握している公開 Lism パッケージ（＝焼き込み済み）のみレジストリへ問い合わせ、latest を採用する。
+ * 未知の workspace 依存は、無関係な npm パッケージを誤って引かないようレジストリへ問い合わせず焼き込み値を返す。
+ * レジストリ取得に失敗した場合も焼き込み値へフォールバックする。
+ */
+async function resolveDepVersion(name: string): Promise<string> {
+  const baked = bakedVersion(name);
+  if (!LISM_PACKAGE_VERSIONS[name]) return baked;
+  const latest = await fetchLatestVersion(name);
+  return latest ?? baked;
+}
+
+/**
+ * npm レジストリの `<pkg>/latest`（dist-tag latest ＝ 安定版）から version を取得する。
+ *
+ * パッケージ全体の最新 version を見ると prerelease を拾う恐れがあるため、必ず `/latest` を使う。
+ * スコープ名はスラッシュのみ `%2F` にエンコードする（`@lism-css/ui` → `@lism-css%2Fui`）。
+ * 失敗（オフライン / タイムアウト / 非 2xx / 不正レスポンス）時は null を返し、呼び出し側でフォールバックする。
+ */
+async function fetchLatestVersion(name: string): Promise<string | null> {
+  const url = `${NPM_REGISTRY_BASE}/${name.replace(/\//g, '%2F')}/latest`;
+  try {
+    const res = await fetch(url, {
+      headers: { accept: 'application/json' },
+      signal: AbortSignal.timeout(REGISTRY_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version?: unknown };
+    return typeof data.version === 'string' ? data.version : null;
+  } catch {
+    return null;
   }
 }

--- a/packages/lism-cli/src/commands/ui/fetcher.ts
+++ b/packages/lism-cli/src/commands/ui/fetcher.ts
@@ -75,11 +75,14 @@ function isExcludedComponentFile(rel: string, excludeRootFiles: ReadonlySet<stri
   return false;
 }
 
+/** raw GitHub からの取得タイムアウト（ms）。ネットワーク不調時に CLI が無限待ちしないための保険。 */
+const FETCH_TIMEOUT_MS = 5000;
+
 /** カタログ（registry-index.json）を raw GitHub から取得 */
 export async function fetchCatalog(options: FetchOptions = {}): Promise<RegistryCatalog> {
   const ref = options.ref ?? DEFAULT_UI_REF;
   const url = `${RAW_GITHUB_BASE}/${SOURCE_REPO}/${ref}/${UI_REGISTRY_INDEX_PATH}`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
   if (!res.ok) {
     throw new Error(`Failed to fetch registry-index.json (${res.status} ${res.statusText}): ${url}`);
   }

--- a/packages/lism-cli/src/constants.ts
+++ b/packages/lism-cli/src/constants.ts
@@ -3,6 +3,7 @@
  *
  * ここに置く対象:
  * - GitHub の取得元（リポジトリ名 / raw base URL / リポジトリ内パス）
+ * - npm レジストリの base URL（公開バージョン解決に使用）
  * - giget で参照する ref のデフォルト値
  *
  * 注: ユーザーが触る `lism.config.js` の設定とは別物。ユーザー設定は config.ts を参照。
@@ -13,6 +14,9 @@ export const SOURCE_REPO = 'lism-css/lism-css';
 
 /** raw GitHub の base URL（生ファイル fetch に使用） */
 export const RAW_GITHUB_BASE = 'https://raw.githubusercontent.com';
+
+/** npm レジストリの base URL（`lism create` の workspace:* 置換時に公開最新版を解決するのに使用） */
+export const NPM_REGISTRY_BASE = 'https://registry.npmjs.org';
 
 // -----------------------------------------------------------------------------
 // Default refs


### PR DESCRIPTION
## 概要

`lism create` の `workspace:*` 置換を、**npm レジストリの `latest` 解決方式**へ変更しました。Closes #447

従来は CLI ビルド時に焼き込んだ版数（`^x.y.z`）を書き込んでいたため、0.x の caret 仕様（`^0.22.2` = `>=0.22.2 <0.23.0`）でマイナー更新に追従できず、feat リリースのたびに `lism-cli` / `create-lism` の再公開が必要でした。本変更により実行時にレジストリの公開最新版を取得するため、`lism-css` 等を publish するだけで新規生成プロジェクトに最新版が入り、**CLI の再公開が不要**になります。

## 変更内容

- `rewriteWorkspaceDeps` を async 化し、`postProcessTemplate` → `runCreateWithTemplates` まで `await` で接続
- `workspace:*` 依存を npm レジストリの dist-tag `latest`（`https://registry.npmjs.org/<pkg>/latest`）で**並列解決**し `^x.y.z` を書き込む
- 取得失敗（オフライン / 非2xx / 404 / 5s タイムアウト）時は、CLI 焼き込み値 `LISM_PACKAGE_VERSIONS` へ**依存ごとに個別フォールバック**（Best Effort、生成は継続）
- レジストリ問い合わせは**既知の Lism 公開パッケージ**（焼き込み済み）に限定。未知の `workspace:*` 依存は無関係な npm パッケージを誤取得しないよう従来どおり焼き込み値を使用
- スコープ名はスラッシュのみ `%2F` にエンコード（`@lism-css/ui` → `@lism-css%2Fui`）
- `constants.ts` に `NPM_REGISTRY_BASE` を追加。`tsup` の版数焼き込み（define）はオフライン保険として**維持**

## 受け入れ条件

- [x] `lism create` 後の `package.json` で 3パッケージがその時点の npm 公開最新版の `^x.y.z` になる
- [x] レジストリ到達不可時は CLI 焼き込み値の `^x.y.z` にフォールバックして生成完了
- [x] feat リリース後、CLI 再公開なしで新版が入る（実行時にレジストリ解決するため）
- [x] prerelease が誤選択されない（`/latest` dist-tag を使用）
- [x] `create.test.ts` を更新（レジストリ取得をモックし、成功 / 失敗フォールバック両方を検証）

## テスト

`create.test.ts` の既定 `fetch` をオフラインスタブ化（全テストを非ネットワーク化）し、3 ケースを追加：

- **成功**：レジストリ `latest` を返し `^9.x` へ置換。スコープ名の `%2F` エンコードを検証
- **全失敗フォールバック**：`fetch` 拒否 → 焼き込み値 `^1.2.3` 等
- **部分フォールバック**：一部のみ 404 → その依存だけ焼き込み値

```
pnpm --filter lism-cli test   # 70 passed
pnpm build:cli                # DTS 型検査含め成功
pnpm exec eslint <changed>    # clean / prettier clean
```

> 注: `create.test.ts` のテンプレフィクスチャに `title` 欠落の既存型エラー（本PR対象外）があります。cli は turbo の `typecheck`/`lint` タスク未設定で、`tsup` ビルドは `lib.ts` のみ型検査するため正規チェックには影響しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
