### PR TITLE
fix(mcp): Prop検索が分冊されたall-props.mdを読まずnr testが失敗する問題を修正

### DIFF
--- a/.claude/commands/update-skill-template.md
+++ b/.claude/commands/update-skill-template.md
@@ -1,6 +1,6 @@
 # Skill Template Update
 
-`skills/lism-css-guide/` 配下のルートファイル＋ `primitives/` サブフォルダ配下のプリミティブ詳細ファイルを、最新ソースに合わせて更新してください。
+`skills/lism-css-guide/` 配下のルートファイル＋サブフォルダ（`primitives/` / `trait-class/` / `property-class/`）配下の詳細ファイルを、最新ソースに合わせて更新してください。
 
 
 ## 対象ファイルと更新内容
@@ -14,7 +14,7 @@
 | `set-class.md` | `set--`クラス (`set--plain`,`set--revert`,`set--bxsh`,`set--hov`,`set--bdrsInner`) の一覧と用途解説 | `packages/lism-css/src/scss/base/set/`, `packages/lism-css/src/scss/base/tokens/_shadow.scss` |
 | `primitive-class.md` | Primitive クラス (`is--`, `l--`, `a--`) と Component クラス (`c--`) の一覧と用途（※俯瞰マップに徹する。個別 Primitive へのリンクは載せない） | `packages/lism-css/src/scss/primitives/`, `packages/lism-ui/src/`（c-- 系） |
 | `utility-class.md` | ユーティリティクラス (`u--` クラス) の一覧とProperty Class との違い | `packages/lism-css/src/scss/utility/` |
-| `property-class.md` | Property Class (`-{prop}:{value}`)の一覧、記法と出力の解説、特殊Prop（ボーダー・ホバー） | `packages/lism-css/config/defaults/props.ts`, `packages/lism-css/src/scss/_prop-config.scss`, `packages/lism-css/src/scss/props/` |
+| `property-class.md` | Property Class (`-{prop}:{value}`) の記法と出力の解説、Prop早見リスト、分冊へのリンク一覧（全Prop表・特殊Propの詳細は `property-class/` 配下に分冊済み） | `packages/lism-css/config/defaults/props.ts`, `packages/lism-css/src/scss/_prop-config.scss`, `packages/lism-css/src/scss/props/` |
 | `responsive.md` | レスポンシブ対応 — ブレークポイント・コンテナクエリ・HTML/コンポーネントでの指定方法 | `packages/lism-css/src/scss/_query.scss`, `packages/lism-css/src/lib/getBpData.ts` |
 | `components-core.md` | コアコンポーネント — セマンティック・Lism Props・getLismProps。Atomic/Trait/Layout の対応表には `primitives/*.md` への詳細リンクを保持する（※個別 Props・仕様の詳細は `primitives/*.md` 側に移管済み） | `packages/lism-css/src/components/`, 各パッケージの exports |
 | `components-ui.md` | UIコンポーネント（`@lism-css/ui`）— Accordion・Modal・Tabs・Button 等の Props・構造・CLI | `packages/lism-ui/src/`, 各パッケージの exports |
@@ -23,7 +23,18 @@
 | `naming.md` | 命名規則 — CSS変数名・クラス名・Property Class の `{prop}` / `{value}` 省略ルール | `packages/lism-css/config/defaults/props.ts`, `apps/docs/src/content/ja/naming.mdx` |
 | `customize.md` | カスタマイズ — @layerオフ・SCSS変数上書き・lism.config.js・CLIビルド | `packages/lism-css/src/scss/`, `packages/lism-css/lism.config.js`, `apps/docs/src/content/ja/customize.mdx` |
 
-### `primitives/` サブフォルダ配下の Primitive 詳細ファイル
+### `property-class/` サブフォルダ配下の分冊ファイル
+
+`property-class.md` から分冊された詳細ファイル。本体と分冊の間で内容の重複・矛盾が生じないよう、セットで照合すること。
+
+| ファイル | 更新内容 | 主なソース参照先 |
+|----------|----------|-----------------|
+| `property-class/all-props.md` | 全 Prop 一覧の詳細表（プリセット値クラス・BP 対応） | `packages/lism-css/config/defaults/props.ts`, `packages/lism-css/src/scss/_prop-config.scss` |
+| `property-class/bd.md` | ボーダー（`bd` 系）の詳細 | `packages/lism-css/src/scss/props/_border.scss`, `apps/docs/src/content/ja/property-class/bd.mdx` |
+| `property-class/hov.md` | ホバー（`hov` 系）の詳細 | `packages/lism-css/src/scss/props/_hover.scss`, `apps/docs/src/content/ja/property-class/hov.mdx` |
+| `property-class/max-sz.md` | `-max-sz:full` / `-max-sz:bleed` 等の特殊クラスの詳細 | `packages/lism-css/src/scss/props/_size.scss`, `apps/docs/src/content/ja/property-class/max-sz.mdx` |
+
+### `primitives/` / `trait-class/` サブフォルダ配下の Primitive 詳細ファイル
 
 各 Primitive に 1 ファイル。クラス名は camelCase のまま（例: `l--withSide.md`, `l--tileGrid.md`, `is--boxLink.md`）、MDX 側は lowercase（`l--withside.mdx` 等）であることに注意。
 
@@ -150,7 +161,7 @@
 
 ### 1. 現在のテンプレートとバージョン情報の取得
 
-- `skills/lism-css-guide/` 配下のルートファイル＋ `primitives/` 配下の全ファイルを読み取る
+- `skills/lism-css-guide/` 配下のルートファイル＋ `primitives/` / `trait-class/` / `property-class/` 配下の全ファイルを読み取る
 - `packages/lism-css/package.json` からバージョンを取得し、`SKILL.md` のバージョン表記と比較する
 - `primitives/` 配下の存在チェック: `packages/lism-css/src/scss/primitives/{layout,trait,atomic}/` 配下の SCSS と `primitives/*.md` が 1:1 対応しているか、さらに `SKILL.md` の「プリミティブ単位の詳細リファレンス」セクションのリンクと実ファイルが一致するかを確認（数値ではなくソースの実体を基準にする）
 

--- a/packages/mcp/src/lib/load-markdown.ts
+++ b/packages/mcp/src/lib/load-markdown.ts
@@ -22,6 +22,16 @@ export function loadMarkdown(filename: string): string {
   return content;
 }
 
+// Prop 検索・変換で参照するファイル群。
+// 全 Prop の実テーブルは property-class/all-props.md に分冊されているため、
+// property-class.md 単体では bd 系などの一部しか拾えない（#474）。
+const PROP_SOURCE_FILES = ['property-class.md', 'property-class/all-props.md'];
+
+/** Prop 検索用の Markdown（property-class.md + 分冊の all-props.md）を結合して返す */
+export function loadPropsMarkdown(): string {
+  return PROP_SOURCE_FILES.map((filename) => loadMarkdown(filename)).join('\n\n');
+}
+
 /** guidesDir 配下を再帰的に走査し、`.md` ファイルの相対パス（posix 区切り）を返す */
 function walkMarkdownFiles(dir: string, baseDir: string = dir): string[] {
   const results: string[] = [];

--- a/packages/mcp/src/tests/tools.test.ts
+++ b/packages/mcp/src/tests/tools.test.ts
@@ -194,6 +194,23 @@ describe('MCP Tools (integration)', () => {
     expect(text).toContain('md');
   });
 
+  it('get_guide で property-class トピックが分冊（all-props / bd / hov / max-sz）を含む Markdown を返す', async () => {
+    const client = await createTestClient();
+    const result = await client.callTool({ name: 'get_guide', arguments: { topic: 'property-class' } });
+    expect(result.isError).toBeFalsy();
+
+    const text = getText(result);
+    // 本体
+    expect(text).toContain('Property Class');
+    // all-props.md の全 Prop 表（本体には存在しない行）
+    expect(text).toContain('`mt`');
+    expect(text).toContain('margin-top');
+    // bd.md / hov.md / max-sz.md
+    expect(text).toContain('-bd-');
+    expect(text).toContain('-hov:');
+    expect(text).toContain('-max-sz:bleed');
+  });
+
   it('get_guide で antipatterns トピックが NG/OK カタログの Markdown を返す', async () => {
     const client = await createTestClient();
     const result = await client.callTool({ name: 'get_guide', arguments: { topic: 'antipatterns' } });

--- a/packages/mcp/src/tools/convert-css.ts
+++ b/packages/mcp/src/tools/convert-css.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { loadMarkdown } from '../lib/load-markdown.js';
+import { loadPropsMarkdown } from '../lib/load-markdown.js';
 import { parsePropRows, type PropRow } from '../lib/markdown-utils.js';
 import { success, error, READ_ONLY_ANNOTATIONS } from '../lib/response.js';
 
@@ -284,7 +284,7 @@ export function registerConvertCss(server: McpServer): void {
           return error(atRuleError);
         }
 
-        const md = loadMarkdown('property-class.md');
+        const md = loadPropsMarkdown();
         const mappings = buildMappings(md);
         const cssPropertyMap = buildCssPropertyMap(mappings);
 

--- a/packages/mcp/src/tools/get-guide.ts
+++ b/packages/mcp/src/tools/get-guide.ts
@@ -3,33 +3,38 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { loadMarkdown } from '../lib/load-markdown.js';
 import { markdownResponse, error, READ_ONLY_ANNOTATIONS } from '../lib/response.js';
 
+// files に複数指定したトピックは結合して返す。
+// MCP クライアントは Markdown 内の相対リンクを辿れないため、分冊ファイルは本体に結合する。
 const GUIDE_TOPICS = {
-  overview: { file: 'SKILL.md', label: 'Framework overview, packages, implementation rules' },
-  tokens: { file: 'tokens.md', label: 'Design tokens (spacing, colors, font sizes, etc.)' },
-  'property-class': { file: 'property-class.md', label: 'Property Class system, all props reference table' },
+  overview: { files: ['SKILL.md'], label: 'Framework overview, packages, implementation rules' },
+  tokens: { files: ['tokens.md'], label: 'Design tokens (spacing, colors, font sizes, etc.)' },
+  'property-class': {
+    files: ['property-class.md', 'property-class/all-props.md', 'property-class/bd.md', 'property-class/hov.md', 'property-class/max-sz.md'],
+    label: 'Property Class system, all props reference table, border (bd) / hover (hov) / max-sz details',
+  },
   'components-core': {
-    file: 'components-core.md',
+    files: ['components-core.md'],
     label: 'Core component system (Lism, Box, Flex, Stack, Grid, etc.)',
   },
   'components-ui': {
-    file: 'components-ui.md',
+    files: ['components-ui.md'],
     label: 'UI components (Accordion, Modal, Tabs, Button, etc.)',
   },
-  'base-styles': { file: 'base-styles.md', label: 'Base styling, reset CSS, HTML element styles' },
-  'set-class': { file: 'set-class.md', label: 'Set classes (set--plain, set--bxsh, set--hov, etc.)' },
+  'base-styles': { files: ['base-styles.md'], label: 'Base styling, reset CSS, HTML element styles' },
+  'set-class': { files: ['set-class.md'], label: 'Set classes (set--plain, set--bxsh, set--hov, etc.)' },
   'primitive-class': {
-    file: 'primitive-class.md',
+    files: ['primitive-class.md'],
     label: 'Primitive class prefixes (is--, l--, a--) and Component class (c--), with column-layout primitive selection guide',
   },
-  'utility-class': { file: 'utility-class.md', label: 'Utility classes (u--trim, u--cbox, etc.)' },
-  'css-rules': { file: 'css-rules.md', label: 'CSS methodology, layer structure, naming conventions' },
-  responsive: { file: 'responsive.md', label: 'Responsive design, breakpoints, container queries' },
+  'utility-class': { files: ['utility-class.md'], label: 'Utility classes (u--trim, u--cbox, etc.)' },
+  'css-rules': { files: ['css-rules.md'], label: 'CSS methodology, layer structure, naming conventions' },
+  responsive: { files: ['responsive.md'], label: 'Responsive design, breakpoints, container queries' },
   antipatterns: {
-    file: 'antipatterns.md',
+    files: ['antipatterns.md'],
     label: 'AI code-generation antipatterns (values / style declarations): px hardcoding, token typos, keycolor misuse, prop type mistakes',
   },
   'antipatterns-layout': {
-    file: 'antipatterns-layout.md',
+    files: ['antipatterns-layout.md'],
     label:
       'AI code-generation antipatterns (structure / layout / responsive): layout choice errors, responsive omissions, is-- misuse, naming mistakes',
   },
@@ -57,8 +62,8 @@ export function registerGetGuide(server: McpServer): void {
     },
     ({ topic }) => {
       try {
-        const { file } = GUIDE_TOPICS[topic];
-        return markdownResponse(loadMarkdown(file));
+        const { files } = GUIDE_TOPICS[topic];
+        return markdownResponse(files.map((file) => loadMarkdown(file)).join('\n\n'));
       } catch (e) {
         return error(
           `Failed to load guide "${topic}": ${e instanceof Error ? e.message : String(e)}. The data files may not be built yet. Run "pnpm build" in packages/mcp first.`

--- a/packages/mcp/src/tools/get-props-system.ts
+++ b/packages/mcp/src/tools/get-props-system.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { loadMarkdown } from '../lib/load-markdown.js';
+import { loadPropsMarkdown } from '../lib/load-markdown.js';
 import { parsePropRows } from '../lib/markdown-utils.js';
 import { parsePropClassName } from '../lib/search.js';
 import { markdownResponse, error, notFound, READ_ONLY_ANNOTATIONS } from '../lib/response.js';
@@ -35,7 +35,7 @@ export function registerGetPropsSystem(server: McpServer): void {
     },
     ({ prop }) => {
       try {
-        const md = loadMarkdown('property-class.md');
+        const md = loadPropsMarkdown();
 
         // prop 未指定: 全文を返す
         if (!prop) {

--- a/packages/mcp/src/tools/search-docs.ts
+++ b/packages/mcp/src/tools/search-docs.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { loadJSON } from '../lib/load-data.js';
-import { loadMarkdown } from '../lib/load-markdown.js';
+import { loadPropsMarkdown } from '../lib/load-markdown.js';
 import { DocsEntrySchema } from '../lib/schemas.js';
 import { parsePropRows } from '../lib/markdown-utils.js';
 import { searchDocs } from '../lib/search.js';
@@ -44,7 +44,7 @@ export function registerSearchDocs(server: McpServer): void {
     ({ query, category, limit }) => {
       try {
         const entries = loadJSON('docs-index.json', z.array(DocsEntrySchema));
-        const cssPropertyMap = buildCssPropertyMapFromMarkdown(loadMarkdown('property-class.md'));
+        const cssPropertyMap = buildCssPropertyMapFromMarkdown(loadPropsMarkdown());
         const results = searchDocs(entries, query, { category, limit, cssPropertyMap });
         return success({ query, results });
       } catch (e) {

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,11 @@
         "src/scss/base/tokens/_tokens.gen.scss"
       ]
     },
+    "@lism-css/mcp#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/skills/lism-css-guide/**"],
+      "outputs": ["dist/**"]
+    },
     "build:css": {
       "inputs": [
         "$TURBO_DEFAULT$",


### PR DESCRIPTION
## 概要

`@lism-css/mcp`のProp検索・変換処理が`property-class.md`だけを読んでProp表を構築していたため、`property-class/all-props.md`へ分冊された実テーブル（`p`/`g`/`mt`など）が索引に入らず、`nr test`で4件のテストが失敗していた問題を修正します。

あわせて、同じ分冊化（#473）へのフォローアップとして`get_guide`ツールと`/update-skill-template`コマンドも追従させます。

Closes #474

## 変更内容

### Prop検索の分冊対応（Issue本体）

- `lib/load-markdown.ts`に共通ヘルパー`loadPropsMarkdown()`を追加。Prop検索用のMarkdownとして`property-class.md`+`property-class/all-props.md`を結合して返す
- 以下の3ツールで`loadMarkdown('property-class.md')`を`loadPropsMarkdown()`に置き換え
  - `get_props_system`（`tools/get-props-system.ts`）
  - `convert_css`（`tools/convert-css.ts`）
  - `search_docs`のCSSプロパティ展開（`tools/search-docs.ts`）

Issueの「やらないこと」の通り、`property-class.md`へ全Prop表を戻す対応はしていません（分冊運用を維持し、MCP側が分冊を読むように修正）。

### `get_guide`の分冊対応（フォローアップ）

- `property-class`トピックが分冊前提のハブファイルだけを返しており、MCPクライアントは`./property-class/all-props.md`等の相対リンクを辿れないため、分冊4ファイル（`all-props.md`/`bd.md`/`hov.md`/`max-sz.md`）を本体に結合して返すように変更
- `GUIDE_TOPICS`を`files`配列に統一し、トピックのラベルも実内容に合わせて更新
- 分冊が含まれることを検証するテストを追加

### `/update-skill-template`コマンドの追従（フォローアップ）

- 対象範囲が「ルートファイル＋`primitives/`」のままだったため、`property-class/`・`trait-class/`配下の分冊ファイルを対象範囲と作業手順に追記
- `property-class/`分冊4ファイルの更新内容・ソース参照先テーブルを追加

### Turboキャッシュの入力追加（レビュー指摘対応）

- `@lism-css/mcp`のbuildは`skills/lism-css-guide/`を`dist/data/guides`へコピーするが、Turboのbuild入力に含まれておらず、ガイドだけ変更した場合に古い`dist/data/guides`がキャッシュから再利用される恐れがあった
- `turbo.json`に`@lism-css/mcp#build`のオーバーライドを追加し、入力へ`$TURBO_ROOT$/skills/lism-css-guide/**`を追加

なお、npm配布時のフォールバック（`dist/data/guides/`）はビルドスクリプトが`skills/lism-css-guide`ディレクトリ全体をコピーするため、分冊ファイルもそのまま読めます。また、公開済みの`@lism-css/mcp@0.23.0`には分冊化（#473）自体が含まれていないため影響はありません。

## 確認内容

- `nr test --filter=./packages/mcp` → 54件すべて通過（修正前は4件失敗、`get_guide`のテスト1件を追加）
- `nr test`（ルート）→ 11タスクすべて成功
- `pnpm --filter @lism-css/mcp build` → tscコンパイル成功
- `turbo build --filter=@lism-css/mcp --dry=json`で入力に`skills/lism-css-guide/`配下48ファイルが含まれること、`all-props.md`変更でタスクハッシュが変わる（=キャッシュが無効化される）ことを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `get_guide` の `property-class` 取得で、分冊ドキュメントをまとめて結合して返すようになりました。
* **改善**
  * プロップ検索・変換・取得系で参照するMarkdownを統合形式へ切り替え、より一貫したプロップ情報に基づいて処理します。
* **テスト**
  * `property-class` の分冊内容（特徴的な記号/文字列）を含むことを確認する統合テストを追加しました。
* **ドキュメント**
  * スキルテンプレートの更新対象範囲と章立てを拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->