### PR TITLE
docs: #351 AstroでLismをラップするProps型の注意点を追記

### DIFF
--- a/apps/docs/src/content/en/core-components/Lism.mdx
+++ b/apps/docs/src/content/en/core-components/Lism.mdx
@@ -58,3 +58,37 @@ import { Lism, Media } from 'lism-css/astro';
 The Lism CSS-specific props that `<Lism>` accepts (**Lism Props**) are documented in a dedicated page.
 
 <DocsLink path="/docs/core-components/lism-props/" />
+
+
+## Prop types when wrapping `<Lism>` in Astro
+
+When you build a custom component in Astro that wraps `<Lism>`, compose its prop type with an **intersection type (`&`)** instead of `interface extends`.
+
+```ts
+import { Lism } from 'lism-css/astro';
+import type { ComponentProps } from 'astro/types';
+
+type LismProps = ComponentProps<typeof Lism>;
+
+// OK: compose with an intersection type
+type Props = LismProps & {
+  class?: string;
+};
+```
+
+The prop type of `Lism` includes a union type whose accepted properties change depending on the value of `layout`. Because of this, extending it with `interface extends` results in a TypeScript error like the following.
+
+```ts
+// NG: interface extends results in an error
+interface Props extends LismProps {
+  class?: string;
+}
+// Error: An interface can only extend an object type or intersection of
+// object types with statically known members.
+```
+
+:::note
+This constraint isn't unique to `<Lism>`. Components such as `<Text>` and `<Wrapper>` that accept the `layout` prop include the same union type in their prop types, so apply the same intersection-type composition when wrapping them as well.
+
+On the other hand, layout components with a fixed `layout`, such as `<Cluster>` and `<Stack>`, don't include a union type in their prop types, so `interface extends` also works for them. That said, we recommend using intersection types consistently so the same approach works for every component.
+:::

--- a/apps/docs/src/content/ja/core-components/Lism.mdx
+++ b/apps/docs/src/content/ja/core-components/Lism.mdx
@@ -58,3 +58,37 @@ import { Lism, Media } from 'lism-css/astro';
 `<Lism>`が受け取る Lism CSS 専用プロパティ（**Lism Props**）については、別ページで詳しく解説しています。
 
 <DocsLink path="/docs/core-components/lism-props/" />
+
+
+## Astroで`<Lism>`をラップする際のProps型
+
+Astroで`<Lism>`をラップした独自コンポーネントを作る場合、Props型は`interface extends`ではなく**交差型（`&`）**で合成してください。
+
+```ts
+import { Lism } from 'lism-css/astro';
+import type { ComponentProps } from 'astro/types';
+
+type LismProps = ComponentProps<typeof Lism>;
+
+// OK: 交差型で合成する
+type Props = LismProps & {
+  class?: string;
+};
+```
+
+`Lism`のProps型には、`layout`の値によって受け取れるプロパティが切り替わるユニオン型が含まれています。そのため、`interface extends`で拡張しようとすると次のようなTypeScriptエラーになります。
+
+```ts
+// NG: interface extends はエラーになる
+interface Props extends LismProps {
+  class?: string;
+}
+// エラー: インターフェイスが拡張できるのは、オブジェクト型または
+// 静的な既知のメンバーを持つオブジェクト型の積集合のみです。
+```
+
+:::note
+この制約は`<Lism>`だけのものではありません。`<Text>`や`<Wrapper>`など、`layout` Propを受け取れるコンポーネントのProps型にも同じユニオン型が含まれるため、これらをラップする場合も同様に交差型で合成してください。
+
+一方、`<Cluster>`や`<Stack>`など`layout`が固定されているレイアウトコンポーネントのProps型にはユニオン型が含まれないため、`interface extends`でも書けます。ただし、どのコンポーネントでも同じように書けるよう、交差型での合成をおすすめします。
+:::

--- a/skills/lism-css-guide/components-core.md
+++ b/skills/lism-css-guide/components-core.md
@@ -19,6 +19,7 @@ import { Lism, Box, Flex, Stack, Grid, Text, Media } from 'lism-css/astro';
 - [Trait Components](#trait-components)
 - [Layout Primitives](#layout-primitives)
 - [`getLismProps()`](#getlismprops--外部コンポーネントとの連携)
+- [AstroでのラップコンポーネントのProps型](#astroでのラップコンポーネントのprops型)
 
 [詳細](https://lism-css.com/docs/core-components/lism-props.md)
 
@@ -293,3 +294,20 @@ function MyComponent({ children }) {
   return <div {...lismProps}>{children}</div>;
 }
 ```
+
+## AstroでのラップコンポーネントのProps型
+
+Astroで`<Lism>`をラップする独自コンポーネントのProps型は、`interface extends`ではなく交差型（`&`）で合成する。`Lism`のProps型は`layout`による discriminated union を含むため、`interface extends`はTSエラーになる。
+
+```ts
+import { Lism } from 'lism-css/astro';
+import type { ComponentProps } from 'astro/types';
+
+type LismProps = ComponentProps<typeof Lism>;
+
+// NG: interface Props extends LismProps { class?: string } → TSエラー
+// OK: 交差型で合成
+type Props = LismProps & { class?: string };
+```
+
+この制約は`<Lism>`に限らず、`<Text>`や`<Wrapper>`など layout Prop を受け取れるコンポーネント全般に共通する。`<Cluster>`など layout 固定のレイアウトコンポーネントのみ union を含まず`interface extends`も通るが、交差型に統一する。


### PR DESCRIPTION
## Summary
- Astroで`<Lism>`をラップする独自コンポーネントのProps型は、`interface extends`ではなく交差型（`&`）で合成する必要がある旨をドキュメントに追記
- `<Text>`や`<Wrapper>`など`layout` Propを受け取れるコンポーネント全般に共通する制約であることも明記
- ja版・en版のドキュメントと`lism-css-guide`スキルの3ファイルを更新

## 変更ファイル
- `apps/docs/src/content/ja/core-components/Lism.mdx`
- `apps/docs/src/content/en/core-components/Lism.mdx`
- `skills/lism-css-guide/components-core.md`

Closes #351

## Test plan
- [ ] `nr dev:docs` でja/en両方のページが正しく表示されることを確認
- [ ] MDXのビルドエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * `Lism` を Astro でラップする際の Props 型の組み立て方を追記しました。
  * `interface extends` ではなく、交差型 `&` で合成する推奨パターンを例付きで説明しました。
  * `Text` や `Wrapper` など、同様の条件を持つコンポーネントにも当てはまる注意点を明記しました。
  * ガイドにも同内容のセクションと目次リンクを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->