### PR TITLE
ci: GitHub Actionsワークフローに最小権限のpermissionsを明示

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - dev
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

`.github/workflows/test.yml` のトップレベルに `permissions: contents: read` を追加し、CI の `GITHUB_TOKEN` 権限を読み取り専用に明示しました。

## 変更内容

- ワークフロートップレベルに以下を追加

```yaml
permissions:
  contents: read
```

## 補足

- `typecheck` ジョブ単体ではなく、全ジョブに適用されるトップレベルで指定しています。
- リポジトリ設定に依存せず、ワークフローファイル単体で必要権限が分かるようにしています。

Closes #464


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * テスト用ワークフローの実行権限を見直し、`contents` を読み取り専用に制限しました。
  * ジョブの処理内容は変更せず、実行時の権限をより明確にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->