### PR TITLE
feat(lism-css): config の値を utils/presets/token から導出してコンポーネント側の補完に反映する

### DIFF
--- a/packages/lism-css/src/index.ts
+++ b/packages/lism-css/src/index.ts
@@ -1,4 +1,5 @@
 export type { BreakpointRegistry, MakeResponsive, Responsive, ResponsiveFor } from './lib/types/ResponsiveProps';
 export type { CustomPropRegistry, CustomPropValue } from './lib/types/CustomPropRegistry';
+export type { CustomPropValueRegistry } from './lib/types/CustomPropValueRegistry';
 export type { CustomTraitRegistry, CustomTraitValue } from './lib/types/CustomTraitRegistry';
 export type { FullModeRegistry } from './lib/types/FullModeRegistry';

--- a/packages/lism-css/src/lib/types/CustomPropRegistry.ts
+++ b/packages/lism-css/src/lib/types/CustomPropRegistry.ts
@@ -1,6 +1,11 @@
 import type { Responsive } from './ResponsiveProps';
 
-export type CustomPropValue = Responsive<(string & {}) | number | boolean | null | undefined>;
+/**
+ * lism.config.js で追加した prop の値型。
+ * `TValues` に utils / presets / token 由来の値リテラルを渡すと、既定 props と同様に
+ * 値が補完されつつ任意文字列も受け付ける（#450）。未指定時は従来通りの緩い型。
+ */
+export type CustomPropValue<TValues extends string = never> = Responsive<TValues | (string & {}) | number | boolean | null | undefined>;
 
 /**
  * lism.config.js で追加した prop キーを型側へ解禁するための拡張ポイント。

--- a/packages/lism-css/src/lib/types/CustomPropValueRegistry.ts
+++ b/packages/lism-css/src/lib/types/CustomPropValueRegistry.ts
@@ -1,0 +1,9 @@
+/**
+ * lism.config.js で既定 prop へ追加した値（presets / utils / token 由来）を型側へ広告するための拡張ポイント（#450）。
+ *
+ * キーは既定 prop 名、値は追加分の文字列リテラルユニオン。
+ * プロジェクト直下の lism-env.d.ts から `declare module 'lism-css'` で拡張され、
+ * PropValueTypes 側で defaults 由来の値ユニオンと `|` 合成される。
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface CustomPropValueRegistry {}

--- a/packages/lism-css/src/lib/types/PropValueTypes.ts
+++ b/packages/lism-css/src/lib/types/PropValueTypes.ts
@@ -2,6 +2,7 @@ import { TOKENS, PROPS } from '../../../config/index';
 import type { WithArbitraryString, ArrayElement, ExtractArrayValues, ExtractObjectKeys, ExtractPropertyValue } from './utils';
 import type { MakeResponsive } from './ResponsiveProps';
 import type { FullModeRegistry } from './FullModeRegistry';
+import type { CustomPropValueRegistry } from './CustomPropValueRegistry';
 
 type PropsConfig = typeof PROPS;
 type TokensConfig = typeof TOKENS;
@@ -58,17 +59,26 @@ type ExtractTokenValues<T> =
  */
 type ExtractPropValues<T> = ExtractArrayValues<T, 'presets'> | ExtractObjectKeys<T, 'utils'> | ExtractTokenValues<T>;
 
+/**
+ * lism.config.js で既定 prop へ追加された値（{@link CustomPropValueRegistry} の拡張分）を取得。
+ * 拡張が無い prop は never（defaults 由来の型のまま）。
+ */
+type UserPropValues<K> = K extends keyof CustomPropValueRegistry ? Extract<CustomPropValueRegistry[K], string> : never;
+
 // ============================================================
 // プロパティ値の型決定
 // ============================================================
 
 /**
  * プロパティの設定から値の型を決定
- * - presets/utils/token がある場合: 具体的な値 + 任意文字列 + number | boolean | null
+ * - presets/utils/token（+ user 追加分）がある場合: 具体的な値 + 任意文字列 + number | boolean | null
  * - ない場合: string | number（フォールバック）
+ *
+ * `[X] extends [never]` の tuple ラップで ExtraValues（naked 型パラメータ）の分配を防ぐ。
  */
-type PropValueType<T> =
-  ExtractPropValues<T> extends never ? string | number | boolean : WithArbitraryString<ExtractPropValues<T>> | number | boolean | null;
+type PropValueType<T, ExtraValues = never> = [ExtractPropValues<T> | ExtraValues] extends [never]
+  ? string | number | boolean
+  : WithArbitraryString<ExtractPropValues<T> | ExtraValues> | number | boolean | null;
 
 // ============================================================
 // ブレイクポイント対応の判定
@@ -106,14 +116,14 @@ type PropsWithoutBreakpoint = Exclude<AllPropKeys, PropsWithBreakpoint>;
  * bp が有効なプロパティの型（レスポンシブ対応あり）
  */
 export type ResponsivePropValueTypes = {
-  [K in PropsWithBreakpoint]?: PropValueType<PropsConfig[K]>;
+  [K in PropsWithBreakpoint]?: PropValueType<PropsConfig[K], UserPropValues<K>>;
 };
 
 /**
  * bp が無効なプロパティの型（レスポンシブ対応なし）
  */
 export type NonResponsivePropValueTypes = {
-  [K in PropsWithoutBreakpoint]?: PropValueType<PropsConfig[K]>;
+  [K in PropsWithoutBreakpoint]?: PropValueType<PropsConfig[K], UserPropValues<K>>;
 };
 
 /** defaults 由来の Props 型（full モード未適用時のデフォルト） */
@@ -148,9 +158,9 @@ type FullPropsWithoutBreakpoint = Exclude<AllPropKeys, FullPropsWithBreakpoint>;
 
 /** full モード適用時の Props 型（isVar 系を除く全 props がレスポンシブ） */
 type FullPropValueTypes = MakeResponsive<{
-  [K in FullPropsWithBreakpoint]?: PropValueType<PropsConfig[K]>;
+  [K in FullPropsWithBreakpoint]?: PropValueType<PropsConfig[K], UserPropValues<K>>;
 }> & {
-  [K in FullPropsWithoutBreakpoint]?: PropValueType<PropsConfig[K]>;
+  [K in FullPropsWithoutBreakpoint]?: PropValueType<PropsConfig[K], UserPropValues<K>>;
 };
 
 /**

--- a/packages/lism-css/src/lib/types/ResponsiveProps.module-augmentation.spec-d.ts
+++ b/packages/lism-css/src/lib/types/ResponsiveProps.module-augmentation.spec-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import 'lism-css';
-import type { CustomPropValue, CustomTraitValue } from 'lism-css';
+import type { CustomPropValue, CustomTraitValue, Responsive } from 'lism-css';
 import type { LismPropsBase } from '../getLismProps';
 import type { PropValueTypes } from './PropValueTypes';
 
@@ -10,7 +10,12 @@ declare module 'lism-css' {
   }
 
   interface CustomPropRegistry {
-    filter?: CustomPropValue;
+    filter?: CustomPropValue<'blur' | 'grayscale'>;
+  }
+
+  interface CustomPropValueRegistry {
+    ta: 'justify';
+    bg: 'primary';
   }
 
   interface CustomTraitRegistry {
@@ -45,6 +50,21 @@ describe('BreakpointRegistry module augmentation', () => {
 
     expectTypeOf(simple).toExtend<LismPropsBase>();
     expectTypeOf(responsive).toExtend<LismPropsBase>();
+  });
+
+  it('CustomPropValue のジェネリクスで新規 prop の値リテラルが補完される（#450）', () => {
+    expectTypeOf<LismPropsBase['filter']>().toEqualTypeOf<CustomPropValue<'blur' | 'grayscale'>>();
+  });
+
+  it('CustomPropValueRegistry 拡張で既定 prop の値ユニオンに user 追加分が合成される（#450）', () => {
+    // FullModeRegistry 有効のため Responsive でラップされる。defaults の presets（center/left/right）に justify が加わる。
+    expectTypeOf<PropValueTypes['ta']>().toEqualTypeOf<
+      Responsive<'center' | 'left' | 'right' | 'justify' | (string & {}) | number | boolean | null | undefined>
+    >();
+  });
+
+  it('値なしフォールバックだった既定 prop も、user 追加分があれば値ユニオン型へ切り替わる（#450）', () => {
+    expectTypeOf<PropValueTypes['bg']>().toEqualTypeOf<Responsive<'primary' | (string & {}) | number | boolean | null | undefined>>();
   });
 
   it('CustomTraitRegistry 拡張で新規 trait が解禁される', () => {

--- a/packages/plugin/src/builder/gen-types.test.ts
+++ b/packages/plugin/src/builder/gen-types.test.ts
@@ -81,6 +81,10 @@ describe('derivePropValueLiterals', () => {
     expect(derivePropValueLiterals({ token: 'unknown' }, { space: { '10': '8px' } })).toEqual([]);
     expect(derivePropValueLiterals({ token: 'space' })).toEqual([]);
   });
+
+  test("token: 'color' は palette カタログのキーも合成する（color ∪ palette の解決規則）", () => {
+    expect(derivePropValueLiterals({ token: 'color' }, { color: { main: '#333' }, palette: { red: '#f00' } })).toEqual(['main', 'red']);
+  });
 });
 
 describe('extraPropValueEntries', () => {
@@ -102,6 +106,12 @@ describe('extraPropValueEntries', () => {
 
   test('追加値が無ければ空配列を返す（defaults と同一の値は差分にしない）', () => {
     expect(extraPropValueEntries({ props: DEFAULT_CONFIG.props, tokens: DEFAULT_CONFIG.tokens }, DEFAULT_CONFIG)).toEqual([]);
+  });
+
+  test("token: 'color' の既定 prop は palette への追加キーも拾う", () => {
+    const defaults = { props: { c: { prop: 'color', token: 'color' } }, tokens: { color: { main: '#333' }, palette: { red: '#f00' } } };
+    const main = { props: defaults.props, tokens: { color: { main: '#333' }, palette: { red: '#f00', brand: '#00f' } } };
+    expect(extraPropValueEntries(main, defaults)).toEqual([['c', ['brand']]]);
   });
 });
 
@@ -223,6 +233,26 @@ describe('generateLismEnvDts', () => {
     // 値レジストリはリテラル型のみで import 不要
     expect(dts).not.toContain('import type');
     expect(dts?.match(/declare module 'lism-css'/g)).toHaveLength(1);
+  });
+
+  test("追加 prop の token: 'color' では palette カタログのキーも候補化される", () => {
+    const dts = generateLismEnvDts(
+      {
+        breakpoints: {},
+        props: { ...DEFAULT_CONFIG.props, accent: { prop: 'accentColor', token: 'color' } },
+        tokens: { ...DEFAULT_CONFIG.tokens, color: { main: '#333' }, palette: { red: '#f00' } },
+      },
+      DEFAULT_CONFIG
+    );
+    expect(dts).toContain("accent?: CustomPropValue<'main' | 'red'>;");
+  });
+
+  test('値リテラル内のシングルクォート・改行・バックスラッシュをエスケープする', () => {
+    const dts = generateLismEnvDts(
+      { breakpoints: {}, props: { ...DEFAULT_CONFIG.props, weird: { prop: 'x', utils: { "a'b": '1', 'c\nd': '2', 'e\\f': '3' } } } },
+      DEFAULT_CONFIG
+    );
+    expect(dts).toContain("weird?: CustomPropValue<'a\\'b' | 'c\\nd' | 'e\\\\f'>;");
   });
 });
 

--- a/packages/plugin/src/builder/gen-types.test.ts
+++ b/packages/plugin/src/builder/gen-types.test.ts
@@ -3,11 +3,26 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, test, afterAll } from 'vitest';
-import { extraAdvertisedBpKeys, extraCustomPropKeys, extraCustomTraitKeys, generateLismEnvDts } from './gen-types';
+import {
+  extraAdvertisedBpKeys,
+  extraCustomPropKeys,
+  extraCustomTraitKeys,
+  derivePropValueLiterals,
+  extraPropValueEntries,
+  generateLismEnvDts,
+} from './gen-types';
 import { writeLismEnvDts, TYPES_FILENAME } from './vite-typegen';
 
-const DEFAULT_PROP_KEYS = ['p', 'bg', 'fz'];
-const DEFAULT_TRAIT_KEYS = ['isContainer', 'hasGutter'];
+// generateLismEnvDts へ渡すマージ前 default-config のフィクスチャ。
+const DEFAULT_CONFIG = {
+  props: {
+    p: { prop: 'padding', token: 'space' },
+    bg: { prop: 'background' },
+    fz: { prop: 'fontSize', token: 'fz', presets: ['inherit'] },
+  },
+  traits: { isContainer: 'is--container', hasGutter: 'has--gutter' },
+  tokens: { space: { '10': '8px', '20': '16px' }, fz: { s: '0.8rem', m: '1rem' } },
+};
 
 describe('extraAdvertisedBpKeys', () => {
   test('有効化された xs/xl のみを追加解禁キーとして返す', () => {
@@ -23,32 +38,76 @@ describe('extraAdvertisedBpKeys', () => {
 });
 
 describe('extraCustomPropKeys', () => {
+  const defaultPropKeys = Object.keys(DEFAULT_CONFIG.props);
+
   test('default-config に無い prop のみを追加解禁キーとして返す', () => {
     expect(
-      extraCustomPropKeys({ p: { prop: 'padding' }, filter: { prop: 'filter' }, 'scroll-m': { prop: 'scrollMargin' } }, DEFAULT_PROP_KEYS)
+      extraCustomPropKeys({ p: { prop: 'padding' }, filter: { prop: 'filter' }, 'scroll-m': { prop: 'scrollMargin' } }, defaultPropKeys)
     ).toEqual(['filter', 'scroll-m']);
   });
 
   test('props が無い場合や既定 prop だけの場合は空配列を返す', () => {
-    expect(extraCustomPropKeys({ p: { prop: 'padding' }, bg: { prop: 'background' } }, DEFAULT_PROP_KEYS)).toEqual([]);
-    expect(extraCustomPropKeys(undefined, DEFAULT_PROP_KEYS)).toEqual([]);
+    expect(extraCustomPropKeys({ p: { prop: 'padding' }, bg: { prop: 'background' } }, defaultPropKeys)).toEqual([]);
+    expect(extraCustomPropKeys(undefined, defaultPropKeys)).toEqual([]);
   });
 });
 
 describe('extraCustomTraitKeys', () => {
+  const defaultTraitKeys = Object.keys(DEFAULT_CONFIG.traits);
+
   test('default-config に無い trait のみを追加解禁キーとして返す', () => {
-    expect(extraCustomTraitKeys({ isContainer: 'is--container', isHoge: 'is--hoge' }, DEFAULT_TRAIT_KEYS)).toEqual(['isHoge']);
+    expect(extraCustomTraitKeys({ isContainer: 'is--container', isHoge: 'is--hoge' }, defaultTraitKeys)).toEqual(['isHoge']);
   });
 
   test('traits が無い場合や既定 trait だけの場合は空配列を返す', () => {
-    expect(extraCustomTraitKeys({ isContainer: 'is--container', hasGutter: 'has--gutter' }, DEFAULT_TRAIT_KEYS)).toEqual([]);
-    expect(extraCustomTraitKeys(undefined, DEFAULT_TRAIT_KEYS)).toEqual([]);
+    expect(extraCustomTraitKeys({ isContainer: 'is--container', hasGutter: 'has--gutter' }, defaultTraitKeys)).toEqual([]);
+    expect(extraCustomTraitKeys(undefined, defaultTraitKeys)).toEqual([]);
+  });
+});
+
+describe('derivePropValueLiterals', () => {
+  test('presets の値・utils のキー・token 参照先カタログのキーを重複なしで返す', () => {
+    expect(
+      derivePropValueLiterals({ presets: ['auto', 0], utils: { none: 'none' }, token: 'space' }, { space: { '10': '8px', '20': '16px' } })
+    ).toEqual(['auto', '0', 'none', '10', '20']);
+  });
+
+  test('token が配列カタログの場合は要素を返す', () => {
+    expect(derivePropValueLiterals({ token: 'fw' }, { fw: ['light', 'bold'] })).toEqual(['light', 'bold']);
+  });
+
+  test('presets / utils / token（または参照先カタログ）が無ければ空配列を返す', () => {
+    expect(derivePropValueLiterals({ prop: 'filter' }, { space: { '10': '8px' } })).toEqual([]);
+    expect(derivePropValueLiterals({ token: 'unknown' }, { space: { '10': '8px' } })).toEqual([]);
+    expect(derivePropValueLiterals({ token: 'space' })).toEqual([]);
+  });
+});
+
+describe('extraPropValueEntries', () => {
+  test('既定 prop への presets / utils 追加分のみを返す', () => {
+    const main = {
+      props: { ...DEFAULT_CONFIG.props, p: { prop: 'padding', token: 'space', presets: ['auto'], utils: { full: '100%' } } },
+      tokens: DEFAULT_CONFIG.tokens,
+    };
+    expect(extraPropValueEntries(main, DEFAULT_CONFIG)).toEqual([['p', ['auto', 'full']]]);
+  });
+
+  test('既定 prop が参照する token カタログへのキー追加も拾う', () => {
+    const main = {
+      props: DEFAULT_CONFIG.props,
+      tokens: { ...DEFAULT_CONFIG.tokens, space: { ...DEFAULT_CONFIG.tokens.space, '99': '99px' } },
+    };
+    expect(extraPropValueEntries(main, DEFAULT_CONFIG)).toEqual([['p', ['99']]]);
+  });
+
+  test('追加値が無ければ空配列を返す（defaults と同一の値は差分にしない）', () => {
+    expect(extraPropValueEntries({ props: DEFAULT_CONFIG.props, tokens: DEFAULT_CONFIG.tokens }, DEFAULT_CONFIG)).toEqual([]);
   });
 });
 
 describe('generateLismEnvDts', () => {
   test('追加解禁キーがあれば BreakpointRegistry 拡張の .d.ts を生成する', () => {
-    const dts = generateLismEnvDts({ breakpoints: { xs: '360px', xl: '1400px' }, props: {} }, DEFAULT_PROP_KEYS);
+    const dts = generateLismEnvDts({ breakpoints: { xs: '360px', xl: '1400px' }, props: {} }, DEFAULT_CONFIG);
     expect(dts).not.toBeNull();
     expect(dts).toContain("declare module 'lism-css'");
     expect(dts).toContain('interface BreakpointRegistry');
@@ -59,7 +118,7 @@ describe('generateLismEnvDts', () => {
   });
 
   test('追加 prop があれば CustomPropRegistry 拡張の .d.ts を生成する', () => {
-    const dts = generateLismEnvDts({ breakpoints: {}, props: { p: { prop: 'padding' }, filter: { prop: 'filter' } } }, DEFAULT_PROP_KEYS);
+    const dts = generateLismEnvDts({ breakpoints: {}, props: { p: { prop: 'padding' }, filter: { prop: 'filter' } } }, DEFAULT_CONFIG);
     expect(dts).not.toBeNull();
     expect(dts).toContain("import type { CustomPropValue } from 'lism-css';");
     expect(dts).toContain('interface CustomPropRegistry');
@@ -70,7 +129,7 @@ describe('generateLismEnvDts', () => {
   test('breakpoints と props を同じ declare module に並べて生成する', () => {
     const dts = generateLismEnvDts(
       { breakpoints: { xs: '360px' }, props: { filter: { prop: 'filter' }, 'scroll-m': { prop: 'scrollMargin' } } },
-      DEFAULT_PROP_KEYS
+      DEFAULT_CONFIG
     );
     expect(dts).not.toBeNull();
     expect(dts).toContain('interface BreakpointRegistry');
@@ -82,11 +141,7 @@ describe('generateLismEnvDts', () => {
   });
 
   test('追加 trait があれば CustomTraitRegistry 拡張の .d.ts を生成する', () => {
-    const dts = generateLismEnvDts(
-      { breakpoints: {}, props: {}, traits: { isContainer: 'is--container', isHoge: 'is--hoge' } },
-      DEFAULT_PROP_KEYS,
-      DEFAULT_TRAIT_KEYS
-    );
+    const dts = generateLismEnvDts({ breakpoints: {}, props: {}, traits: { isContainer: 'is--container', isHoge: 'is--hoge' } }, DEFAULT_CONFIG);
     expect(dts).not.toBeNull();
     expect(dts).toContain("import type { CustomTraitValue } from 'lism-css';");
     expect(dts).toContain('interface CustomTraitRegistry');
@@ -97,8 +152,7 @@ describe('generateLismEnvDts', () => {
   test('breakpoints / props / traits を同じ declare module に並べ、型 import をまとめる', () => {
     const dts = generateLismEnvDts(
       { breakpoints: { xs: '360px' }, props: { filter: { prop: 'filter' } }, traits: { isHoge: 'is--hoge' } },
-      DEFAULT_PROP_KEYS,
-      DEFAULT_TRAIT_KEYS
+      DEFAULT_CONFIG
     );
     expect(dts).not.toBeNull();
     expect(dts).toContain('interface BreakpointRegistry');
@@ -112,20 +166,14 @@ describe('generateLismEnvDts', () => {
     expect(
       generateLismEnvDts(
         { breakpoints: { sm: '480px', md: '800px', lg: '1120px' }, props: { p: { prop: 'padding' } }, traits: { isContainer: 'is--container' } },
-        DEFAULT_PROP_KEYS,
-        DEFAULT_TRAIT_KEYS
+        DEFAULT_CONFIG
       )
     ).toBeNull();
-    expect(generateLismEnvDts({ breakpoints: undefined, props: {} }, DEFAULT_PROP_KEYS)).toBeNull();
+    expect(generateLismEnvDts({ breakpoints: undefined, props: {} }, DEFAULT_CONFIG)).toBeNull();
   });
 
   test('isFullMode: true なら FullModeRegistry 拡張を生成する（追加キーが他に無くても null にしない）', () => {
-    const dts = generateLismEnvDts(
-      { breakpoints: { sm: '480px', md: '800px', lg: '1120px' }, props: {} },
-      DEFAULT_PROP_KEYS,
-      DEFAULT_TRAIT_KEYS,
-      true
-    );
+    const dts = generateLismEnvDts({ breakpoints: { sm: '480px', md: '800px', lg: '1120px' }, props: {} }, DEFAULT_CONFIG, true);
     expect(dts).not.toBeNull();
     expect(dts).toContain('interface FullModeRegistry');
     expect(dts).toContain('enabled: true;');
@@ -133,22 +181,47 @@ describe('generateLismEnvDts', () => {
   });
 
   test('isFullMode: false（既定）では FullModeRegistry 拡張を含めない', () => {
-    const dts = generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_PROP_KEYS);
+    const dts = generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_CONFIG);
     expect(dts).not.toBeNull();
     expect(dts).not.toContain('FullModeRegistry');
   });
 
   test('isFullMode と追加 breakpoints / props を同じ declare module に並べて生成する', () => {
-    const dts = generateLismEnvDts(
-      { breakpoints: { xs: '360px' }, props: { filter: { prop: 'filter' } } },
-      DEFAULT_PROP_KEYS,
-      DEFAULT_TRAIT_KEYS,
-      true
-    );
+    const dts = generateLismEnvDts({ breakpoints: { xs: '360px' }, props: { filter: { prop: 'filter' } } }, DEFAULT_CONFIG, true);
     expect(dts).not.toBeNull();
     expect(dts).toContain('interface BreakpointRegistry');
     expect(dts).toContain('interface CustomPropRegistry');
     expect(dts).toContain('interface FullModeRegistry');
+    expect(dts?.match(/declare module 'lism-css'/g)).toHaveLength(1);
+  });
+
+  test('追加 prop に utils / presets / token があれば値リテラルを CustomPropValue のジェネリクスへ埋め込む（#450）', () => {
+    const dts = generateLismEnvDts(
+      {
+        breakpoints: {},
+        props: { ...DEFAULT_CONFIG.props, filter: { prop: 'filter', presets: ['none'], utils: { blur: 'blur(4px)' }, token: 'space' } },
+        tokens: DEFAULT_CONFIG.tokens,
+      },
+      DEFAULT_CONFIG
+    );
+    expect(dts).toContain("filter?: CustomPropValue<'none' | 'blur' | '10' | '20'>;");
+    expect(dts).toContain("import type { CustomPropValue } from 'lism-css';");
+  });
+
+  test('既定 prop への追加値があれば CustomPropValueRegistry 拡張を生成する（#450）', () => {
+    const dts = generateLismEnvDts(
+      {
+        breakpoints: {},
+        props: { ...DEFAULT_CONFIG.props, p: { prop: 'padding', token: 'space', utils: { full: '100%' } } },
+        tokens: { ...DEFAULT_CONFIG.tokens, space: { ...DEFAULT_CONFIG.tokens.space, '99': '99px' } },
+      },
+      DEFAULT_CONFIG
+    );
+    expect(dts).not.toBeNull();
+    expect(dts).toContain('interface CustomPropValueRegistry');
+    expect(dts).toContain("p: 'full' | '99';");
+    // 値レジストリはリテラル型のみで import 不要
+    expect(dts).not.toContain('import type');
     expect(dts?.match(/declare module 'lism-css'/g)).toHaveLength(1);
   });
 });
@@ -164,7 +237,7 @@ describe('writeLismEnvDts', () => {
 
   test('content があれば lism-env.d.ts を書き出す', () => {
     const root = tmpDir();
-    writeLismEnvDts(root, generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_PROP_KEYS));
+    writeLismEnvDts(root, generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_CONFIG));
     const file = path.join(root, TYPES_FILENAME);
     expect(fs.existsSync(file)).toBe(true);
     expect(fs.readFileSync(file, 'utf8')).toContain('xs: true;');
@@ -172,7 +245,7 @@ describe('writeLismEnvDts', () => {
 
   test('内容が変わらなければ書き込まない（mtime 不変 = HMR ループ回避）', () => {
     const root = tmpDir();
-    const content = generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_PROP_KEYS);
+    const content = generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_CONFIG);
     writeLismEnvDts(root, content);
     const file = path.join(root, TYPES_FILENAME);
     const mtime1 = fs.statSync(file).mtimeMs;
@@ -184,18 +257,18 @@ describe('writeLismEnvDts', () => {
     const root = tmpDir();
     const file = path.join(root, TYPES_FILENAME);
     // 自動生成された .d.ts（マーカー付き）を置いておく
-    fs.writeFileSync(file, generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_PROP_KEYS)!, 'utf8');
-    writeLismEnvDts(root, generateLismEnvDts({ breakpoints: { sm: '480px' }, props: { p: { prop: 'padding' } } }, DEFAULT_PROP_KEYS)); // null
+    fs.writeFileSync(file, generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_CONFIG)!, 'utf8');
+    writeLismEnvDts(root, generateLismEnvDts({ breakpoints: { sm: '480px' }, props: { p: { prop: 'padding' } } }, DEFAULT_CONFIG)); // null
     expect(fs.existsSync(file)).toBe(false);
   });
 
   test('追加 breakpoints が無くても追加 props が残れば削除しない', () => {
     const root = tmpDir();
     const file = path.join(root, TYPES_FILENAME);
-    const content = generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_PROP_KEYS)!;
+    const content = generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_CONFIG)!;
     fs.writeFileSync(file, content, 'utf8');
 
-    writeLismEnvDts(root, generateLismEnvDts({ breakpoints: { sm: '480px' }, props: { filter: { prop: 'filter' } } }, DEFAULT_PROP_KEYS));
+    writeLismEnvDts(root, generateLismEnvDts({ breakpoints: { sm: '480px' }, props: { filter: { prop: 'filter' } } }, DEFAULT_CONFIG));
 
     expect(fs.existsSync(file)).toBe(true);
     expect(fs.readFileSync(file, 'utf8')).toContain('filter?: CustomPropValue;');
@@ -215,7 +288,7 @@ describe('writeLismEnvDts', () => {
     const file = path.join(root, TYPES_FILENAME);
     fs.writeFileSync(file, '// 手書きの型定義\n', 'utf8');
 
-    writeLismEnvDts(root, generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_PROP_KEYS));
+    writeLismEnvDts(root, generateLismEnvDts({ breakpoints: { xs: '360px' }, props: {} }, DEFAULT_CONFIG));
 
     expect(fs.readFileSync(file, 'utf8')).toBe('// 手書きの型定義\n');
   });

--- a/packages/plugin/src/builder/gen-types.ts
+++ b/packages/plugin/src/builder/gen-types.ts
@@ -1,15 +1,17 @@
 /**
- * lism.config.js の breakpoints / props / traits / isFullMode から module augmentation の `.d.ts` を生成する純粋関数（#427 / P4-P5）。
+ * lism.config.js の breakpoints / props / traits / tokens / isFullMode から module augmentation の `.d.ts` を生成する純粋関数（#427 / P4-P5）。
  *
  * 型のデフォルト広告は sm/md/lg（`lib/types/ResponsiveProps.ts` の `BreakpointRegistry`）。
  * config で xs/xl にサイズ（≠0）を与えて有効化した分を、プロジェクト直下の `.d.ts` で
  * `declare module 'lism-css'` 拡張して型側にも解禁する。これにより #428 の手書き augmentation を不要にする。
  * さらに、lism.config.js で追加された props / traits は `CustomPropRegistry` / `CustomTraitRegistry` 拡張として並べて出力し、
  * `isFullMode: true` のときは `FullModeRegistry` 拡張で型を full 版に切り替える（#425）。
+ * prop の utils / presets / token から導出した値リテラルも型へ広告する（#450）:
+ * 新規 prop は `CustomPropValue<'a' | 'b'>`、既定 prop への追加値は `CustomPropValueRegistry` 拡張として出力する。
  *
  * 副作用（ファイル書き出し）は `vite-typegen.ts` 側に分離し、ここは入力 → 文字列の純粋変換に限定する。
  */
-import type { BuildConfig } from './serialize';
+import type { BuildConfig, PropConfig } from './serialize';
 
 /** 型がデフォルトで広告済みのキー（`ResponsiveProps.ts` の `BreakpointRegistry` と一致させる）。 */
 const DEFAULT_ADVERTISED = ['sm', 'md', 'lg'];
@@ -20,7 +22,7 @@ const KNOWN_BP_KEYS = ['xs', 'sm', 'md', 'lg', 'xl'];
 /** 自動生成物であることを示す識別マーカー。HEADER に埋め込み、削除時の安全判定にも使う。 */
 export const GENERATED_MARKER = 'このファイルは lism-css が';
 
-const HEADER = `// ${GENERATED_MARKER} lism.config.js の breakpoints / props / traits から自動生成します。
+const HEADER = `// ${GENERATED_MARKER} lism.config.js の breakpoints / props / traits / tokens から自動生成します。
 // 編集しないでください（次回の dev / build 時に上書きされます）。`;
 
 const CUSTOM_PROP_VALUE_TYPE = 'CustomPropValue';
@@ -60,8 +62,54 @@ export function extraCustomTraitKeys(traits: BuildConfig['traits'] | undefined, 
   return Object.keys(traits).filter((key) => !defaults.has(key));
 }
 
+/** typegen が差分抽出に使う default-config（マージ前）。traits / tokens は未定義でも動くよう optional。 */
+export type TypegenDefaultConfig = Pick<BuildConfig, 'props'> & Partial<Pick<BuildConfig, 'tokens' | 'traits'>>;
+
+/**
+ * PropConfig から補完対象の値リテラル一覧を導出する（presets の値 + utils のキー + token 参照先カタログのキー）。
+ * `PropValueTypes.ts` の型レベル計算（ExtractPropValues）と同じ規則の文字列生成版（#450）。
+ * token カタログは配列なら要素、値付きフラットマップならキー一覧（'-' センチネルもカタログ上有効なので含める）。
+ */
+export function derivePropValueLiterals(propConfig: PropConfig, tokens?: BuildConfig['tokens']): string[] {
+  const values: string[] = [];
+  if (propConfig.presets) values.push(...propConfig.presets.map(String));
+  if (propConfig.utils) values.push(...Object.keys(propConfig.utils));
+  const catalog = propConfig.token ? tokens?.[propConfig.token] : undefined;
+  if (Array.isArray(catalog)) {
+    values.push(...catalog.map(String));
+  } else if (catalog && typeof catalog === 'object') {
+    values.push(...Object.keys(catalog));
+  }
+  return [...new Set(values)];
+}
+
+/**
+ * 既定 prop への user 追加値 = 「マージ後 config から導出した値 − defaults から導出した値」（#450）。
+ * 既定 prop 自体への presets / utils 追加と、既定 prop が参照する token カタログへのキー追加の両方を拾う。
+ * 値の削除・置換は型のユニオン合成では表現できないため対象外（任意文字列は常に許容されるので実害はない）。
+ */
+export function extraPropValueEntries(
+  mainConfig: Pick<BuildConfig, 'props'> & Partial<Pick<BuildConfig, 'tokens'>>,
+  defaultConfig: TypegenDefaultConfig
+): [string, string[]][] {
+  const entries: [string, string[]][] = [];
+  for (const [key, defaultProp] of Object.entries(defaultConfig.props)) {
+    const mergedProp = mainConfig.props?.[key];
+    if (!mergedProp) continue;
+    const defaults = new Set(derivePropValueLiterals(defaultProp, defaultConfig.tokens));
+    const added = derivePropValueLiterals(mergedProp, mainConfig.tokens).filter((value) => !defaults.has(value));
+    if (added.length > 0) entries.push([key, added]);
+  }
+  return entries;
+}
+
 function formatTypePropertyKey(key: string): string {
   return /^[$A-Z_a-z][$\w]*$/.test(key) ? key : JSON.stringify(key);
+}
+
+/** 値リテラルの配列を single quote の文字列リテラルユニオンへ整形する。 */
+function formatStringLiteralUnion(values: string[]): string {
+  return values.map((value) => `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`).join(' | ');
 }
 
 function generateBreakpointBlock(keys: string[]): string | null {
@@ -72,10 +120,26 @@ ${lines}
   }`;
 }
 
-function generateCustomPropBlock(keys: string[]): string | null {
+function generateCustomPropBlock(props: BuildConfig['props'] | undefined, keys: string[], tokens?: BuildConfig['tokens']): string | null {
   if (keys.length === 0) return null;
-  const lines = keys.map((key) => `    ${formatTypePropertyKey(key)}?: ${CUSTOM_PROP_VALUE_TYPE};`).join('\n');
+  const lines = keys
+    .map((key) => {
+      // 値があれば既定 props と同様に補完されるよう、リテラルユニオンをジェネリクスで渡す（#450）
+      const values = derivePropValueLiterals(props?.[key] ?? {}, tokens);
+      const type = values.length > 0 ? `${CUSTOM_PROP_VALUE_TYPE}<${formatStringLiteralUnion(values)}>` : CUSTOM_PROP_VALUE_TYPE;
+      return `    ${formatTypePropertyKey(key)}?: ${type};`;
+    })
+    .join('\n');
   return `  interface CustomPropRegistry {
+${lines}
+  }`;
+}
+
+/** 既定 prop への追加値を CustomPropValueRegistry 拡張として出力する（値はリテラル型のみで import 不要）。 */
+function generateCustomPropValueBlock(entries: [string, string[]][]): string | null {
+  if (entries.length === 0) return null;
+  const lines = entries.map(([key, values]) => `    ${formatTypePropertyKey(key)}: ${formatStringLiteralUnion(values)};`).join('\n');
+  return `  interface CustomPropValueRegistry {
 ${lines}
   }`;
 }
@@ -100,23 +164,24 @@ function generateFullModeBlock(isFullMode: boolean): string | null {
 }
 
 /**
- * breakpoints / props / traits / isFullMode から `.d.ts` の内容を生成する。
- * 追加解禁キーも isFullMode も無ければ `null`（= ファイル不要）を返す。
+ * breakpoints / props / traits / tokens / isFullMode から `.d.ts` の内容を生成する。
+ * 追加解禁キーも追加値も isFullMode も無ければ `null`（= ファイル不要）を返す。
  */
 export function generateLismEnvDts(
-  mainConfig: Pick<BuildConfig, 'breakpoints' | 'props' | 'traits'>,
-  defaultPropKeys: Iterable<string>,
-  defaultTraitKeys: Iterable<string> = [],
+  mainConfig: Pick<BuildConfig, 'breakpoints' | 'props' | 'traits'> & Partial<Pick<BuildConfig, 'tokens'>>,
+  defaultConfig: TypegenDefaultConfig,
   isFullMode = false
 ): string | null {
   const bpKeys = extraAdvertisedBpKeys(mainConfig.breakpoints);
-  const propKeys = extraCustomPropKeys(mainConfig.props, defaultPropKeys);
-  const traitKeys = extraCustomTraitKeys(mainConfig.traits, defaultTraitKeys);
-  if (bpKeys.length === 0 && propKeys.length === 0 && traitKeys.length === 0 && !isFullMode) return null;
+  const propKeys = extraCustomPropKeys(mainConfig.props, Object.keys(defaultConfig.props));
+  const traitKeys = extraCustomTraitKeys(mainConfig.traits, Object.keys(defaultConfig.traits ?? {}));
+  const propValueEntries = extraPropValueEntries(mainConfig, defaultConfig);
+  if (bpKeys.length === 0 && propKeys.length === 0 && traitKeys.length === 0 && propValueEntries.length === 0 && !isFullMode) return null;
 
   const blocks = [
     generateBreakpointBlock(bpKeys),
-    generateCustomPropBlock(propKeys),
+    generateCustomPropBlock(mainConfig.props, propKeys, mainConfig.tokens),
+    generateCustomPropValueBlock(propValueEntries),
     generateCustomTraitBlock(traitKeys),
     generateFullModeBlock(isFullMode),
   ]

--- a/packages/plugin/src/builder/gen-types.ts
+++ b/packages/plugin/src/builder/gen-types.ts
@@ -65,20 +65,28 @@ export function extraCustomTraitKeys(traits: BuildConfig['traits'] | undefined, 
 /** typegen が差分抽出に使う default-config（マージ前）。traits / tokens は未定義でも動くよう optional。 */
 export type TypegenDefaultConfig = Pick<BuildConfig, 'props'> & Partial<Pick<BuildConfig, 'tokens' | 'traits'>>;
 
+/** token カタログ（配列 or 値付きフラットマップ）から値リテラル一覧を取り出す。 */
+function tokenCatalogKeys(catalog: unknown): string[] {
+  if (Array.isArray(catalog)) return catalog.map(String);
+  if (catalog && typeof catalog === 'object') return Object.keys(catalog);
+  return [];
+}
+
 /**
  * PropConfig から補完対象の値リテラル一覧を導出する（presets の値 + utils のキー + token 参照先カタログのキー）。
  * `PropValueTypes.ts` の型レベル計算（ExtractPropValues）と同じ規則の文字列生成版（#450）。
  * token カタログは配列なら要素、値付きフラットマップならキー一覧（'-' センチネルもカタログ上有効なので含める）。
+ * token: 'color' は color（セマンティック）∪ palette（パレット）の合成カタログとして解決されるため、palette も加える。
  */
 export function derivePropValueLiterals(propConfig: PropConfig, tokens?: BuildConfig['tokens']): string[] {
   const values: string[] = [];
   if (propConfig.presets) values.push(...propConfig.presets.map(String));
   if (propConfig.utils) values.push(...Object.keys(propConfig.utils));
-  const catalog = propConfig.token ? tokens?.[propConfig.token] : undefined;
-  if (Array.isArray(catalog)) {
-    values.push(...catalog.map(String));
-  } else if (catalog && typeof catalog === 'object') {
-    values.push(...Object.keys(catalog));
+  if (propConfig.token) {
+    values.push(...tokenCatalogKeys(tokens?.[propConfig.token]));
+    // color は color（セマンティック）∪ palette（パレット）の合成カタログとして解決される
+    // （config/index.ts の tokensWithColor / getMaybeTokenValue.ts の palette フォールバックと同じ規則）。
+    if (propConfig.token === 'color') values.push(...tokenCatalogKeys(tokens?.palette));
   }
   return [...new Set(values)];
 }
@@ -109,7 +117,15 @@ function formatTypePropertyKey(key: string): string {
 
 /** 値リテラルの配列を single quote の文字列リテラルユニオンへ整形する。 */
 function formatStringLiteralUnion(values: string[]): string {
-  return values.map((value) => `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`).join(' | ');
+  return values.map((value) => `'${escapeStringLiteral(value)}'`).join(' | ');
+}
+
+/**
+ * 文字列を single quote リテラルの中身としてエスケープする。
+ * バックスラッシュ・制御文字（改行等）のエスケープは JSON.stringify に任せ、生成 .d.ts の構文エラーを防ぐ。
+ */
+function escapeStringLiteral(value: string): string {
+  return JSON.stringify(value).slice(1, -1).replace(/\\"/g, '"').replace(/'/g, "\\'");
 }
 
 function generateBreakpointBlock(keys: string[]): string | null {

--- a/packages/plugin/src/builder/load-config.ts
+++ b/packages/plugin/src/builder/load-config.ts
@@ -66,10 +66,8 @@ export interface LoadedBuildConfigs {
   mainConfig: BuildConfig;
   /** full 系（full.css / full_no_layer.css）が読む prop-config の元 CONFIG。 */
   fullConfig: BuildConfig;
-  /** default-config に最初から含まれる prop キー。typegen で追加 prop との差分抽出に使う。 */
-  defaultPropKeys: string[];
-  /** default-config に最初から含まれる trait キー。typegen で追加 trait との差分抽出に使う。 */
-  defaultTraitKeys: string[];
+  /** マージ前の default-config。typegen で追加 prop / trait / 追加値の差分抽出に使う。 */
+  defaultConfig: BuildConfig;
   /** lism.config.* の isFullMode フラグ。 */
   isFullMode: boolean;
   /** 見つかった user 設定ファイルの絶対パス（無ければ null）。watch 対象に使う。 */
@@ -152,8 +150,7 @@ export async function loadBuildConfigs(projectRoot: string, opts: LoadBuildConfi
   return {
     mainConfig,
     fullConfig,
-    defaultPropKeys: Object.keys(defaultConfig.props),
-    defaultTraitKeys: Object.keys(defaultConfig.traits ?? {}),
+    defaultConfig,
     isFullMode,
     userConfigPath,
   };

--- a/packages/plugin/src/builder/typegen.ts
+++ b/packages/plugin/src/builder/typegen.ts
@@ -52,11 +52,11 @@ export function writeLismEnvDts(projectRoot: string, content: string | null, log
 }
 
 /**
- * projectRoot の lism.config を読み、breakpoints / props / traits から `.d.ts` を生成 / 更新 / 削除する。
+ * projectRoot の lism.config を読み、breakpoints / props / traits / tokens から `.d.ts` を生成 / 更新 / 削除する。
  */
 export async function syncLismEnvDts(projectRoot: string, opts: SyncTypesOptions = {}): Promise<void> {
-  const { mainConfig, defaultPropKeys, defaultTraitKeys, isFullMode } = await loadBuildConfigs(projectRoot, {
+  const { mainConfig, defaultConfig, isFullMode } = await loadBuildConfigs(projectRoot, {
     configPath: opts.configPath,
   });
-  writeLismEnvDts(projectRoot, generateLismEnvDts(mainConfig, defaultPropKeys, defaultTraitKeys, isFullMode), opts.log);
+  writeLismEnvDts(projectRoot, generateLismEnvDts(mainConfig, defaultConfig, isFullMode), opts.log);
 }


### PR DESCRIPTION
## 概要

`lism.config.js` で追加・拡張した prop の値（`utils` / `presets` / `token` 由来）を `lism-env.d.ts` 生成時にリテラルユニオンとして埋め込み、既定 props と同様にコンポーネント側で値補完されるようにします。

Closes #450

## 変更内容

### 生成側（`@lism-css/plugin`）

- `gen-types.ts` に `derivePropValueLiterals()` を新設。`PropConfig` の presets の値・utils のキー・token 参照先カタログのキーから値リテラル一覧を導出する（`PropValueTypes.ts` の型レベル計算 `ExtractPropValues` と同じ規則の文字列生成版）
- **新規 prop**: 値があれば `filter?: CustomPropValue<'none' | 'blur'>;` のようにジェネリクスへ値ユニオンを埋め込む（値が無ければ従来通り `CustomPropValue`）
- **既定 prop への値追加**: `extraPropValueEntries()` で「マージ後 config 由来の値 − defaults 由来の値」の差分を取り、`CustomPropValueRegistry` 拡張として出力。既定 prop 自体への presets / utils 追加に加え、**既定 prop が参照する token カタログへのキー追加**（例: `tokens.space` への追加）も拾う
- `generateLismEnvDts()` のシグネチャを `(mainConfig, defaultConfig, isFullMode)` に変更（差分抽出に defaults の props / tokens が必要になったため）。`LoadedBuildConfigs` は `defaultPropKeys` / `defaultTraitKeys` を `defaultConfig` に置き換え

### 型側（`lism-css`）

- `CustomPropValue` をジェネリクス化: `CustomPropValue<TValues extends string = never>`。既定は従来と同一の型なので既存の生成物・手書き augmentation はそのまま有効
- `CustomPropValueRegistry`（空 interface）を新設し公開。既定 prop 名 → 追加値リテラルユニオンの拡張ポイント
- `PropValueTypes.ts` の `PropValueType<T, ExtraValues = never>` で defaults 由来の値と registry の user 追加分を `|` 合成（default / full モードの両方に適用）。値なしフォールバック（`string | number | boolean`）だった prop も、追加値があれば値ユニオン型へ切り替わる

### 生成例

```ts
declare module 'lism-css' {
  interface CustomPropRegistry {
    filter?: CustomPropValue<'none' | 'blur'>;
  }

  interface CustomPropValueRegistry {
    p: 'full' | '99';
  }
}
```

## テスト

- `gen-types.test.ts`: `derivePropValueLiterals` / `extraPropValueEntries` の単体テストと、値埋め込み・`CustomPropValueRegistry` 生成のテストを追加。既存テストは新シグネチャへ更新
- `ResponsiveProps.module-augmentation.spec-d.ts`（分離コンパイルの型フィクスチャ）: 新規 prop の値補完、既定 prop への値合成、フォールバック prop の値ユニオン化の型テストを追加
- `packages/lism-css`: 716 tests passed / typecheck（tsc + astro check）エラーなし
- `packages/plugin`: 193 tests passed / typecheck エラーなし

## 留意点

- 既定 props のみの利用（registry 拡張なし）では `PropValueTypes` の解決結果は従来と完全に同一（既存の spec-d 型テストが全て通ることで担保）
- 値の削除・置換（deep merge で配列は上書き）は型のユニオン合成では表現できないため対象外。stale な候補が補完に残り得るが、任意文字列は常に許容されるため実害なし
- `CustomPropValue<...>` 付きの生成物は今回の `lism-css` 型変更に依存するため、plugin と lism-css のバージョン連動が必要（リリース時に要注意）
- 既定 prop への `bp` 変更（非レスポンシブ → レスポンシブ化）の型反映は本 issue のスコープ外
- ドキュメント（apps/docs）の追従は別途

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 設定で追加したカスタムプロパティの値候補が、型補完に反映されるようになりました（任意文字列・数値・真偽値・null/undefined を含む）。
  * 追加した値リテラル／トークンが、生成される型定義に反映されるようになりました。

* **Bug Fixes**
  * 既定プロパティに追加した値が、補完や型チェックで正しく扱われるようになりました。
  * レスポンシブ／非レスポンシブでの拡張反映漏れを改善しました。

* **Tests**
  * 型生成・宣言ファイル出力の検証を、既定設定基準に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->