### PR TITLE
skill(lism-css-guide): PNG再現テストで判明したアンチパターン2件を追記 (#485)

### DIFF
--- a/skills/lism-css-guide/antipatterns-layout.md
+++ b/skills/lism-css-guide/antipatterns-layout.md
@@ -11,6 +11,8 @@
 - [全面リンクの手組み（`BoxLink` 未使用）](#全面リンクの手組みboxlink-未使用)
 - [primitive 既定値の重複指定](#primitive-既定値の重複指定)
 - [サイト最外殻を `Wrapper` に使う](#サイト最外殻を-wrapper-に使う)
+- [row 方向の `Flex` / `Cluster` 直下に `Wrapper` を置く](#row-方向の-flex--cluster-直下に-wrapper-を置く)
+- [セクション外殻を `Flex` + `min-h` で組む](#セクション外殻を-flex--min-h-で組む)
 - [標準 HTML 属性を `exProps` に入れる](#標準-html-属性を-exprops-に入れる)
 - [レスポンシブ抜け](#レスポンシブ抜け)
 - [レスポンシブ配列の冗長指定](#レスポンシブ配列の冗長指定)
@@ -107,6 +109,22 @@ Primitiveが既に持つCSSと同じ値を、Lism Props/Property Classで重ね�
 | `<main className="is--wrapper">`をページ全体に付与 | `<main className="z--main"><Wrapper>...</Wrapper></main>` | ゾーニングは`z--*`、幅制限は`Wrapper` |
 
 `Wrapper`直下の子要素には幅に関する既定が当たるため、最外殻に置くと予期しない幅制御を生むことがある。
+
+## row 方向の `Flex` / `Cluster` 直下に `Wrapper` を置く
+
+`is--wrapper`は直下の子に幅を配るだけで、自身の幅を決める宣言を持たない。row方向のflexアイテムになるとコンテンツ幅まで縮み、内側の`jc="between"`等が広がる余地を失う。外殻は`Group`等のブロック要素にする。
+
+| NG | OK | 理由 |
+| --- | --- | --- |
+| `<Flex as="header" ai="center"><Wrapper>...</Wrapper></Flex>` | `<Group as="header" py="20"><Wrapper>...</Wrapper></Group>` | flexアイテム化した`Wrapper`は幅が縮み、両端寄せ等が効かなくなる |
+
+## セクション外殻を `Flex` + `min-h` で組む
+
+ヘッダー等のセクション外殻を、デザイン実測の高さを再現するために`Flex`＋`ai="center"`＋`min-h`で組まない。高さは`py`とコンテンツが決める（→ [page-sections.md](./references/page-sections.md)）。
+
+| NG | OK | 理由 |
+| --- | --- | --- |
+| `<Flex as="header" ai="center" min-h="77px">` | `<Group as="header" py="20">` | セクションの高さをデザインpxで固定しない |
 
 ## 標準 HTML 属性を `exProps` に入れる
 

--- a/skills/lism-css-guide/antipatterns.md
+++ b/skills/lism-css-guide/antipatterns.md
@@ -26,6 +26,8 @@ AI が Lism CSS のコードを生成する際に間違いやすい記法と、�
 - [全面リンクの手組み（`BoxLink` 未使用）](./antipatterns-layout.md#全面リンクの手組みboxlink-未使用)
 - [primitive 既定値の重複指定](./antipatterns-layout.md#primitive-既定値の重複指定)
 - [サイト最外殻を `Wrapper` に使う](./antipatterns-layout.md#サイト最外殻を-wrapper-に使う)
+- [row 方向の `Flex` / `Cluster` 直下に `Wrapper` を置く](./antipatterns-layout.md#row-方向の-flex--cluster-直下に-wrapper-を置く)
+- [セクション外殻を `Flex` + `min-h` で組む](./antipatterns-layout.md#セクション外殻を-flex--min-h-で組む)
 - [標準 HTML 属性を `exProps` に入れる](./antipatterns-layout.md#標準-html-属性を-exprops-に入れる)
 - [レスポンシブ抜け](./antipatterns-layout.md#レスポンシブ抜け)
 - [レスポンシブ配列の冗長指定](./antipatterns-layout.md#レスポンシブ配列の冗長指定)
@@ -244,4 +246,12 @@ Lism CSSのreset/base styleで既に初期化されている値を、念のた�
 | --- | --- | --- |
 | `<Columns cols="1,2,3">` | `<Columns cols={[1, 2, 3]}>` | レスポンシブは配列 |
 | `<Box p="20 30 40">` | `<Box p={[20, 30, 40]}>` | 同上 |
+
+### BP 非対応 Prop への配列指定
+
+レスポンシブ配列を渡せるのは BP 対応の Prop だけ。BP 対応可否は [all-props.md](./property-class/all-props.md) の BP 列で確認する。
+
+| NG | OK | 理由 |
+| --- | --- | --- |
+| `<Grid cg={['40', null, '80']}>` | `<Grid g={['40', null, '80']}>` または `<Grid cg="40">` | `cg` / `rg` は BP 非対応。レスポンシブにするなら BP 対応の `g` を使うか、単一値にする |
 


### PR DESCRIPTION
Closes #485

## 概要

PNGデザイン再現テストで判明したアンチパターン2件を、`lism-css-guide`スキルの既存詳細ファイルへ最小追記しました。CLAUDE.mdの方針に従い、`SKILL.md`冒頭への積み増しは行っていません。

## 変更内容

### `antipatterns-layout.md`（+18行、「サイト最外殻を `Wrapper` に使う」の直後に配置）

1. **row 方向の `Flex` / `Cluster` 直下に `Wrapper` を置く**
   - `is--wrapper`は直下の子に幅を配るだけで自身の幅宣言を持たないため（`packages/lism-css/src/scss/trait/is/_wrapper.scss`で確認）、row方向のflexアイテムになるとコンテンツ幅まで縮み、`jc="between"`等が効かなくなる旨をNG/OK例で明文化
2. **セクション外殻を `Flex` + `min-h` で組む**
   - `page-sections.md`の「高さは`py`とコンテンツが決める」原則をNG/OK例として明文化（Issueで報告されたヘッダー高77px再現の逸脱パターンそのもの）

### `antipatterns.md`（+10行、「Prop 型ミス」節に追記）

3. **BP 非対応 Prop への配列指定**
   - `cg={['40', null, '80']}` → BP対応の`g`を使うか単一値にするNG/OK例を追加
   - BP対応可否は`property-class/all-props.md`のBP列で確認する導線も記載（`g`: ✔ / `cg`・`rg`: — であることをソース確認済み）

## 補足

- 追記後の行数は`antipatterns.md`が257行（260行目安内）、`antipatterns-layout.md`が268行で目安を8行超過します。分冊化はIssueの「最小追記」方針の範囲外と判断してそのままにしています。必要であれば別Issueで対応します。
- 高違反頻度の節を先頭200行以内に置く方針（#471）に従い、layout側の追記は130行目付近に配置しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMcDV6GFgKfz1RUudW6DBb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * アンチパターン集に、レイアウト・レスポンシブ関連の新しい目次項目と参照リンクを追加しました。
  * レイアウトの組み方に関する注意点として、横並び要素の直下に余白用要素を置かないこと、セクションの高さを無理に固定しないことを追記しました。
  * レスポンシブ配列の指定可否についての注意事項を追加し、対応している項目の確認方法と代替例を明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->