### PR TITLE
ci: typecheck を横断コマンド化し lism-ui/plugin の漏れを解消

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
             packages/*/.astro
             apps/*/.astro
 
-  typecheck-lism-css:
+  typecheck:
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -62,36 +62,8 @@ jobs:
           name: dist
           path: .
 
-      - name: Typecheck lism-css
-        run: pnpm --filter lism-css run typecheck
-
-  typecheck-docs:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: .
-
-      - name: Typecheck docs
-        run: pnpm --filter lism-docs run typecheck
+      - name: Run typecheck
+        run: pnpm typecheck
 
   lint:
     needs: build


### PR DESCRIPTION
## Summary
- `typecheck-lism-css` / `typecheck-docs` の個別ジョブを廃止し、`lint` と同様に `pnpm typecheck`（`turbo run typecheck`）を実行する単一の `typecheck` ジョブに統合
- これにより typecheck スクリプトを持つ `@lism-css/ui`・`@lism-css/plugin` も CI でチェック対象になる（従来は漏れていた）

## Test plan
- [x] ローカルで `pnpm typecheck` が成功すること（8タスク成功を確認済み）
- [x] この PR の CI 上で `Test` ワークフローの `typecheck` ジョブが green になること

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストには、ユーザーに表示される機能変更はありません。

* **チア**
  * CI/CDパイプラインの型チェック処理を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->