### PR TITLE
fix(purge): #492 Astro SSR/hybrid構成でserver出力もスキャン・参照書き換えの対象に含める

### DIFF
--- a/apps/docs/src/content/en/customize/purge.mdx
+++ b/apps/docs/src/content/en/customize/purge.mdx
@@ -89,7 +89,9 @@ export default defineConfig({
 </PreviewCode>
 </Preview>
 
-The Vite plugin runs as `apply: 'build'` / `enforce: 'post'`, so nothing happens during `vite dev`. Unused selectors are stripped only when you run `vite build`. The Astro integration hooks into `astro:build:done`, scans HTML / JS under `dist/`, and rewrites the CSS files in place.
+The Vite plugin runs as `apply: 'build'` / `enforce: 'post'`, so nothing happens during `vite dev`. Unused selectors are stripped only when you run `vite build`. The Astro integration hooks into `astro:build:done`, scans HTML / JS under the build output, and rewrites the CSS files in place.
+
+In SSR / hybrid setups (`output: 'server'`, or when some routes have `prerender = false`), the server output (`dist/server/`) is also scanned and reference-rewritten in addition to the client output (`dist/client/`). This ensures that classes used only on on-demand rendered pages are preserved correctly.
 
 
 ## Pairing with full.css

--- a/apps/docs/src/content/ja/customize/purge.mdx
+++ b/apps/docs/src/content/ja/customize/purge.mdx
@@ -89,7 +89,9 @@ export default defineConfig({
 </PreviewCode>
 </Preview>
 
-Vite プラグインは `apply: 'build'` / `enforce: 'post'` で動作するため、開発サーバー (`vite dev`) では何も実行されません。`vite build` 実行時のみ、生成された CSS から未使用セレクタが削除されます。Astro 用は `astro:build:done` フックで、`dist/` 配下の HTML / JS をスキャンし、CSS ファイルを書き換えます。
+Vite プラグインは `apply: 'build'` / `enforce: 'post'` で動作するため、開発サーバー (`vite dev`) では何も実行されません。`vite build` 実行時のみ、生成された CSS から未使用セレクタが削除されます。Astro 用は `astro:build:done` フックで、ビルド出力配下の HTML / JS をスキャンし、CSS ファイルを書き換えます。
+
+SSR / hybrid 構成（`output: 'server'`、または `prerender = false` のルートがある場合）では、client 出力（`dist/client/`）に加えて server 出力（`dist/server/`）もスキャンと参照書き換えの対象になります。これにより、オンデマンドレンダリングされるページだけで使われているクラスも正しく保持されます。
 
 
 ## full.css と組み合わせる

--- a/packages/plugin/src/purge/astro.test.ts
+++ b/packages/plugin/src/purge/astro.test.ts
@@ -21,6 +21,12 @@ function getBuildDoneHook(integration: ReturnType<typeof lismPurgeAstro>) {
   return hook;
 }
 
+function getConfigDoneHook(integration: ReturnType<typeof lismPurgeAstro>) {
+  const hook = integration.hooks['astro:config:done'];
+  if (!hook) throw new Error('astro:config:done hook not found');
+  return hook;
+}
+
 async function fileExists(path: string): Promise<boolean> {
   try {
     await stat(path);
@@ -189,6 +195,86 @@ describe('lismPurgeAstro (Astro)', () => {
       expect(cssAfter).not.toContain('sourceMappingURL');
       expect(entries.some((f) => f.endsWith('.css.map'))).toBe(false);
       expect(await fileExists(join(dir, '_astro/main.AAAA1111.css.map'))).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('server ビルドでは server 出力も走査され、SSR ページのみのクラスが保持・参照書き換えされる', async () => {
+    // serverビルドを模倣: dir(=client) には prerender 済み HTML、server にはオンデマンドページのチャンク
+    const cssOriginal = `.l--stack{display:flex}.l--switch{display:grid}.l--unused{display:block}`;
+    const dir = await setupDist({
+      'client/_astro/main.AAAA1111.css': cssOriginal,
+      'client/index.html': `<link rel="stylesheet" href="/_astro/main.AAAA1111.css"><div class="l--stack"></div>`,
+      'server/chunks/ssr-page.mjs': `const $$Ssr = '<div class="l--switch"></div>';`,
+      'server/chunks/manifest.mjs': `const assets = ["/_astro/main.AAAA1111.css"];`,
+    });
+    try {
+      const integration = lismPurgeAstro({
+        known: { classes: new Set(['l--stack', 'l--switch', 'l--unused']), attrs: new Set() },
+      });
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      await getConfigDoneHook(integration)({
+        config: { build: { server: pathToFileURL(join(dir, 'server') + '/') } },
+        buildOutput: 'server',
+        logger,
+      } as never);
+      await getBuildDoneHook(integration)({
+        dir: pathToFileURL(join(dir, 'client') + '/'),
+        logger,
+        pages: [],
+        routes: [],
+      } as never);
+
+      const entries = await readdir(join(dir, 'client/_astro'));
+      const newName = entries.filter((f) => f.endsWith('.css'))[0];
+      expect(newName).not.toBe('main.AAAA1111.css');
+
+      // server チャンクのみで使われる l--switch が保持される（over-purge しない）
+      const cssAfter = await readFile(join(dir, 'client/_astro', newName), 'utf8');
+      expect(cssAfter).toContain('l--stack');
+      expect(cssAfter).toContain('l--switch');
+      expect(cssAfter).not.toContain('l--unused');
+
+      // server 側 manifest の CSS 参照も新ファイル名に更新される（CSS 404 を防ぐ）
+      const manifestAfter = await readFile(join(dir, 'server/chunks/manifest.mjs'), 'utf8');
+      expect(manifestAfter).toContain(newName);
+      expect(manifestAfter).not.toContain('main.AAAA1111.css');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('static ビルドでは server 出力は走査されない', async () => {
+    // buildOutput が 'static' なら config.build.server 配下にファイルがあっても対象外（従来挙動の維持）
+    const dir = await setupDist({
+      'client/_astro/main.AAAA1111.css': `.l--stack{display:flex}.l--switch{display:grid}`,
+      'client/index.html': `<link rel="stylesheet" href="/_astro/main.AAAA1111.css"><div class="l--stack"></div>`,
+      'server/chunks/leftover.mjs': `const html = '<div class="l--switch"></div>';`,
+    });
+    try {
+      const integration = lismPurgeAstro({
+        known: { classes: new Set(['l--stack', 'l--switch']), attrs: new Set() },
+      });
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      await getConfigDoneHook(integration)({
+        config: { build: { server: pathToFileURL(join(dir, 'server') + '/') } },
+        buildOutput: 'static',
+        logger,
+      } as never);
+      await getBuildDoneHook(integration)({
+        dir: pathToFileURL(join(dir, 'client') + '/'),
+        logger,
+        pages: [],
+        routes: [],
+      } as never);
+
+      // server/ は走査されないため、l--switch は unused として削除される
+      const entries = await readdir(join(dir, 'client/_astro'));
+      const newName = entries.filter((f) => f.endsWith('.css'))[0];
+      const cssAfter = await readFile(join(dir, 'client/_astro', newName), 'utf8');
+      expect(cssAfter).toContain('l--stack');
+      expect(cssAfter).not.toContain('l--switch');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/plugin/src/purge/astro.ts
+++ b/packages/plugin/src/purge/astro.ts
@@ -104,49 +104,67 @@ async function purgeCssFiles(
   return { renames, beforeBytes, afterBytes };
 }
 
-async function updateReferences(distPath: string, renames: RenameInfo[]): Promise<void> {
+async function updateReferences(distPaths: string[], renames: RenameInfo[]): Promise<void> {
   if (renames.length === 0) return;
-  for await (const file of walk(distPath)) {
-    if (!REF_EXT.test(file)) continue;
-    let content = await readFile(file, 'utf8');
-    let changed = false;
-    for (const { oldBase, newBase } of renames) {
-      if (content.includes(oldBase)) {
-        content = content.split(oldBase).join(newBase);
-        changed = true;
+  for (const distPath of distPaths) {
+    for await (const file of walk(distPath)) {
+      if (!REF_EXT.test(file)) continue;
+      let content = await readFile(file, 'utf8');
+      let changed = false;
+      for (const { oldBase, newBase } of renames) {
+        if (content.includes(oldBase)) {
+          content = content.split(oldBase).join(newBase);
+          changed = true;
+        }
       }
+      if (changed) await writeFile(file, content, 'utf8');
     }
-    if (changed) await writeFile(file, content, 'utf8');
   }
 }
 
 export function lismPurgeAstro(options: LismPurgeOptions = {}): AstroIntegration {
   const safelist: SafelistEntry[] | undefined = options.safelist;
   const report = options.report ?? false;
+  // server ビルド時の server 出力ディレクトリ。`astro:config:done` で確定する。
+  let serverDir: URL | undefined;
 
   return {
     name: 'lism-css:purge',
     hooks: {
+      'astro:config:done': ({ config, buildOutput }) => {
+        // server ビルド（`output: 'server'` または `prerender = false` ルートあり）では、
+        // `astro:build:done` の `dir` が `config.build.client` のみを指す。
+        // オンデマンドページのクラス名は server 側チャンクにしか現れず、SSR ページへ
+        // `<link>` を注入する manifest も server 側にあるため、server 出力も走査対象に含める（#492）。
+        // buildOutput はルート解析後に確定してからこのフックへ渡されるので、hybrid 構成でも正しく判定できる。
+        if (buildOutput === 'server') serverDir = config.build.server;
+      },
       // Astro の SSG では HTML 生成が Vite build より後に走るため、Vite plugin 経由では
       // 最終 HTML のクラスを拾えない。`astro:build:done` で dist を直接走査し、
       // CSS を purge した上で内容ベースの hash を再計算して参照側も同期更新する。
       'astro:build:done': async ({ dir, logger }) => {
         // known は build 実行時に解決する（関数形式の遅延解決にも対応）。
         const known = resolveKnownSelectors(options.known);
-        const distPath = fileURLToPath(dir);
+        const distPaths = [fileURLToPath(dir)];
+        if (serverDir) {
+          const serverPath = fileURLToPath(serverDir);
+          if (!distPaths.includes(serverPath)) distPaths.push(serverPath);
+        }
         const used = new Set<string>();
         const cssFiles: string[] = [];
 
-        for await (const file of walk(distPath)) {
-          if (SCAN_EXT.test(file)) {
-            extractLismClasses(await readFile(file, 'utf8'), used);
-          } else if (CSS_EXT.test(file)) {
-            cssFiles.push(file);
+        for (const distPath of distPaths) {
+          for await (const file of walk(distPath)) {
+            if (SCAN_EXT.test(file)) {
+              extractLismClasses(await readFile(file, 'utf8'), used);
+            } else if (CSS_EXT.test(file)) {
+              cssFiles.push(file);
+            }
           }
         }
 
         const { renames, beforeBytes, afterBytes } = await purgeCssFiles(cssFiles, used, safelist, known);
-        await updateReferences(distPath, renames);
+        await updateReferences(distPaths, renames);
 
         if (report && beforeBytes > 0) {
           logger.info(formatReport(beforeBytes, afterBytes));


### PR DESCRIPTION
## 概要

Astro の SSR / hybrid 構成で purge を有効にすると、server 出力（`dist/server/`）がスキャン対象外のために以下の2つの問題が発生していた。

1. **over-purge（UI破壊）**: オンデマンドレンダリングされるページのクラス名は server 側チャンクにしか存在せず、そのページでしか使われていないクラスの CSS が削除される
2. **CSS 404**: purge 後の CSS リネームの参照書き換えが client 側のみで、SSR ページに `<link>` を注入する server 側マニフェストが古い CSS ファイル名を参照したままになる

Closes #492

## 変更内容

- `astro:config:done` で `buildOutput` と `config.build.server` を取得し、server ビルド時（`output: 'server'` または `prerender = false` ルートあり）は server 出力も used 収集・参照書き換えの対象に追加（Issue の案a）
- テスト追加: server ビルドで SSR ページ専用クラスが保持され、server 側の CSS 参照も書き換わること / static ビルドでは server 出力を走査しないこと
- ドキュメント（ja / en の purge.mdx）に SSR / hybrid 構成での動作説明を追記

## 検証

最小の Astro SSR プロジェクト（Astro 6.4.8 + @astrojs/node、prerender ページ + SSR ページ構成）で修正前後を比較。

- 修正前: SSR ページ専用クラス `l--switchColumns` が CSS から削除され、SSR ページの `<link>` 先 CSS が 404（実サーバー起動 + curl で確認）
- 修正後: クラスが保持され、`<link>` 先も新ファイル名に同期して 200。`output: 'server'` / hybrid（`prerender = false` ルートによる昇格）の両構成で確認

Issue の「確認事項」もすべて確認済み:

- serverビルド時の `astro:build:done` の `dir` は `config.build.client` のみを指す（Astro 6.1.9 の `getClientOutputDirectory` で確認）
- prerender 済みページの HTML / CSS アセットは `dist/client` 側に出力される
- `buildOutput` は Astro 本体でルート解析後に確定してから `astro:config:done` に渡されるため、hybrid 構成でも正しく判定できる。`buildOutput` パラメータは Astro 5.0 からあり、peer dep 範囲（`^6.0.0`）全体で利用可能

## このPRで扱わないもの（#492 記載の低優先の関連改善点）

- Vite 版のチャンク内容書き換えとハッシュ不整合の既知の制限のドキュメント化
- `HASHED_CSS_NAME` の誤検知
- `formatReport` の「bytes」表記

上記は #496 に切り出し済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * Astro 統合で、ビルド後の CSS 参照更新がクライアント出力だけでなくサーバー出力にも対応しました。
  * SSR / ハイブリッド構成でも、生成された CSS ファイル名の変更が関連参照に反映されるようになりました。

* **ドキュメント**
  * Vite / Astro 利用時の動作説明を明確化し、開発時とビルド時の挙動の違いを追記しました。
  * どの出力先がスキャン対象になるかを、構成別により具体的に説明しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
