### PR TITLE
fix(mcp): #483 search_docs等のoutputSchemaとTS型の重複定義をzodスキーマに一本化

### DIFF
--- a/packages/mcp/src/lib/schemas.ts
+++ b/packages/mcp/src/lib/schemas.ts
@@ -15,3 +15,12 @@ export const DocsEntrySchema = z.object({
   keywords: z.array(z.string()),
   snippet: z.string(),
 });
+
+export const SearchResultSchema = z.object({
+  sourcePath: z.string(),
+  url: z.string(),
+  heading: z.string(),
+  snippet: z.string(),
+  score: z.number(),
+  nextTool: z.string().nullable(),
+});

--- a/packages/mcp/src/lib/types.ts
+++ b/packages/mcp/src/lib/types.ts
@@ -1,24 +1,6 @@
-export interface MetaInfo {
-  generatedAt: string;
-  sourceCommit: string;
-  docsVersion: string;
-}
+import type { z } from 'zod';
+import type { MetaInfoSchema, DocsEntrySchema, SearchResultSchema } from './schemas.js';
 
-export interface SearchResult {
-  sourcePath: string;
-  url: string;
-  heading: string;
-  snippet: string;
-  score: number;
-  nextTool: string | null;
-}
-
-export interface DocsEntry {
-  sourcePath: string;
-  title: string;
-  description: string;
-  category: string;
-  headings: string[];
-  keywords: string[];
-  snippet: string;
-}
+export type MetaInfo = z.infer<typeof MetaInfoSchema>;
+export type SearchResult = z.infer<typeof SearchResultSchema>;
+export type DocsEntry = z.infer<typeof DocsEntrySchema>;

--- a/packages/mcp/src/tools/convert-css.ts
+++ b/packages/mcp/src/tools/convert-css.ts
@@ -12,21 +12,23 @@ interface CssDeclaration {
 }
 
 /** 変換結果の1行 */
-interface ConversionEntry {
-  css: string;
-  lismProp: string | null;
-  suggestedValue: string | null;
-  availableTokens: string[] | null;
-  confidence: 'exact' | 'approximate' | 'unmapped';
-  note: string;
-}
+const ConversionEntrySchema = z.object({
+  css: z.string(),
+  lismProp: z.string().nullable(),
+  suggestedValue: z.string().nullable(),
+  availableTokens: z.array(z.string()).nullable(),
+  confidence: z.enum(['exact', 'approximate', 'unmapped']),
+  note: z.string(),
+});
+type ConversionEntry = z.infer<typeof ConversionEntrySchema>;
 
 /** コンポーネント提案 */
-interface ComponentSuggestion {
-  name: string;
-  reason: string;
-  implicitCss: string[];
-}
+const ComponentSuggestionSchema = z.object({
+  name: z.string(),
+  reason: z.string(),
+  implicitCss: z.array(z.string()),
+});
+type ComponentSuggestion = z.infer<typeof ComponentSuggestionSchema>;
 
 // ----------------------------------------------------------------
 // CSS パース
@@ -277,17 +279,8 @@ export function registerConvertCss(server: McpServer): void {
       },
       outputSchema: {
         meta: MetaInfoSchema,
-        conversions: z.array(
-          z.object({
-            css: z.string(),
-            lismProp: z.string().nullable(),
-            suggestedValue: z.string().nullable(),
-            availableTokens: z.array(z.string()).nullable(),
-            confidence: z.enum(['exact', 'approximate', 'unmapped']),
-            note: z.string(),
-          })
-        ),
-        suggestedComponent: z.object({ name: z.string(), reason: z.string(), implicitCss: z.array(z.string()) }).nullable(),
+        conversions: z.array(ConversionEntrySchema),
+        suggestedComponent: ComponentSuggestionSchema.nullable(),
         example: z.string(),
         tip: z.string(),
       },

--- a/packages/mcp/src/tools/search-docs.ts
+++ b/packages/mcp/src/tools/search-docs.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { loadJSON } from '../lib/load-data.js';
 import { loadPropsMarkdown } from '../lib/load-markdown.js';
-import { DocsEntrySchema, MetaInfoSchema } from '../lib/schemas.js';
+import { DocsEntrySchema, MetaInfoSchema, SearchResultSchema } from '../lib/schemas.js';
 import { parsePropRows } from '../lib/markdown-utils.js';
 import { searchDocs } from '../lib/search.js';
 import { success, loadFailureError, READ_ONLY_ANNOTATIONS } from '../lib/response.js';
@@ -43,16 +43,7 @@ export function registerSearchDocs(server: McpServer): void {
       outputSchema: {
         meta: MetaInfoSchema,
         query: z.string(),
-        results: z.array(
-          z.object({
-            sourcePath: z.string(),
-            url: z.string(),
-            heading: z.string(),
-            snippet: z.string(),
-            score: z.number(),
-            nextTool: z.string().nullable(),
-          })
-        ),
+        results: z.array(SearchResultSchema),
       },
       annotations: READ_ONLY_ANNOTATIONS,
     },


### PR DESCRIPTION
## 概要

`packages/mcp` で zod スキーマと TypeScript 型が手動で二重定義されていた箇所を、zod スキーマを唯一の定義元として `z.infer` で型を導出する形に一本化しました。

Closes #483

## 対応要否の検討結果

Issue の確認事項に沿って調査した結果、**対応する価値あり**と判断しました。

- zod の `z.object` はデフォルトで未知キーを黙って除去（strip）するため、「型・データ側にフィールドを追加したが `outputSchema` に追加し忘れた」方向のドリフトは既存テストでは検知されず、レスポンスから新フィールドが静かに消えるという実害が起こりえます（逆方向 = スキーマだけに必須フィールドが残るケースのみ検証エラーで検知可能）
- `schemas.ts` には既に `MetaInfoSchema` / `DocsEntrySchema` があり、`types.ts` の `MetaInfo` / `DocsEntry` と同種の重複が既にありました。`SearchResult` だけ直すと混在状態になるため、`types.ts` の3型すべてを `z.infer` 導出に統一しました
- 確認事項で名指しされていた `convert_css` にも同一ファイル内で同種の重複（`ConversionEntry` / `ComponentSuggestion` インターフェース ↔ `outputSchema` のインライン定義）があったため、同じパターンで解消しました

## 変更内容

- `lib/schemas.ts`: `SearchResultSchema` を追加
- `lib/types.ts`: 手書きの `MetaInfo` / `SearchResult` / `DocsEntry` インターフェースを削除し、`z.infer<typeof ...Schema>` による導出に置き換え（export 名は維持しており、既存の import 箇所への影響なし）
- `tools/search-docs.ts`: `outputSchema.results` のインライン定義を `z.array(SearchResultSchema)` に置き換え
- `tools/convert-css.ts`: `ConversionEntry` / `ComponentSuggestion` をローカルの zod スキーマ + `z.infer` に置き換え、`outputSchema` から参照する形に変更（ツール専用のため `schemas.ts` には移していません）

ランタイムのスキーマ内容・フィールドは変更前と完全に同一で、挙動の変化はありません。

## 検証

- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx vitest run` — 4ファイル・66テストすべて成功
- prettier / eslint（pre-commit hook）— 通過

※ `tsconfig.json`（tests 込み）での typecheck には、`tests/docs-index.test.ts` が `apps/docs` のファイルを rootDir 外から import していることによる既存の TS6059 エラーが1件ありますが、変更前から存在するもので本 PR とは無関係です（`git stash` で変更前状態でも再現することを確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NHvbovHKFvCHEpyVnhzDv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 検索結果の出力に、関連度スコアと次の推奨アクションを含められるようになりました。
  * 検索系の結果形式を共通化し、返却内容の一貫性が向上しました。

* **Refactor**
  * 主要なデータ形式の定義を整理し、各機能で同じルールを参照するようにしました。
  * CSS 変換やドキュメント検索の出力形式を統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->