### PR TITLE
fix(lism-cli): 旧設定ファイル lism-ui.json の後方互換を削除（#498）

### DIFF
--- a/documents/lism-config.md
+++ b/documents/lism-config.md
@@ -16,7 +16,7 @@ CSS出力、React/Astroコンポーネントの実行時設定、`lism-cli ui`�
 | `breakpoints` | `xs`/`xl`などの有効化や、BPサイズを上書きする |
 | `isFullMode` | コンポーネント側のprops設定も`full.css`寄りにする |
 | `defaultImportant` | Property Classにデフォルトで`!important`を付与する（Sassの`$default_important`相当のビルド時設定） |
-| `ui` | `lism-cli ui add`などの出力先設定。旧`lism-ui.json`の後継。旧`cli`キーも互換読込される（deprecation警告あり） |
+| `ui` | `lism-cli ui add`などの出力先設定。旧`cli`キーも互換読込される（deprecation警告あり） |
 
 ```js
 // lism.config.js

--- a/packages/lism-cli/README.md
+++ b/packages/lism-cli/README.md
@@ -150,7 +150,7 @@ helper の配置先は個別に設定できず、常に `{dir}/_helper` に固�
 
 設定ファイルは `lism.config.ts` / `lism.config.mjs` / `lism.config.js` に対応しており、この順で探索して最初に見つかったものを読み込みます。`lism-css` 本体の設定読込（`@lism-css/plugin` / `lism-css build`）も同じ探索順です。
 
-旧 `lism-ui.json` は廃止予定（互換ロードのみ。起動時にdeprecation警告）。旧 `cli` セクション名も後方互換のため読み込めますが、deprecation警告が出るので `ui` へのリネームを推奨します。
+旧 `cli` セクション名も後方互換のため読み込めますが、deprecation警告が出るので `ui` へのリネームを推奨します。
 
 ## パッケージが見つからないエラーが出る場合
 

--- a/packages/lism-cli/src/commands/init.test.ts
+++ b/packages/lism-cli/src/commands/init.test.ts
@@ -145,14 +145,4 @@ describe('initCommand', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(fs.existsSync(path.join(tmpDir, 'lism.config.js'))).toBe(false);
   });
-
-  it('legacy json (lism-ui.json) 検出時は警告を出して新規生成する', async () => {
-    vi.mocked(confirm).mockResolvedValue(false);
-    writeFile(path.join(tmpDir, 'lism-ui.json'), JSON.stringify({ framework: 'react', componentsDir: 'src/components/ui' }));
-
-    await initCommand({});
-
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(fs.existsSync(path.join(tmpDir, 'lism.config.js'))).toBe(true);
-  });
 });

--- a/packages/lism-cli/src/commands/init.test.ts
+++ b/packages/lism-cli/src/commands/init.test.ts
@@ -145,4 +145,14 @@ describe('initCommand', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(fs.existsSync(path.join(tmpDir, 'lism.config.js'))).toBe(false);
   });
+
+  it('旧 lism-ui.json は既存 config として扱わず、警告なしで新規生成へ進む', async () => {
+    vi.mocked(confirm).mockResolvedValue(false);
+    writeFile(path.join(tmpDir, 'lism-ui.json'), JSON.stringify({ framework: 'react', componentsDir: 'src/components/ui' }));
+
+    await initCommand({});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tmpDir, 'lism.config.js'))).toBe(true);
+  });
 });

--- a/packages/lism-cli/src/commands/init.ts
+++ b/packages/lism-cli/src/commands/init.ts
@@ -20,12 +20,9 @@ export interface InitOptions {
 export async function initCommand(options: InitOptions = {}): Promise<void> {
   const found = findConfigFile();
 
-  if (found?.kind === 'module') {
+  if (found) {
     logger.warn(t('init.alreadyExists', { filename: found.filename }));
     return;
-  }
-  if (found?.kind === 'legacy-json') {
-    logger.warn(t('init.legacyDetected', { filename: found.filename }));
   }
 
   const ui = await resolveUiConfig(options);

--- a/packages/lism-cli/src/config.test.ts
+++ b/packages/lism-cli/src/config.test.ts
@@ -99,6 +99,13 @@ describe('readConfig', () => {
     await expect(readConfig()).rejects.toThrow();
   });
 
+  it('旧 lism-ui.json は設定ファイルとして扱わない（findConfigFile / readConfig とも null、警告なし）', async () => {
+    writeFile(path.join(tmpDir, 'lism-ui.json'), JSON.stringify({ framework: 'react', componentsDir: 'src/components/ui' }));
+    expect(findConfigFile()).toBeNull();
+    await expect(readConfig()).resolves.toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('ui: が null で cli: もある場合、cli へフォールバックせず throw する', async () => {
     writeFile(path.join(tmpDir, 'lism.config.js'), "export default { ui: null, cli: { framework: 'astro', dir: 'src/components/ui' } };\n");
     await expect(readConfig()).rejects.toThrow();

--- a/packages/lism-cli/src/config.test.ts
+++ b/packages/lism-cli/src/config.test.ts
@@ -99,18 +99,6 @@ describe('readConfig', () => {
     await expect(readConfig()).rejects.toThrow();
   });
 
-  it('legacy json (lism-ui.json) を読み込み、deprecation警告を出す', async () => {
-    writeFile(path.join(tmpDir, 'lism-ui.json'), JSON.stringify({ framework: 'react', componentsDir: 'src/components/ui' }));
-    const result = await readConfig();
-    expect(result).toEqual({ framework: 'react', dir: 'src/components/ui' });
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('legacy json の値が不正なら throw する', async () => {
-    writeFile(path.join(tmpDir, 'lism-ui.json'), JSON.stringify({ framework: 'vue', componentsDir: 'x' }));
-    await expect(readConfig()).rejects.toThrow();
-  });
-
   it('ui: が null で cli: もある場合、cli へフォールバックせず throw する', async () => {
     writeFile(path.join(tmpDir, 'lism.config.js'), "export default { ui: null, cli: { framework: 'astro', dir: 'src/components/ui' } };\n");
     await expect(readConfig()).rejects.toThrow();
@@ -139,7 +127,7 @@ describe('lism.config.ts の読み込み', () => {
     writeFile(path.join(tmpDir, 'lism.config.ts'), 'export default {};\n');
 
     const found = findConfigFile();
-    expect(found).toEqual({ path: path.join(tmpDir, 'lism.config.ts'), filename: 'lism.config.ts', kind: 'module' });
+    expect(found).toEqual({ path: path.join(tmpDir, 'lism.config.ts'), filename: 'lism.config.ts' });
   });
 
   it('readConfig が lism.config.ts の ui セクションを読める（型注釈を含む TS 構文）', async () => {

--- a/packages/lism-cli/src/config.ts
+++ b/packages/lism-cli/src/config.ts
@@ -3,9 +3,7 @@ import path from 'node:path';
 import { createJiti } from 'jiti';
 import { logger } from './logger.js';
 import { t } from './i18n.js';
-import { getInvokeCommand } from './invokeCommand.js';
 
-const LEGACY_CONFIG_FILE = 'lism-ui.json';
 const CONFIG_SEARCH = ['lism.config.ts', 'lism.config.mjs', 'lism.config.js'] as const;
 
 export interface LismCliConfig {
@@ -36,13 +34,11 @@ function resolvePath(filename: string): string {
 }
 
 /** 使用する設定ファイルを検出（存在する最初のもの）。見つからなければ null。 */
-export function findConfigFile(): { path: string; filename: string; kind: 'module' | 'legacy-json' } | null {
+export function findConfigFile(): { path: string; filename: string } | null {
   for (const name of CONFIG_SEARCH) {
     const abs = resolvePath(name);
-    if (fs.existsSync(abs)) return { path: abs, filename: name, kind: 'module' };
+    if (fs.existsSync(abs)) return { path: abs, filename: name };
   }
-  const legacy = resolvePath(LEGACY_CONFIG_FILE);
-  if (fs.existsSync(legacy)) return { path: legacy, filename: LEGACY_CONFIG_FILE, kind: 'legacy-json' };
   return null;
 }
 
@@ -60,8 +56,7 @@ export function getDefaultConfigPath(): string {
 
 /**
  * UI（旧 CLI）設定を読み込む。
- * - `lism.config.{ts,mjs,js}`: 動的インポート（jiti）で default export から `ui`（フォールバックで旧 `cli`）を取得
- * - `lism-ui.json` (legacy): JSON.parse、deprecation 警告を出す
+ * `lism.config.{ts,mjs,js}` を動的インポート（jiti）し、default export から `ui`（フォールバックで旧 `cli`）を取得する。
  *
  * `ui`/`cli` セクションが見つからない場合は `null` を返す（throw しない）。
  * `lism.config.js` が tokens/props 等の CSS カスタマイズ専用に作られていて
@@ -71,12 +66,6 @@ export function getDefaultConfigPath(): string {
 export async function readConfig(): Promise<LismCliConfig | null> {
   const found = findConfigFile();
   if (!found) return null;
-
-  if (found.kind === 'legacy-json') {
-    logger.warn(t('config.legacyWarning', { filename: LEGACY_CONFIG_FILE, invoke: getInvokeCommand() }));
-    const raw = fs.readFileSync(found.path, 'utf-8');
-    return normalizeUiConfig(JSON.parse(raw));
-  }
 
   const jiti = createJiti(import.meta.url, { interopDefault: true });
   let mod: unknown;

--- a/packages/lism-cli/src/messages.ts
+++ b/packages/lism-cli/src/messages.ts
@@ -234,10 +234,6 @@ export const messages = {
     ja: '{filename} は既に存在するため、何も変更しませんでした。',
     en: '{filename} already exists; nothing was changed.',
   },
-  'init.legacyDetected': {
-    ja: '{filename} を検出しました。lism.config.js へ移行します。古いファイルは後で削除してください。',
-    en: 'Detected {filename}. Migrating to lism.config.js. Please remove the old file afterwards.',
-  },
   'init.promptUseUi': {
     ja: 'Lism UI のコンポーネントも使いますか？（ui セクションを追加します）',
     en: 'Will you also use Lism UI components? (adds a ui section)',
@@ -446,10 +442,6 @@ export const messages = {
   // ---------------------------------------------------------------------------
   // config
   // ---------------------------------------------------------------------------
-  'config.legacyWarning': {
-    ja: '[deprecated] {filename} は廃止予定です。"{invoke} init" で lism.config.js へ移行してください。',
-    en: '[deprecated] {filename} is deprecated. Run "{invoke} init" to migrate to lism.config.js.',
-  },
   'config.invalidFramework': {
     ja: 'ui.framework は "react" または "astro" を指定してください。',
     en: 'ui.framework must be "react" or "astro".',


### PR DESCRIPTION
## 概要

初期開発版の設定ファイル `lism-ui.json` の後方互換（読み込み・deprecation警告・`init` での検出警告）を削除します。

Closes #498

## 変更内容

- `packages/lism-cli/src/config.ts`
  - `LEGACY_CONFIG_FILE` 定数、`findConfigFile()` の legacy-json 検出、`readConfig()` の legacy JSON 読み込み分岐を削除
  - `findConfigFile()` の戻り値から `kind` を廃止（`'module'` のみになるため。Issue の確認事項に対応）
  - 不要になった `getInvokeCommand` の import を削除
- `packages/lism-cli/src/commands/init.ts`: legacy 検出警告の分岐を削除。`kind` 廃止に伴い `found` の存在チェックのみに簡素化
- `packages/lism-cli/src/messages.ts`: `config.legacyWarning` / `init.legacyDetected` を削除
- テスト: `config.test.ts` / `init.test.ts` の legacy ケースを削除、`findConfigFile` の期待値から `kind` を除去
- ドキュメント: `packages/lism-cli/README.md`、`documents/lism-config.md` から `lism-ui.json` への言及を削除

## やらないこと（Issue 記載どおり）

- `lism-ui.json` の値の自動引き継ぎ（互換ごと削除するため不要）
- 旧 `cli:` セクション名の後方互換（`config.cliKeyDeprecated`）の削除

## 検証

- `pnpm vitest run`（lism-cli）: 8 files / 111 tests すべて成功（lism-ui.json を無視することを固定するテスト2件を追加）
- `pnpm run build:cli`: 成功
- `pnpm exec eslint packages/lism-cli/src`: エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLvpEtW27Jb2YicD64k6Ef

