### PR TITLE
fix(lism-cli): lism.config の ui セクション運用を自動書き換えから手動案内方式に変更

### DIFF
--- a/packages/lism-cli/src/commands/ui/add.test.ts
+++ b/packages/lism-cli/src/commands/ui/add.test.ts
@@ -84,7 +84,7 @@ describe('addCommand', () => {
     // lism.config.js は書き換えられない
     expect(fs.readFileSync(path.join(tmpDir, 'lism.config.js'), 'utf-8')).toBe(original);
     // 末尾にスニペット案内が出る
-    expect(infoSpy.mock.calls.some((call) => String(call[0]).includes('ui: {'))).toBe(true);
+    expect(infoSpy.mock.calls.some((call: unknown[]) => String(call[0]).includes('ui: {'))).toBe(true);
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
@@ -99,7 +99,7 @@ describe('addCommand', () => {
     expect(select).not.toHaveBeenCalled();
     expect(input).not.toHaveBeenCalled();
     expect(fs.existsSync(path.join(tmpDir, 'src/components/ui/Button/Button.astro'))).toBe(true);
-    expect(infoSpy.mock.calls.some((call) => String(call[0]).includes('ui: {'))).toBe(false);
+    expect(infoSpy.mock.calls.some((call: unknown[]) => String(call[0]).includes('ui: {'))).toBe(false);
   });
 
   it('--framework 指定時は select がスキップされる', async () => {

--- a/packages/lism-cli/src/commands/ui/add.test.ts
+++ b/packages/lism-cli/src/commands/ui/add.test.ts
@@ -120,4 +120,16 @@ describe('addCommand', () => {
     expect(exitSpy).not.toHaveBeenCalled();
     expect(fs.existsSync(path.join(tmpDir, 'src/components/ui/Button/Button.jsx'))).toBe(true);
   });
+
+  it('既存ファイルが lism.config.mjs の場合、スニペット案内のファイル名も lism.config.mjs になる', async () => {
+    writeFile(path.join(tmpDir, 'lism.config.mjs'), "export default { tokens: { space: ['10', '20'] } };\n");
+    vi.mocked(select).mockResolvedValue('react');
+    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
+
+    await addCommand(['Button'], { overwrite: false, all: false });
+
+    const guidance = infoSpy.mock.calls.map((call: unknown[]) => String(call[0])).find((msg) => msg.includes('ui: {'));
+    expect(guidance).toContain('lism.config.mjs');
+    expect(guidance).not.toContain('lism.config.js');
+  });
 });

--- a/packages/lism-cli/src/commands/ui/add.test.ts
+++ b/packages/lism-cli/src/commands/ui/add.test.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { select, input } from '@inquirer/prompts';
+import { setLang } from '../../i18n';
+import { logger } from '../../logger';
+import { addCommand } from './add';
+import type { RegistryCatalog, RegistryComponent } from './fetcher';
+
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn(),
+  input: vi.fn(),
+  confirm: vi.fn(),
+}));
+
+vi.mock('./fetcher.js', () => ({
+  fetchCatalog: vi.fn(),
+  fetchComponent: vi.fn(),
+  fetchHelper: vi.fn(),
+}));
+
+const cwd = process.cwd();
+let tmpDir: string;
+let infoSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+const catalog: RegistryCatalog = {
+  version: '1',
+  excludeComponentFiles: [],
+  components: [{ name: 'Button', helpers: [] }],
+  helpers: [],
+};
+
+const buttonComponent: RegistryComponent = {
+  name: 'Button',
+  helpers: [],
+  files: {
+    shared: [],
+    react: [{ path: 'Button.jsx', content: 'export default function Button() {}\n' }],
+    astro: [{ path: 'Button.astro', content: '<button></button>\n' }],
+  },
+};
+
+beforeEach(async () => {
+  setLang('en');
+  vi.clearAllMocks();
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'lism-add-')));
+  process.chdir(tmpDir);
+  infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+  vi.spyOn(logger, 'success').mockImplementation(() => undefined);
+  vi.spyOn(logger, 'log').mockImplementation(() => undefined);
+  vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  const fetcher = await import('./fetcher.js');
+  vi.mocked(fetcher.fetchCatalog).mockResolvedValue(catalog);
+  vi.mocked(fetcher.fetchComponent).mockResolvedValue(buttonComponent);
+});
+
+afterEach(() => {
+  process.chdir(cwd);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('addCommand', () => {
+  it('ui セクションが無い場合、対話で値を収集してメモリ上の値で配置し、ファイルは書き換えない', async () => {
+    const original = "export default { tokens: { space: ['10', '20'] } };\n";
+    writeFile(path.join(tmpDir, 'lism.config.js'), original);
+    vi.mocked(select).mockResolvedValue('react');
+    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
+
+    await addCommand(['Button'], { overwrite: false, all: false });
+
+    expect(select).toHaveBeenCalledTimes(1);
+    // 配置はメモリ上の値で行われる
+    expect(fs.existsSync(path.join(tmpDir, 'src/components/ui/Button/Button.jsx'))).toBe(true);
+    // lism.config.js は書き換えられない
+    expect(fs.readFileSync(path.join(tmpDir, 'lism.config.js'), 'utf-8')).toBe(original);
+    // 末尾にスニペット案内が出る
+    expect(infoSpy.mock.calls.some((call) => String(call[0]).includes('ui: {'))).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('ui セクションが既にある場合、prompt は呼ばれずスニペット案内も出ない', async () => {
+    writeFile(
+      path.join(tmpDir, 'lism.config.js'),
+      "export default { ui: { framework: 'astro', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' } };\n"
+    );
+
+    await addCommand(['Button'], { overwrite: false, all: false });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(input).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tmpDir, 'src/components/ui/Button/Button.astro'))).toBe(true);
+    expect(infoSpy.mock.calls.some((call) => String(call[0]).includes('ui: {'))).toBe(false);
+  });
+
+  it('--framework 指定時は select がスキップされる', async () => {
+    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
+
+    await addCommand(['Button'], { overwrite: false, all: false, framework: 'react' });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tmpDir, 'src/components/ui/Button/Button.jsx'))).toBe(true);
+  });
+
+  it('設定ファイルが全く無い場合でも未捕捉エラーにならず、対話にフォールバックする（旧バグの再発防止）', async () => {
+    vi.mocked(select).mockResolvedValue('react');
+    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
+
+    await addCommand(['Button'], { overwrite: false, all: false });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tmpDir, 'src/components/ui/Button/Button.jsx'))).toBe(true);
+  });
+});

--- a/packages/lism-cli/src/commands/ui/add.test.ts
+++ b/packages/lism-cli/src/commands/ui/add.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { select, input } from '@inquirer/prompts';
+import { select } from '@inquirer/prompts';
 import { setLang } from '../../i18n';
 import { logger } from '../../logger';
 import { addCommand } from './add';
@@ -10,7 +10,6 @@ import type { RegistryCatalog, RegistryComponent } from './fetcher';
 
 vi.mock('@inquirer/prompts', () => ({
   select: vi.fn(),
-  input: vi.fn(),
   confirm: vi.fn(),
 }));
 
@@ -70,16 +69,15 @@ afterEach(() => {
 });
 
 describe('addCommand', () => {
-  it('ui セクションが無い場合、対話で値を収集してメモリ上の値で配置し、ファイルは書き換えない', async () => {
+  it('ui セクションが無い場合、framework のみ対話で収集してメモリ上の値で配置し、ファイルは書き換えない', async () => {
     const original = "export default { tokens: { space: ['10', '20'] } };\n";
     writeFile(path.join(tmpDir, 'lism.config.js'), original);
     vi.mocked(select).mockResolvedValue('react');
-    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
 
     await addCommand(['Button'], { overwrite: false, all: false });
 
     expect(select).toHaveBeenCalledTimes(1);
-    // 配置はメモリ上の値で行われる
+    // 配置はメモリ上の値（componentsDir/helperDirは既定値）で行われる
     expect(fs.existsSync(path.join(tmpDir, 'src/components/ui/Button/Button.jsx'))).toBe(true);
     // lism.config.js は書き換えられない
     expect(fs.readFileSync(path.join(tmpDir, 'lism.config.js'), 'utf-8')).toBe(original);
@@ -97,23 +95,34 @@ describe('addCommand', () => {
     await addCommand(['Button'], { overwrite: false, all: false });
 
     expect(select).not.toHaveBeenCalled();
-    expect(input).not.toHaveBeenCalled();
     expect(fs.existsSync(path.join(tmpDir, 'src/components/ui/Button/Button.astro'))).toBe(true);
     expect(infoSpy.mock.calls.some((call: unknown[]) => String(call[0]).includes('ui: {'))).toBe(false);
   });
 
-  it('--framework 指定時は select がスキップされる', async () => {
-    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
-
+  it('--framework のみ指定すれば、componentsDir/helperDir のフラグが無くても完全に非対話で完走する', async () => {
     await addCommand(['Button'], { overwrite: false, all: false, framework: 'react' });
 
     expect(select).not.toHaveBeenCalled();
     expect(fs.existsSync(path.join(tmpDir, 'src/components/ui/Button/Button.jsx'))).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('--components-dir / --helper-dir を指定すると、その値で配置され既定値は使われない', async () => {
+    await addCommand(['Button'], {
+      overwrite: false,
+      all: false,
+      framework: 'react',
+      componentsDir: 'custom/ui',
+      helperDir: 'custom/ui/_helper',
+    });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tmpDir, 'custom/ui/Button/Button.jsx'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'src/components/ui/Button/Button.jsx'))).toBe(false);
   });
 
   it('設定ファイルが全く無い場合でも未捕捉エラーにならず、対話にフォールバックする（旧バグの再発防止）', async () => {
     vi.mocked(select).mockResolvedValue('react');
-    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
 
     await addCommand(['Button'], { overwrite: false, all: false });
 
@@ -124,7 +133,6 @@ describe('addCommand', () => {
   it('既存ファイルが lism.config.mjs の場合、スニペット案内のファイル名も lism.config.mjs になる', async () => {
     writeFile(path.join(tmpDir, 'lism.config.mjs'), "export default { tokens: { space: ['10', '20'] } };\n");
     vi.mocked(select).mockResolvedValue('react');
-    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
 
     await addCommand(['Button'], { overwrite: false, all: false });
 

--- a/packages/lism-cli/src/commands/ui/add.ts
+++ b/packages/lism-cli/src/commands/ui/add.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { confirm, select } from '@inquirer/prompts';
-import { configExists, readConfig } from '../../config.js';
+import { readConfig, renderUiSnippet, DEFAULT_CONFIG_FILENAME } from '../../config.js';
 import {
   fetchCatalog,
   fetchComponent,
@@ -12,7 +12,7 @@ import {
   type RegistryFile,
 } from './fetcher.js';
 import { resolveHelperPlaceholder } from '../../transform.js';
-import { runInit } from './init.js';
+import { promptUiConfig } from './promptUiConfig.js';
 import { logger } from '../../logger.js';
 import { normalizeComponentName } from './normalize.js';
 import type { LismCliConfig } from '../../config.js';
@@ -22,6 +22,7 @@ interface AddOptions {
   overwrite: boolean;
   all: boolean;
   ref?: string;
+  framework?: LismCliConfig['framework'];
 }
 
 /** 上書き方針 */
@@ -29,13 +30,21 @@ type OverwritePolicy = 'all' | 'none' | 'per-component';
 
 export async function addCommand(names: string[], options: AddOptions): Promise<void> {
   let config: LismCliConfig;
+  let needsGuidance = false;
 
-  if (configExists()) {
-    config = await readConfig();
-  } else {
-    logger.info(t('ui.add.noConfig'));
-    config = await runInit();
-    console.log();
+  try {
+    const existing = await readConfig();
+    if (existing) {
+      config = existing;
+    } else {
+      needsGuidance = true;
+      logger.info(t('ui.add.noConfig'));
+      config = await promptUiConfig({ framework: options.framework });
+      console.log();
+    }
+  } catch (err) {
+    logger.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
   }
 
   const fetchOpts: FetchOptions = { ref: options.ref };
@@ -101,6 +110,10 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
     }
     const helperFailed = await writeComponent(result.value, config, overwriteAll, overwritePolicy, installedHelpers, fetchOpts);
     if (helperFailed) hasFailure = true;
+  }
+
+  if (needsGuidance) {
+    logger.info(t('ui.init.snippetGuide', { filename: DEFAULT_CONFIG_FILENAME, snippet: renderUiSnippet(config) }));
   }
 
   if (hasFailure) {

--- a/packages/lism-cli/src/commands/ui/add.ts
+++ b/packages/lism-cli/src/commands/ui/add.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { confirm, select } from '@inquirer/prompts';
-import { readConfig, renderUiSnippet, DEFAULT_CONFIG_FILENAME } from '../../config.js';
+import { findConfigFile, readConfig, renderUiSnippet, DEFAULT_CONFIG_FILENAME } from '../../config.js';
 import {
   fetchCatalog,
   fetchComponent,
@@ -113,7 +113,8 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
   }
 
   if (needsGuidance) {
-    logger.info(t('ui.init.snippetGuide', { filename: DEFAULT_CONFIG_FILENAME, snippet: renderUiSnippet(config) }));
+    const filename = findConfigFile()?.filename ?? DEFAULT_CONFIG_FILENAME;
+    logger.info(t('ui.init.snippetGuide', { filename, snippet: renderUiSnippet(config) }));
   }
 
   if (hasFailure) {

--- a/packages/lism-cli/src/commands/ui/add.ts
+++ b/packages/lism-cli/src/commands/ui/add.ts
@@ -23,6 +23,8 @@ interface AddOptions {
   all: boolean;
   ref?: string;
   framework?: LismCliConfig['framework'];
+  componentsDir?: string;
+  helperDir?: string;
 }
 
 /** 上書き方針 */
@@ -39,7 +41,7 @@ export async function addCommand(names: string[], options: AddOptions): Promise<
     } else {
       needsGuidance = true;
       logger.info(t('ui.add.noConfig'));
-      config = await promptUiConfig({ framework: options.framework });
+      config = await promptUiConfig({ framework: options.framework, componentsDir: options.componentsDir, helperDir: options.helperDir });
       console.log();
     }
   } catch (err) {

--- a/packages/lism-cli/src/commands/ui/index.ts
+++ b/packages/lism-cli/src/commands/ui/index.ts
@@ -21,6 +21,8 @@ export function createUiCommand(): Command {
     .option('-o, --overwrite', t('cli.ui.add.opt.overwrite'), false)
     .option('-a, --all', t('cli.ui.add.opt.all'), false)
     .addOption(new Option('--framework <name>', t('cli.ui.init.opt.framework')).choices(['react', 'astro']))
+    .option('--components-dir <path>', t('cli.ui.init.opt.componentsDir'))
+    .option('--helper-dir <path>', t('cli.ui.init.opt.helperDir'))
     .option('--ref <ref>', t('cli.ui.opt.ref'))
     .action(addCommand);
 

--- a/packages/lism-cli/src/commands/ui/index.ts
+++ b/packages/lism-cli/src/commands/ui/index.ts
@@ -13,7 +13,6 @@ export function createUiCommand(): Command {
     .addOption(new Option('--framework <name>', t('cli.ui.init.opt.framework')).choices(['react', 'astro']))
     .option('--components-dir <path>', t('cli.ui.init.opt.componentsDir'))
     .option('--helper-dir <path>', t('cli.ui.init.opt.helperDir'))
-    .option('-f, --force', t('cli.ui.init.opt.force'), false)
     .action(initCommand);
 
   ui.command('add')
@@ -21,6 +20,7 @@ export function createUiCommand(): Command {
     .argument('[names...]', t('cli.ui.add.arg.names'))
     .option('-o, --overwrite', t('cli.ui.add.opt.overwrite'), false)
     .option('-a, --all', t('cli.ui.add.opt.all'), false)
+    .addOption(new Option('--framework <name>', t('cli.ui.init.opt.framework')).choices(['react', 'astro']))
     .option('--ref <ref>', t('cli.ui.opt.ref'))
     .action(addCommand);
 

--- a/packages/lism-cli/src/commands/ui/init.test.ts
+++ b/packages/lism-cli/src/commands/ui/init.test.ts
@@ -2,14 +2,13 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { select, input } from '@inquirer/prompts';
+import { select } from '@inquirer/prompts';
 import { setLang } from '../../i18n';
 import { logger } from '../../logger';
 import { runInit, initCommand } from './init';
 
 vi.mock('@inquirer/prompts', () => ({
   select: vi.fn(),
-  input: vi.fn(),
 }));
 
 const cwd = process.cwd();
@@ -24,7 +23,6 @@ function writeFile(filePath: string, content: string): void {
 
 function mockPrompts(): void {
   vi.mocked(select).mockResolvedValue('react');
-  vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
 }
 
 beforeEach(() => {
@@ -78,7 +76,6 @@ describe('initCommand', () => {
     await initCommand({});
 
     expect(select).not.toHaveBeenCalled();
-    expect(input).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/lism-cli/src/commands/ui/init.test.ts
+++ b/packages/lism-cli/src/commands/ui/init.test.ts
@@ -1,0 +1,108 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { select, input } from '@inquirer/prompts';
+import { setLang } from '../../i18n';
+import { logger } from '../../logger';
+import { runInit, initCommand } from './init';
+
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn(),
+  input: vi.fn(),
+}));
+
+const cwd = process.cwd();
+let tmpDir: string;
+let infoSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function mockPrompts(): void {
+  vi.mocked(select).mockResolvedValue('react');
+  vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
+}
+
+beforeEach(() => {
+  setLang('en');
+  vi.clearAllMocks();
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'lism-init-')));
+  process.chdir(tmpDir);
+  infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+  warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+  vi.spyOn(logger, 'success').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  process.chdir(cwd);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('runInit', () => {
+  it('設定ファイルが無ければ ui: を含む新規ファイルを生成する', async () => {
+    mockPrompts();
+
+    const config = await runInit();
+
+    expect(config).toEqual({ framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' });
+    const content = fs.readFileSync(path.join(tmpDir, 'lism.config.js'), 'utf-8');
+    expect(content).toContain('ui: {');
+  });
+
+  it('既存ファイルがある場合はファイルを書き換えず、スニペットのみ案内する', async () => {
+    mockPrompts();
+    const original = "export default { tokens: { space: ['10', '20'] } };\n";
+    writeFile(path.join(tmpDir, 'lism.config.js'), original);
+
+    await runInit();
+
+    const after = fs.readFileSync(path.join(tmpDir, 'lism.config.js'), 'utf-8');
+    expect(after).toBe(original);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain('ui: {');
+  });
+});
+
+describe('initCommand', () => {
+  it('既に ui セクションがある場合は中断し、prompt は呼ばれない', async () => {
+    writeFile(
+      path.join(tmpDir, 'lism.config.js'),
+      "export default { ui: { framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' } };\n"
+    );
+
+    await initCommand({});
+
+    expect(select).not.toHaveBeenCalled();
+    expect(input).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ui セクションが無ければ runInit まで進む', async () => {
+    mockPrompts();
+    writeFile(path.join(tmpDir, 'lism.config.js'), "export default { tokens: { space: ['10', '20'] } };\n");
+
+    await initCommand({});
+
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('legacy json 検出時は警告を出して runInit まで進む（新規 lism.config.js を生成）', async () => {
+    mockPrompts();
+    writeFile(
+      path.join(tmpDir, 'lism-ui.json'),
+      JSON.stringify({ framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' })
+    );
+
+    await initCommand({});
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(path.join(tmpDir, 'lism.config.js'))).toBe(true);
+  });
+});

--- a/packages/lism-cli/src/commands/ui/init.ts
+++ b/packages/lism-cli/src/commands/ui/init.ts
@@ -1,64 +1,22 @@
-import { select, input } from '@inquirer/prompts';
-import { findConfigFile, hasCliSection, patchConfigWithCli, writeFreshConfig } from '../../config.js';
+import { findConfigFile, readConfig, writeFreshConfig, renderUiSnippet } from '../../config.js';
+import { promptUiConfig, type PromptUiConfigOptions } from './promptUiConfig.js';
 import { logger } from '../../logger.js';
 import { t } from '../../i18n.js';
 import type { LismCliConfig } from '../../config.js';
 
-export interface InitOptions {
-  framework?: LismCliConfig['framework'];
-  componentsDir?: string;
-  helperDir?: string;
-  force?: boolean;
-  /**
-   * initCommand 経路で既に hasCliSection を評価済みのときにその結果を伝搬する内部用フラグ。
-   * 未指定の場合は patchConfigWithCli 内で通常通り判定される。
-   */
-  existingCli?: boolean;
-}
+export type InitOptions = PromptUiConfigOptions;
 
 /**
- * 設定を作成し lism.config.* に書き込む（既存時は cli セクションをパッチ）。作成した config を返す。
- * options で指定された項目は prompt をスキップする（全指定なら完全非対話）。
+ * UI セクションの値を対話で収集し、設定ファイルが無ければ新規作成する。
+ * 既に lism.config.* が存在する場合はファイルを書き換えず、貼り付け用スニペットを案内するだけにする
+ * （CSS カスタマイズ用に先に作られたファイルを壊さないため）。収集した config を返す。
  */
 export async function runInit(options: InitOptions = {}): Promise<LismCliConfig> {
-  const framework =
-    options.framework ??
-    (await select<LismCliConfig['framework']>({
-      message: t('ui.init.promptFramework'),
-      choices: [
-        { name: 'React', value: 'react' },
-        { name: 'Astro', value: 'astro' },
-      ],
-    }));
-
-  const componentsDir =
-    options.componentsDir ??
-    (await input({
-      message: t('ui.init.promptComponentsDir'),
-      default: 'src/components/ui',
-    }));
-
-  const helperDir =
-    options.helperDir ??
-    (await input({
-      message: t('ui.init.promptHelperDir'),
-      default: `${componentsDir}/_helper`,
-    }));
-
-  const config: LismCliConfig = { framework, componentsDir, helperDir };
-
+  const config = await promptUiConfig(options);
   const found = findConfigFile();
 
   if (found?.kind === 'module') {
-    const { patched, path: outPath } = await patchConfigWithCli(config, found.path, {
-      force: options.force,
-      existingCli: options.existingCli,
-    });
-    if (patched) {
-      logger.success(t(options.force ? 'ui.init.patchedUpdate' : 'ui.init.patchedAdd', { path: outPath }));
-    } else {
-      logger.warn(t('ui.init.notPatched', { path: outPath }));
-    }
+    logger.info(t('ui.init.snippetGuide', { filename: found.filename, snippet: renderUiSnippet(config) }));
   } else {
     // found が null、または legacy-json（別途 initCommand で warning 済み）
     const outPath = writeFreshConfig(config);
@@ -71,26 +29,21 @@ export async function runInit(options: InitOptions = {}): Promise<LismCliConfig>
 export async function initCommand(options: InitOptions): Promise<void> {
   const found = findConfigFile();
 
-  let existingCli = false;
   if (found?.kind === 'legacy-json') {
     logger.warn(t('ui.init.legacyDetected', { filename: found.filename }));
   } else if (found?.kind === 'module') {
-    // ユーザーの lism.config.* に構文エラーがあると jiti が throw するため、
-    // スタックトレース付きで uncaught にならないよう logger.error で握って終了する。
+    let existing: LismCliConfig | null;
     try {
-      existingCli = await hasCliSection(found.path);
+      existing = await readConfig();
     } catch (err) {
       logger.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
     }
-    if (existingCli) {
-      if (!options.force) {
-        logger.warn(t('ui.init.alreadyExists', { filename: found.filename }));
-        return;
-      }
-      logger.warn(t('ui.init.willOverwrite', { filename: found.filename }));
+    if (existing) {
+      logger.warn(t('ui.init.alreadyExists', { filename: found.filename }));
+      return;
     }
   }
 
-  await runInit({ ...options, existingCli });
+  await runInit(options);
 }

--- a/packages/lism-cli/src/commands/ui/promptUiConfig.test.ts
+++ b/packages/lism-cli/src/commands/ui/promptUiConfig.test.ts
@@ -1,10 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { select, input } from '@inquirer/prompts';
+import { select } from '@inquirer/prompts';
 import { promptUiConfig } from './promptUiConfig';
 
 vi.mock('@inquirer/prompts', () => ({
   select: vi.fn(),
-  input: vi.fn(),
 }));
 
 describe('promptUiConfig', () => {
@@ -12,41 +11,32 @@ describe('promptUiConfig', () => {
     vi.clearAllMocks();
   });
 
-  it('オプション未指定なら framework/componentsDir/helperDir を全て対話で聞く', async () => {
+  it('オプション未指定なら framework のみ対話で聞き、componentsDir/helperDir はデフォルト値を採用する', async () => {
     vi.mocked(select).mockResolvedValue('react');
-    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
 
     const result = await promptUiConfig();
 
     expect(select).toHaveBeenCalledTimes(1);
-    expect(input).toHaveBeenCalledTimes(2);
     expect(result).toEqual({ framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' });
   });
 
-  it('framework を指定すると select はスキップされる', async () => {
-    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
-
+  it('framework を指定すると select はスキップされ、プロンプトが一切呼ばれない', async () => {
     const result = await promptUiConfig({ framework: 'astro' });
 
     expect(select).not.toHaveBeenCalled();
-    expect(input).toHaveBeenCalledTimes(2);
-    expect(result.framework).toBe('astro');
+    expect(result).toEqual({ framework: 'astro', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' });
   });
 
-  it('全オプション指定時は prompt が一切呼ばれない', async () => {
+  it('全オプション指定時は指定値がそのまま使われる', async () => {
     const result = await promptUiConfig({ framework: 'react', componentsDir: 'src/ui', helperDir: 'src/ui/_helper' });
 
     expect(select).not.toHaveBeenCalled();
-    expect(input).not.toHaveBeenCalled();
     expect(result).toEqual({ framework: 'react', componentsDir: 'src/ui', helperDir: 'src/ui/_helper' });
   });
 
-  it('componentsDir 指定時、helperDir の prompt デフォルト値が連動する', async () => {
-    vi.mocked(input).mockResolvedValueOnce('custom/_helper');
+  it('componentsDir 指定時、helperDir の既定値が連動する', async () => {
+    const result = await promptUiConfig({ framework: 'react', componentsDir: 'custom' });
 
-    await promptUiConfig({ framework: 'react', componentsDir: 'custom' });
-
-    expect(input).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(input).mock.calls[0][0]).toMatchObject({ default: 'custom/_helper' });
+    expect(result.helperDir).toBe('custom/_helper');
   });
 });

--- a/packages/lism-cli/src/commands/ui/promptUiConfig.test.ts
+++ b/packages/lism-cli/src/commands/ui/promptUiConfig.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { select, input } from '@inquirer/prompts';
+import { promptUiConfig } from './promptUiConfig';
+
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn(),
+  input: vi.fn(),
+}));
+
+describe('promptUiConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('オプション未指定なら framework/componentsDir/helperDir を全て対話で聞く', async () => {
+    vi.mocked(select).mockResolvedValue('react');
+    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
+
+    const result = await promptUiConfig();
+
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(input).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' });
+  });
+
+  it('framework を指定すると select はスキップされる', async () => {
+    vi.mocked(input).mockResolvedValueOnce('src/components/ui').mockResolvedValueOnce('src/components/ui/_helper');
+
+    const result = await promptUiConfig({ framework: 'astro' });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(input).toHaveBeenCalledTimes(2);
+    expect(result.framework).toBe('astro');
+  });
+
+  it('全オプション指定時は prompt が一切呼ばれない', async () => {
+    const result = await promptUiConfig({ framework: 'react', componentsDir: 'src/ui', helperDir: 'src/ui/_helper' });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(input).not.toHaveBeenCalled();
+    expect(result).toEqual({ framework: 'react', componentsDir: 'src/ui', helperDir: 'src/ui/_helper' });
+  });
+
+  it('componentsDir 指定時、helperDir の prompt デフォルト値が連動する', async () => {
+    vi.mocked(input).mockResolvedValueOnce('custom/_helper');
+
+    await promptUiConfig({ framework: 'react', componentsDir: 'custom' });
+
+    expect(input).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(input).mock.calls[0][0]).toMatchObject({ default: 'custom/_helper' });
+  });
+});

--- a/packages/lism-cli/src/commands/ui/promptUiConfig.ts
+++ b/packages/lism-cli/src/commands/ui/promptUiConfig.ts
@@ -1,0 +1,42 @@
+import { select, input } from '@inquirer/prompts';
+import { t } from '../../i18n.js';
+import type { LismCliConfig } from '../../config.js';
+
+export interface PromptUiConfigOptions {
+  framework?: LismCliConfig['framework'];
+  componentsDir?: string;
+  helperDir?: string;
+}
+
+/**
+ * UI セクション（`framework`/`componentsDir`/`helperDir`）を対話で収集する。
+ * ファイルの読み書きは一切行わない。永続化するかどうかは呼び出し側の責務
+ * （`runInit` は書き込み、`addCommand` は今回限りの値として使うだけ）。
+ */
+export async function promptUiConfig(options: PromptUiConfigOptions = {}): Promise<LismCliConfig> {
+  const framework =
+    options.framework ??
+    (await select<LismCliConfig['framework']>({
+      message: t('ui.init.promptFramework'),
+      choices: [
+        { name: 'React', value: 'react' },
+        { name: 'Astro', value: 'astro' },
+      ],
+    }));
+
+  const componentsDir =
+    options.componentsDir ??
+    (await input({
+      message: t('ui.init.promptComponentsDir'),
+      default: 'src/components/ui',
+    }));
+
+  const helperDir =
+    options.helperDir ??
+    (await input({
+      message: t('ui.init.promptHelperDir'),
+      default: `${componentsDir}/_helper`,
+    }));
+
+  return { framework, componentsDir, helperDir };
+}

--- a/packages/lism-cli/src/commands/ui/promptUiConfig.ts
+++ b/packages/lism-cli/src/commands/ui/promptUiConfig.ts
@@ -1,4 +1,4 @@
-import { select, input } from '@inquirer/prompts';
+import { select } from '@inquirer/prompts';
 import { t } from '../../i18n.js';
 import type { LismCliConfig } from '../../config.js';
 
@@ -9,9 +9,16 @@ export interface PromptUiConfigOptions {
 }
 
 /**
- * UI セクション（`framework`/`componentsDir`/`helperDir`）を対話で収集する。
+ * UI セクション（`framework`/`componentsDir`/`helperDir`）の値を決定する。
  * ファイルの読み書きは一切行わない。永続化するかどうかは呼び出し側の責務
  * （`runInit` は書き込み、`addCommand` は今回限りの値として使うだけ）。
+ *
+ * `componentsDir`/`helperDir` は本質的に config に書く値であり、毎回対話で
+ * 尋ねる必要は無いため既定値をそのまま採用する（変更したい場合は
+ * `--components-dir`/`--helper-dir` フラグ、または `lism.config.js` の
+ * `ui:` セクションを直接編集してもらう）。`framework` は react/astro を
+ * 確実に自動判定できない（Astro + React アイランド併用等）ため、唯一の
+ * 対話質問として残す。
  */
 export async function promptUiConfig(options: PromptUiConfigOptions = {}): Promise<LismCliConfig> {
   const framework =
@@ -24,19 +31,8 @@ export async function promptUiConfig(options: PromptUiConfigOptions = {}): Promi
       ],
     }));
 
-  const componentsDir =
-    options.componentsDir ??
-    (await input({
-      message: t('ui.init.promptComponentsDir'),
-      default: 'src/components/ui',
-    }));
-
-  const helperDir =
-    options.helperDir ??
-    (await input({
-      message: t('ui.init.promptHelperDir'),
-      default: `${componentsDir}/_helper`,
-    }));
+  const componentsDir = options.componentsDir ?? 'src/components/ui';
+  const helperDir = options.helperDir ?? `${componentsDir}/_helper`;
 
   return { framework, componentsDir, helperDir };
 }

--- a/packages/lism-cli/src/config.test.ts
+++ b/packages/lism-cli/src/config.test.ts
@@ -110,6 +110,20 @@ describe('readConfig', () => {
     writeFile(path.join(tmpDir, 'lism-ui.json'), JSON.stringify({ framework: 'vue', componentsDir: 'x', helperDir: 'y' }));
     await expect(readConfig()).rejects.toThrow();
   });
+
+  it('ui: が null で cli: もある場合、cli へフォールバックせず throw する', async () => {
+    writeFile(
+      path.join(tmpDir, 'lism.config.js'),
+      "export default { ui: null, cli: { framework: 'astro', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' } };\n"
+    );
+    await expect(readConfig()).rejects.toThrow();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('cli: が null のみ（ui キー無し）の場合、旧形式フォールバックを試みず throw する', async () => {
+    writeFile(path.join(tmpDir, 'lism.config.js'), 'export default { cli: null };\n');
+    await expect(readConfig()).rejects.toThrow();
+  });
 });
 
 describe('writeFreshConfig', () => {
@@ -131,6 +145,13 @@ describe('writeFreshConfig', () => {
     expect(content).toContain('ui: {');
     expect(content).not.toContain('cli: {');
     expect(content).toContain('"react"');
+  });
+
+  it('既に lism.config.js が存在する場合は throw する（上書きしない）', () => {
+    writeFile(path.join(tmpDir, 'lism.config.js'), 'export default { tokens: {} };\n');
+    expect(() => writeFreshConfig({ framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' })).toThrow();
+    // 上書きされていないことを確認
+    expect(fs.readFileSync(path.join(tmpDir, 'lism.config.js'), 'utf-8')).toBe('export default { tokens: {} };\n');
   });
 });
 

--- a/packages/lism-cli/src/config.test.ts
+++ b/packages/lism-cli/src/config.test.ts
@@ -1,0 +1,142 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setLang } from './i18n';
+import { logger } from './logger';
+import { readConfig, writeFreshConfig, renderUiSnippet, getDefaultConfigPath } from './config';
+
+const cwd = process.cwd();
+let tmpDir: string;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+describe('readConfig', () => {
+  beforeEach(() => {
+    setLang('en');
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'lism-config-')));
+    process.chdir(tmpDir);
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('設定ファイルが無ければ null を返す', async () => {
+    await expect(readConfig()).resolves.toBeNull();
+  });
+
+  it('lism.config.js はあるが ui/cli セクションが無く、モジュール全体も ui 設定として無効なら null を返す', async () => {
+    writeFile(path.join(tmpDir, 'lism.config.js'), "export default { tokens: { space: ['10', '20'] } };\n");
+    await expect(readConfig()).resolves.toBeNull();
+  });
+
+  it('ui: セクションがあれば値を返し、deprecation警告は出さない', async () => {
+    writeFile(
+      path.join(tmpDir, 'lism.config.js'),
+      "export default { ui: { framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' } };\n"
+    );
+    const result = await readConfig();
+    expect(result).toEqual({ framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('旧 cli: セクションのみあれば値を返し、deprecation警告を出す', async () => {
+    writeFile(
+      path.join(tmpDir, 'lism.config.js'),
+      "export default { cli: { framework: 'astro', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' } };\n"
+    );
+    const result = await readConfig();
+    expect(result).toEqual({ framework: 'astro', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ui: と cli: が両方あれば ui: を優先し、警告は出さない', async () => {
+    writeFile(
+      path.join(tmpDir, 'lism.config.js'),
+      "export default { ui: { framework: 'react', componentsDir: 'a', helperDir: 'a/_helper' }, cli: { framework: 'astro', componentsDir: 'b', helperDir: 'b/_helper' } };\n"
+    );
+    const result = await readConfig();
+    expect(result).toEqual({ framework: 'react', componentsDir: 'a', helperDir: 'a/_helper' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('旧形式（ui/cliキー無しでモジュール全体が有効な設定）は後方互換で読み込める', async () => {
+    writeFile(
+      path.join(tmpDir, 'lism.config.js'),
+      "export default { framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' };\n"
+    );
+    const result = await readConfig();
+    expect(result).toEqual({ framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' });
+  });
+
+  it('framework が不正な値なら throw する', async () => {
+    writeFile(
+      path.join(tmpDir, 'lism.config.js'),
+      "export default { ui: { framework: 'vue', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' } };\n"
+    );
+    await expect(readConfig()).rejects.toThrow();
+  });
+
+  it('componentsDir が文字列でなければ throw する', async () => {
+    writeFile(path.join(tmpDir, 'lism.config.js'), "export default { ui: { framework: 'react', componentsDir: 123, helperDir: 'x' } };\n");
+    await expect(readConfig()).rejects.toThrow();
+  });
+
+  it('構文エラーのあるファイルは config.loadFailed で throw する', async () => {
+    writeFile(path.join(tmpDir, 'lism.config.js'), 'export default {{{ syntax error\n');
+    await expect(readConfig()).rejects.toThrow();
+  });
+
+  it('legacy json (lism-ui.json) を読み込み、deprecation警告を出す', async () => {
+    writeFile(
+      path.join(tmpDir, 'lism-ui.json'),
+      JSON.stringify({ framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' })
+    );
+    const result = await readConfig();
+    expect(result).toEqual({ framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('legacy json の値が不正なら throw する', async () => {
+    writeFile(path.join(tmpDir, 'lism-ui.json'), JSON.stringify({ framework: 'vue', componentsDir: 'x', helperDir: 'y' }));
+    await expect(readConfig()).rejects.toThrow();
+  });
+});
+
+describe('writeFreshConfig', () => {
+  beforeEach(() => {
+    setLang('en');
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'lism-config-')));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('ui: キーで新規 lism.config.js を生成する', () => {
+    const outPath = writeFreshConfig({ framework: 'react', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' });
+    expect(outPath).toBe(getDefaultConfigPath());
+    const content = fs.readFileSync(outPath, 'utf-8');
+    expect(content).toContain('ui: {');
+    expect(content).not.toContain('cli: {');
+    expect(content).toContain('"react"');
+  });
+});
+
+describe('renderUiSnippet', () => {
+  it('貼り付け用の ui: スニペット文字列を返す', () => {
+    const snippet = renderUiSnippet({ framework: 'astro', componentsDir: 'src/components/ui', helperDir: 'src/components/ui/_helper' });
+    expect(snippet).toBe('ui: {\n  framework: "astro",\n  componentsDir: "src/components/ui",\n  helperDir: "src/components/ui/_helper",\n},');
+  });
+});

--- a/packages/lism-cli/src/config.ts
+++ b/packages/lism-cli/src/config.ts
@@ -81,11 +81,14 @@ export async function readConfig(): Promise<LismCliConfig | null> {
   }
 
   const modObj = mod as LismConfigFile | undefined;
-  const explicit = modObj?.ui ?? modObj?.cli;
+  // `??` だと「ui キーは存在するが値が null 等」のケースで cli/旧形式へ静かにフォールバックしてしまい、
+  // 設定ミスが見えなくなる。キーの「存在」自体で判定し、値の妥当性は validateCliConfig に委ねる。
+  const hasUiKey = modObj?.ui !== undefined;
+  const hasCliKey = modObj?.cli !== undefined;
 
-  if (explicit !== undefined) {
-    // 明示的な `ui:`（または旧 `cli:`）キーがある場合は厳格に検証し、不正なら throw する
-    if (modObj?.ui === undefined && modObj?.cli !== undefined) {
+  if (hasUiKey || hasCliKey) {
+    const explicit = hasUiKey ? modObj.ui : modObj.cli;
+    if (!hasUiKey && hasCliKey) {
       logger.warn(t('config.cliKeyDeprecated', { filename: found.filename }));
     }
     validateCliConfig(explicit);
@@ -119,9 +122,12 @@ function validateCliConfig(cli: unknown): asserts cli is LismCliConfig {
   }
 }
 
-/** lism.config.js を新規作成する（既存の場合は書き換えない） */
+/** lism.config.js を新規作成する。既に存在する場合は呼び出し側のロジック誤りとして throw する。 */
 export function writeFreshConfig(cli: LismCliConfig): string {
   const filePath = getDefaultConfigPath();
+  if (fs.existsSync(filePath)) {
+    throw new Error(t('config.freshConfigExists', { path: filePath }));
+  }
   const body = renderConfigTemplate(cli);
   fs.writeFileSync(filePath, body);
   return filePath;

--- a/packages/lism-cli/src/config.ts
+++ b/packages/lism-cli/src/config.ts
@@ -97,7 +97,10 @@ export async function readConfig(): Promise<LismCliConfig | null> {
   // CSS カスタマイズ専用の lism.config.js（tokens/props 等）を誤って UI 設定と解釈しないため。
   try {
     validateCliConfig(modObj);
-    return modObj as LismCliConfig;
+    // jiti の interopDefault は default export のプロパティをモジュール名前空間に
+    // 合成する Proxy を返すため、そのまま返すと __esModule 等の余計な内部プロパティが
+    // 漏れる。必要な3フィールドだけを抜き出してクリーンなオブジェクトを構築する。
+    return { framework: modObj.framework, componentsDir: modObj.componentsDir, helperDir: modObj.helperDir };
   } catch {
     return null;
   }

--- a/packages/lism-cli/src/config.ts
+++ b/packages/lism-cli/src/config.ts
@@ -15,6 +15,8 @@ export interface LismCliConfig {
 }
 
 interface LismConfigFile {
+  ui?: LismCliConfig;
+  /** @deprecated `ui` へリネーム済み。後方互換のための読み取り専用。 */
   cli?: LismCliConfig;
   // 他のキー（tokens 等）はここでは関心外
   [key: string]: unknown;
@@ -49,37 +51,60 @@ export function getDefaultConfigPath(): string {
 }
 
 /**
- * CLI 設定を読み込む。
- * - `lism.config.{js,mjs}`: 動的インポート（jiti）で default export から `cli` を取得
+ * UI（旧 CLI）設定を読み込む。
+ * - `lism.config.{js,mjs}`: 動的インポート（jiti）で default export から `ui`（フォールバックで旧 `cli`）を取得
  * - `lism-ui.json` (legacy): JSON.parse、deprecation 警告を出す
+ *
+ * `ui`/`cli` セクションが見つからない場合は `null` を返す（throw しない）。
+ * `lism.config.js` が tokens/props 等の CSS カスタマイズ専用に作られていて
+ * UI セクションがまだ無いケースで、呼び出し側が対話プロンプトへフォールバックできるようにするため。
+ * セクションが存在するが値の形が不正な場合は throw する（ユーザーの入力ミスを黙って無視しない）。
  */
-export async function readConfig(): Promise<LismCliConfig> {
+export async function readConfig(): Promise<LismCliConfig | null> {
   const found = findConfigFile();
-  if (!found) {
-    throw new Error(t('config.notFound'));
-  }
+  if (!found) return null;
 
   if (found.kind === 'legacy-json') {
     logger.warn(t('config.legacyWarning', { filename: LEGACY_CONFIG_FILE, invoke: getInvokeCommand() }));
     const raw = fs.readFileSync(found.path, 'utf-8');
     const parsed = JSON.parse(raw) as LismCliConfig;
+    validateCliConfig(parsed);
     return parsed;
   }
 
   const jiti = createJiti(import.meta.url, { interopDefault: true });
-  const mod = await jiti.import(found.path);
-
-  // `cli` サブキーがあればそれを優先、なければモジュール全体を CLI 設定として扱う（後方互換）
-  const cli = (mod as LismConfigFile | undefined)?.cli ?? (mod as LismCliConfig | undefined);
-  if (!cli || typeof cli !== 'object') {
-    throw new Error(t('config.cliSectionMissing', { filename: found.filename }));
+  let mod: unknown;
+  try {
+    mod = await jiti.import(found.path);
+  } catch (err) {
+    throw new Error(t('config.loadFailed', { path: found.path, reason: String(err) }));
   }
-  validateCliConfig(cli);
-  return cli;
+
+  const modObj = mod as LismConfigFile | undefined;
+  const explicit = modObj?.ui ?? modObj?.cli;
+
+  if (explicit !== undefined) {
+    // 明示的な `ui:`（または旧 `cli:`）キーがある場合は厳格に検証し、不正なら throw する
+    if (modObj?.ui === undefined && modObj?.cli !== undefined) {
+      logger.warn(t('config.cliKeyDeprecated', { filename: found.filename }));
+    }
+    validateCliConfig(explicit);
+    return explicit;
+  }
+
+  // 明示キーが無い場合、モジュール全体が直接 UI 設定という旧形式への後方互換を試す。
+  // 検証に失敗したら「UI セクションが無い」とみなし null を返す（throw しない）。
+  // CSS カスタマイズ専用の lism.config.js（tokens/props 等）を誤って UI 設定と解釈しないため。
+  try {
+    validateCliConfig(modObj);
+    return modObj as LismCliConfig;
+  } catch {
+    return null;
+  }
 }
 
 function validateCliConfig(cli: unknown): asserts cli is LismCliConfig {
-  const c = cli as Partial<LismCliConfig>;
+  const c = (cli ?? {}) as Partial<LismCliConfig>;
   if (c.framework !== 'react' && c.framework !== 'astro') {
     throw new Error(t('config.invalidFramework'));
   }
@@ -99,151 +124,18 @@ export function writeFreshConfig(cli: LismCliConfig): string {
   return filePath;
 }
 
-/**
- * 指定された lism.config.{js,mjs} に `cli` セクションが存在するかを返す。
- * jiti で実際にモジュールを評価して `default.cli` の有無を判定するため、コメントや
- * 他キー値に含まれる "cli:" で false positive にならない。
- */
-export async function hasCliSection(filePath: string): Promise<boolean> {
-  try {
-    const jiti = createJiti(import.meta.url, { interopDefault: true });
-    const mod = await jiti.import(filePath);
-    return !!(mod as LismConfigFile | undefined)?.cli;
-  } catch (err) {
-    throw new Error(t('config.loadFailed', { path: filePath, reason: String(err) }));
-  }
-}
-
-/**
- * 既存の lism.config.{js,mjs} に `cli` セクションを追記する。
- * - すでに `cli` が含まれ、かつ `options.force` が false（既定）の場合は patched: false を返す
- * - `options.force` が true の場合は既存の `cli` セクションを削除してから追記する
- * - オブジェクトリテラルの挿入位置を特定できない場合も patched: false
- *
- * 対応する記法：
- * - `export default { ... }`
- * - `export default defineConfig({ ... })`（関数呼び出しラッパー）
- * - `export default ({ ... })`（カッコ包み）
- * - `const config = { ... }; export default config;`（変数経由）
- *
- * @param targetPath 対象ファイルの絶対パス。省略時は lism.config.js を対象にする。
- */
-export async function patchConfigWithCli(
-  cli: LismCliConfig,
-  targetPath?: string,
-  options: { force?: boolean; existingCli?: boolean } = {}
-): Promise<{ path: string; patched: boolean }> {
-  const filePath = targetPath ?? getDefaultConfigPath();
-  let source = fs.readFileSync(filePath, 'utf-8');
-
-  // 呼び出し側で既に hasCliSection を評価済みならその結果を使い、jiti による再評価を避ける
-  const hasExisting = options.existingCli ?? (await hasCliSection(filePath));
-  if (hasExisting) {
-    if (!options.force) {
-      return { path: filePath, patched: false };
-    }
-    const removed = removeCliSection(source);
-    if (removed === null) {
-      return { path: filePath, patched: false };
-    }
-    source = removed;
-  }
-
-  const insertAt = findInsertPosition(source);
-  if (insertAt === -1) {
-    return { path: filePath, patched: false };
-  }
-
-  const insertion = `\n  cli: ${renderCliObject(cli, '  ')},`;
-  const updated = source.slice(0, insertAt) + insertion + source.slice(insertAt);
-  fs.writeFileSync(filePath, updated);
-  return { path: filePath, patched: true };
-}
-
-/**
- * 既存の `cli: { ... }` セクション（と末尾カンマ）を取り除いた文字列を返す。
- * 文字列リテラル・コメント内の `{` / `}` はバランス計算から除外する。
- * 見つからない、または括弧がアンバランスな場合は null を返す。
- */
-function removeCliSection(source: string): string | null {
-  // 直前が行頭・カンマ・`{` のいずれかに限定し、"my_cli:" や文字列値との誤マッチを避ける
-  const match = source.match(/(^|[\n,{])(\s*)cli\s*:\s*\{/);
-  if (!match) return null;
-  const sectionStart = match.index! + match[1].length + match[2].length;
-  const openBrace = match.index! + match[0].length - 1;
-
-  let i = openBrace + 1;
-  let depth = 1;
-  while (i < source.length && depth > 0) {
-    const c = source[i];
-    if (c === '"' || c === "'" || c === '`') {
-      const quote = c;
-      i++;
-      while (i < source.length && source[i] !== quote) {
-        if (source[i] === '\\') i++;
-        i++;
-      }
-      i++;
-      continue;
-    }
-    if (c === '/' && source[i + 1] === '/') {
-      while (i < source.length && source[i] !== '\n') i++;
-      continue;
-    }
-    if (c === '/' && source[i + 1] === '*') {
-      i += 2;
-      while (i < source.length - 1 && !(source[i] === '*' && source[i + 1] === '/')) i++;
-      i += 2;
-      continue;
-    }
-    if (c === '{') depth++;
-    else if (c === '}') depth--;
-    i++;
-  }
-  if (depth !== 0) return null;
-
-  let end = i;
-  if (source[end] === ',') end++;
-  // セクションの直後に改行だけが残らないよう、末尾の空行を 1 つ吸収
-  const trailing = source.slice(end).match(/^[ \t]*\n/);
-  if (trailing) end += trailing[0].length;
-
-  return source.slice(0, sectionStart) + source.slice(end);
-}
-
-/**
- * `cli` キーを挿入すべきオブジェクトリテラルの `{` 直後の位置を返す。
- * 見つからなければ -1。
- */
-function findInsertPosition(source: string): number {
-  // パターン1: `export default {` / `export default defineConfig({` / `export default ({`
-  // 末尾が必ず `{` になるように構成
-  const inline = source.match(/export default\s*(?:[A-Za-z_$][A-Za-z0-9_$]*\s*)?\(?\s*\{/);
-  if (inline) {
-    return inline.index! + inline[0].length;
-  }
-
-  // パターン2: `const config = { ... }; export default config;` のような変数経由
-  const varExport = source.match(/export default\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*;?/);
-  if (varExport) {
-    const varName = varExport[1];
-    const escaped = varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const decl = source.match(new RegExp(`(?:const|let|var)\\s+${escaped}\\s*=\\s*(?:[A-Za-z_$][A-Za-z0-9_$]*\\s*)?\\(?\\s*\\{`));
-    if (decl) {
-      return decl.index! + decl[0].length;
-    }
-  }
-
-  return -1;
-}
-
 function renderConfigTemplate(cli: LismCliConfig): string {
   return [
     'export default {', //
-    `  cli: ${renderCliObject(cli, '  ')},`,
+    `  ui: ${renderCliObject(cli, '  ')},`,
     '};',
     '',
   ].join('\n');
+}
+
+/** `ui add` / `ui init` で「貼り付け用スニペット」として表示する文字列を返す（`ui:` キーを含む） */
+export function renderUiSnippet(cli: LismCliConfig): string {
+  return `ui: ${renderCliObject(cli, '')},`;
 }
 
 function renderCliObject(cli: LismCliConfig, indent: string): string {

--- a/packages/lism-cli/src/messages.ts
+++ b/packages/lism-cli/src/messages.ts
@@ -461,6 +461,10 @@ export const messages = {
     ja: '{path} を読み込めませんでした（構文エラー等）。修正してから再実行してください: {reason}',
     en: 'Failed to load {path} (syntax error, etc). Please fix it and retry: {reason}',
   },
+  'config.freshConfigExists': {
+    ja: '{path} は既に存在するため新規作成できません。',
+    en: 'Cannot create {path} because it already exists.',
+  },
 
   // ---------------------------------------------------------------------------
   // common

--- a/packages/lism-cli/src/messages.ts
+++ b/packages/lism-cli/src/messages.ts
@@ -308,14 +308,6 @@ export const messages = {
     ja: 'フレームワークを選択してください:',
     en: 'Select a framework:',
   },
-  'ui.init.promptComponentsDir': {
-    ja: 'コンポーネントの出力先ディレクトリ:',
-    en: 'Output directory for components:',
-  },
-  'ui.init.promptHelperDir': {
-    ja: 'helper の出力先ディレクトリ:',
-    en: 'Output directory for helpers:',
-  },
   'ui.init.created': {
     ja: '{path} を作成しました。',
     en: 'Created {path}.',

--- a/packages/lism-cli/src/messages.ts
+++ b/packages/lism-cli/src/messages.ts
@@ -54,8 +54,8 @@ export const messages = {
     en: 'Manage Lism UI components',
   },
   'cli.ui.init.description': {
-    ja: 'lism.config.js の cli セクションを生成する',
-    en: 'Generate the cli section of lism.config.js',
+    ja: 'lism.config.js の ui セクションを生成する',
+    en: 'Generate the ui section of lism.config.js',
   },
   'cli.ui.init.opt.framework': {
     ja: 'フレームワーク',
@@ -68,10 +68,6 @@ export const messages = {
   'cli.ui.init.opt.helperDir': {
     ja: 'helper の出力先ディレクトリ',
     en: 'Output directory for helpers',
-  },
-  'cli.ui.init.opt.force': {
-    ja: '既存の cli セクションを上書き',
-    en: 'Overwrite the existing cli section',
   },
   'cli.ui.add.description': {
     ja: 'コンポーネントを追加する',
@@ -239,8 +235,8 @@ export const messages = {
 
   // ui add
   'ui.add.noConfig': {
-    ja: 'lism.config.js が見つかりません。セットアップを開始します...\n',
-    en: 'lism.config.js not found. Starting setup...\n',
+    ja: 'ui セクションが見つかりません。いくつか質問します。',
+    en: 'No ui section found. A few questions to get you started.',
   },
   'ui.add.addingAll': {
     ja: '全 {count} コンポーネントを追加します...',
@@ -320,18 +316,6 @@ export const messages = {
     ja: 'helper の出力先ディレクトリ:',
     en: 'Output directory for helpers:',
   },
-  'ui.init.patchedUpdate': {
-    ja: '{path} に cli セクションを更新しました。',
-    en: 'Updated the cli section in {path}.',
-  },
-  'ui.init.patchedAdd': {
-    ja: '{path} に cli セクションを追記しました。',
-    en: 'Added the cli section to {path}.',
-  },
-  'ui.init.notPatched': {
-    ja: '{path} に既に cli セクションが含まれているか、export default が検出できませんでした。手動で追記してください。',
-    en: 'Either {path} already contains a cli section or no export default was detected. Please add it manually.',
-  },
   'ui.init.created': {
     ja: '{path} を作成しました。',
     en: 'Created {path}.',
@@ -341,12 +325,12 @@ export const messages = {
     en: 'Detected {filename}. Migrating to lism.config.js. Please remove the old file afterwards.',
   },
   'ui.init.alreadyExists': {
-    ja: '{filename} には既に cli セクションが設定されています。上書きするには --force を指定してください。',
-    en: '{filename} already has a cli section. Use --force to overwrite.',
+    ja: '{filename} には既に ui セクションが設定されています。',
+    en: '{filename} already has a ui section configured.',
   },
-  'ui.init.willOverwrite': {
-    ja: '{filename} の既存の cli セクションを上書きします。',
-    en: 'Overwriting the existing cli section in {filename}.',
+  'ui.init.snippetGuide': {
+    ja: '次回から同じ質問をされないために、{filename} に以下を貼り付けてください:\n\n{snippet}\n',
+    en: 'To avoid being asked these questions again, paste the following into {filename}:\n\n{snippet}\n',
   },
 
   // ui list
@@ -457,25 +441,21 @@ export const messages = {
     ja: '[deprecated] {filename} は廃止予定です。"{invoke} ui init" で lism.config.js へ移行してください。',
     en: '[deprecated] {filename} is deprecated. Run "{invoke} ui init" to migrate to lism.config.js.',
   },
-  'config.notFound': {
-    ja: 'lism.config.js / lism.config.mjs / lism-ui.json のいずれも見つかりません。',
-    en: 'None of lism.config.js / lism.config.mjs / lism-ui.json were found.',
-  },
-  'config.cliSectionMissing': {
-    ja: '{filename} から CLI 設定（cli キー）を読み込めませんでした。',
-    en: 'Failed to read the CLI config (cli key) from {filename}.',
-  },
   'config.invalidFramework': {
-    ja: 'cli.framework は "react" または "astro" を指定してください。',
-    en: 'cli.framework must be "react" or "astro".',
+    ja: 'ui.framework は "react" または "astro" を指定してください。',
+    en: 'ui.framework must be "react" or "astro".',
   },
   'config.invalidComponentsDir': {
-    ja: 'cli.componentsDir は文字列で指定してください。',
-    en: 'cli.componentsDir must be a string.',
+    ja: 'ui.componentsDir は文字列で指定してください。',
+    en: 'ui.componentsDir must be a string.',
   },
   'config.invalidHelperDir': {
-    ja: 'cli.helperDir は文字列で指定してください。',
-    en: 'cli.helperDir must be a string.',
+    ja: 'ui.helperDir は文字列で指定してください。',
+    en: 'ui.helperDir must be a string.',
+  },
+  'config.cliKeyDeprecated': {
+    ja: '[deprecated] {filename} の "cli:" キーは "ui:" への変更が推奨されています。',
+    en: '[deprecated] The "cli:" key in {filename} is recommended to be renamed to "ui:".',
   },
   'config.loadFailed': {
     ja: '{path} を読み込めませんでした（構文エラー等）。修正してから再実行してください: {reason}',

--- a/packages/lism-cli/src/messages.ts
+++ b/packages/lism-cli/src/messages.ts
@@ -54,8 +54,8 @@ export const messages = {
     en: 'Manage Lism UI components',
   },
   'cli.ui.init.description': {
-    ja: 'lism.config.js の ui セクションを生成する',
-    en: 'Generate the ui section of lism.config.js',
+    ja: 'lism.config の ui セクションを生成する',
+    en: 'Generate the ui section of lism.config',
   },
   'cli.ui.init.opt.framework': {
     ja: 'フレームワーク',
@@ -321,8 +321,8 @@ export const messages = {
     en: '{filename} already has a ui section configured.',
   },
   'ui.init.snippetGuide': {
-    ja: '次回から同じ質問をされないために、{filename} に以下を貼り付けてください:\n\n{snippet}\n',
-    en: 'To avoid being asked these questions again, paste the following into {filename}:\n\n{snippet}\n',
+    ja: '次回から同じ質問をされないために、{filename} の export default オブジェクト内に以下を貼り付けてください:\n\n{snippet}\n',
+    en: 'To avoid being asked these questions again, paste the following inside the exported config object in {filename}:\n\n{snippet}\n',
   },
 
   // ui list


### PR DESCRIPTION
## Summary

- `lism ui init`/`lism ui add` が `lism.config.js` の `cli` セクションを正規表現ベースで自動書き換えしていた仕組み（`patchConfigWithCli`/`findInsertPosition`/`removeCliSection`）を全廃。既存ファイルがある場合は自動編集せず、貼り付け用スニペットを案内するだけにした
- 設定キーを `cli:` から `ui:` にリネーム（後方互換のフォールバック + deprecation 警告つき）。`ui`/`cli` キーが明示的にあれば厳格に検証し、無い場合のみモジュール全体を旧形式として試す（`ui: null` のような「キーはあるが値が不正」なケースを黒く無視しない）
- `readConfig()` を non-throw 化。CSS カスタマイズ専用の `lism.config.js`（`ui` セクション無し）で `lism ui add` が未捕捉エラーで落ちていたバグを修正し、対話プロンプトへのフォールバックに変更
- `lism ui add` 実行時に `ui` セクションが無い場合、`framework` のみ対話で収集 → メモリ上の値でコンポーネントを配置（ファイルは書き換えない）→ 配置成功後に貼り付け用スニペットを案内
- **`componentsDir`/`helperDir` は対話プロンプトの対象から外し、常に既定値（または `--components-dir`/`--helper-dir` 指定値）を採用**。これらは本質的に config に書く値であり、毎回対話で尋ねる必要は無いと判断（カスタマイズしたい場合はフラグ、または `lism.config.js` の `ui:` セクションを直接編集）。`framework` は react/astro を確実に自動判定できない（Astro + React アイランド併用等）ため唯一の対話質問として残す
- `-f, --force` オプションを `ui init` から削除（自動上書き機構自体が無くなったため不要）。`ui add` に `--framework`/`--components-dir`/`--helper-dir` を追加し、`ui init` と対称な非対話フラグを揃えた
- `writeFreshConfig()` は既存ファイルがある場合に throw するよう変更（コメントと実装の不一致を解消）

## Background

issue #445 の調査から派生した一連の課題（#449-#454）の一つ。詳細な議論・確定仕様は #452 を参照。

GitHub Copilot のレビューで合計4件の指摘を受け、いずれも妥当と判断して対応済み（スニペット案内のファイル名が `.mjs` 環境で誤っていた件、`writeFreshConfig` の意図と実装の不一致、`??` フォールバックが `ui: null` 等を黒く隠す件、`--framework` だけでは非対話環境で `componentsDir`/`helperDir` の prompt で停止する件）。

## Test plan

- [x] `pnpm --filter lism-cli test`（101テスト全合格、新規4ファイル追加）
- [x] `pnpm --filter lism-cli exec tsc --noEmit`（新規コードに型エラー無し）
- [x] `pnpm --filter lism-cli exec eslint 'src/**/*.ts'`（クリーン）
- [x] 実際にビルドした CLI バイナリで手動確認:
  - CSS専用 `lism.config.js`（`ui`セクション無し）に対する `lism ui init` → ファイル不変、スニペット表示のみ
  - 旧 `cli:` キーに対する `lism ui init` → deprecation警告 + alreadyExists警告
  - 設定ファイル無しでの `lism ui add Button`（対話） → コンポーネント配置成功、`lism.config.js` 未作成、スニペット案内表示
  - `ui:` セクションありでの `lism ui add Button` → prompt無し、スニペット無し、ファイル不変
  - `stdin < /dev/null`（完全な非対話環境）で `lism ui add Button --framework react` が停止せずに完走すること

Refs #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `ui add` に `--framework`、`--components-dir`、`--helper-dir` オプションを追加
  * `--framework` 指定時は対話なしで完了（未指定時のみフレームワークを対話選択）

* **改善**
  * 設定ファイル未存在時は対話でUI設定を取得して進行
  * 設定済みの場合は、次回利用向けのUIスニペット案内を表示

* **変更点**
  * `ui init` の `--force` オプションを廃止

* **テスト**
  * 初期化・追加・設定読み書き・スニペット生成のテストを拡充
<!-- end of auto-generated comment: release notes by coderabbit.ai -->