### PR TITLE
fix: lism-uiのstoriesでcanvasElementがanyになる型解決を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "astro-eslint-parser": "^1.4.0",
     "autoprefixer": "^10.4.27",
     "cross-env": "^7.0.3",

--- a/packages/lism-ui/tsconfig.astro.json
+++ b/packages/lism-ui/tsconfig.astro.json
@@ -1,5 +1,5 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": ["src/**/*.astro", "src/**/*.ts"],
-  "exclude": ["dist"]
+  "exclude": ["dist", "src/**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       astro-eslint-parser:
         specifier: ^1.4.0
         version: 1.4.0


### PR DESCRIPTION
## 概要

`packages/lism-ui` の Storybook ストーリー4ファイルで、`play` 関数の `canvasElement` が `any` と推論され、eslint（`@typescript-eslint/no-unsafe-argument`）8件と `tsc --noEmit` の TS7031 が8件発生していた問題を修正します。

Closes #478

## 原因

`StoryObj` 型そのものが `any` に崩壊していました。メカニズムは以下の通りです。

1. `@storybook/react` は `@types/react` を依存関係に持たないため、pnpm 仮想ストア内の `@storybook/react/dist/index.d.ts` から `import ... from 'react'` の型定義（`@types/react`）を解決できない（TS7016）。ルートの `node_modules/@types` にも `react` がないため、walk-up 解決も失敗する
2. この d.ts 内のエラーは `skipLibCheck: true` により握り潰され、`ComponentType` / `ComponentProps` 等が暗黙の `any` になる
3. その結果 `StoryObj` 全体が `any` に評価され、`play` 関数の引数に文脈型が付かず TS7031 / eslint エラーが発生

`--traceResolution` ではモジュール解決自体（`@storybook/react-vite` → `@storybook/react` → `storybook/internal/types`）は全て成功しており、`--skipLibCheck false` で実行することで上記の TS7016 を特定しました。

## Issue の確認事項への回答

- **`StoryObj` の `play` シグネチャが `any` になる原因**: 上記の通り。tsconfig の `types: ["node"]` は無関係でした（`types` オプションはグローバル型の自動読み込みのみに影響し、import の解決には影響しない）
- **ルートの `nr typecheck` で検出されていなかった理由**: 現在の `dev` では再現せず、ルートの `nr typecheck` でも同じ8件のエラーで失敗します。起票時に検出されなかったのは Turbo キャッシュのヒットによるものと推測されます

## 変更内容

### 1. ルートに `@types/react` / `@types/react-dom` を追加（本修正）

ルートの `node_modules/@types/react` に配置されることで、pnpm 仮想ストア内の d.ts からの walk-up 解決が成功するようになります。ワークスペース内の `@types/react` は全て `19.2.14` に統一されているため、バージョン競合はありません（各パッケージ自身の `node_modules/@types` が優先されるため、既存パッケージの解決には影響しません）。

修正後は `StoryObj` が `StoryAnnotations<ReactRenderer, ...>` に正しく解決され、`canvasElement` に `HTMLElement` が付きます。

### 2. `tsconfig.astro.json` からテストファイルを除外（付随修正）

`tsc --noEmit` が通るようになったことで、`&&` で隠れていた `astro check` の既存エラー43件（`setAccordion.test.ts` 等3ファイルの jest-dom マッチャー型エラー、#365 でテスト追加時から存在）が顕在化しました。

原因は、jest-dom の型拡張を読み込む `vitest.setup.ts`（パッケージ直下）が `tsconfig.astro.json` の `include`（`src/**` のみ）に含まれないためです。テストファイルは本体の `tsc --noEmit` 側で既に型チェックされているため、`.astro` ファイル検証用の `astro check` からは除外しました。

## 検証

- `packages/lism-ui` で `nr lint` / `nr typecheck` が通ることを確認
- ルートで `nr typecheck`（8/8）/ `nr lint`（4/4）/ `nr test`（11/11）が全て成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BTwktZYjKCs1gdhFij4Eg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発用の型定義パッケージが追加され、React/ReactDOM 関連の型チェックがより安定しました。
  * テスト関連のファイルがビルド対象から除外され、開発時の設定が整理されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->