### PR TITLE
fix(lism-cli): 対話プロンプト中の Ctrl+C を未処理エラーにせず静かに終了する（#500）

### DIFF
--- a/packages/create-lism/src/index.ts
+++ b/packages/create-lism/src/index.ts
@@ -69,6 +69,8 @@ function printHelp(): void {
 }
 
 main().catch((err: unknown) => {
+  // プロンプトの Ctrl+C 中断はユーザーの意思なので、何も表示せず SIGINT 慣例の 130 で終了する
+  if (err instanceof Error && err.name === 'ExitPromptError') process.exit(130);
   process.stderr.write(String(err) + '\n');
   process.exit(1);
 });

--- a/packages/lism-cli/src/commands/ui/add.ts
+++ b/packages/lism-cli/src/commands/ui/add.ts
@@ -30,22 +30,15 @@ interface AddOptions {
 type OverwritePolicy = 'all' | 'none' | 'per-component';
 
 export async function addCommand(names: string[], options: AddOptions): Promise<void> {
-  let config: LismCliConfig;
+  // 設定読み込み・プロンプトのエラー（Ctrl+C 中断含む）はエントリポイントで一括処理する。#500
+  let config = await readConfig();
   let needsGuidance = false;
 
-  try {
-    const existing = await readConfig();
-    if (existing) {
-      config = existing;
-    } else {
-      needsGuidance = true;
-      logger.info(t('ui.add.noConfig'));
-      config = await promptUiConfig({ framework: options.uiFramework, dir: options.uiDir });
-      console.log();
-    }
-  } catch (err) {
-    logger.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
+  if (!config) {
+    needsGuidance = true;
+    logger.info(t('ui.add.noConfig'));
+    config = await promptUiConfig({ framework: options.uiFramework, dir: options.uiDir });
+    console.log();
   }
 
   const fetchOpts: FetchOptions = { ref: options.ref };

--- a/packages/lism-cli/src/index.ts
+++ b/packages/lism-cli/src/index.ts
@@ -1,8 +1,16 @@
 import { createLismProgram } from './createProgram.js';
 import { preScanLang } from './i18n.js';
+import { logger } from './logger.js';
 
 // --help 出力や description の評価は parse 前に確定するため、
 // argv から --lang を先に抽出して言語を設定してから CLI を構築する。
 preScanLang(process.argv.slice(2));
 const program = createLismProgram();
-program.parse();
+
+// async な action の rejection をここで一括処理する（個別コマンドでは catch しない）。#500
+program.parseAsync().catch((err: unknown) => {
+  // プロンプトの Ctrl+C 中断はユーザーの意思なので、何も表示せず SIGINT 慣例の 130 で終了する
+  if (err instanceof Error && err.name === 'ExitPromptError') process.exit(130);
+  logger.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要

対話プロンプト（`@inquirer/prompts`）をCtrl+Cで中断すると、`ExitPromptError`が未処理rejectionとなりNode.jsのスタックトレースがそのまま表示される問題を修正します。

## 変更内容

- `packages/lism-cli/src/index.ts`: `program.parse()`を`program.parseAsync()`に変更し、actionのrejectionをエントリポイントで一括処理
  - `ExitPromptError`（`err.name === 'ExitPromptError'`で判定）: ユーザー自身の中断のため何も表示せず、SIGINT慣例の終了コード130（128+2）で終了
  - その他のエラー: `logger.error`でメッセージのみ表示して`exit(1)`（従来はスタックトレースが出ていた）
- `packages/lism-cli/src/commands/ui/add.ts`: 設定読み込み部分のtry/catchを削除し、エントリポイントの一括処理へ集約。`ExitPromptError`の内部メッセージ（英語）が`logger.error`で表示されていた点も解消。設定エラー時の表示・終了コードは従来と同等（`ERROR: <message>` + exit 1）
- `packages/create-lism/src/index.ts`: `main().catch`に同様の`ExitPromptError`処理を追加（ラッパー経由の`runCreate`でも同じ症状が出ていたため）

## Issueの確認事項への回答

- **終了コード**: SIGINT慣例の130を採用
- **create-lismラッパーへの影響**: エントリポイント変更自体の影響はなし。ただし同じ症状がラッパー側にもあったため、上記のとおり合わせて修正

## 動作確認

- `lism-cli init`のプロンプト中にCtrl+C → 何も表示されずexit 130（PTY経由でSIGINTを送信して確認）
- `create-lism`の言語選択プロンプト中にCtrl+C → 何も表示されずexit 130
- `lism-cli create --template nonexistent` → `ERROR: Template "nonexistent" not found. ...`のみ表示されexit 1（スタックトレースなし）
- `pnpm typecheck` / `pnpm test`（111件）/ `nr build:cli` すべてパス

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLvpEtW27Jb2YicD64k6Ef
