### PR TITLE
fix: UA由来のtext-align / letter-spacingが打ち消されない問題を修正 (#516)

### DIFF
--- a/packages/lism-css/src/scss/base/set/_plain.scss
+++ b/packages/lism-css/src/scss/base/set/_plain.scss
@@ -16,6 +16,6 @@
   margin: 0;
   border: none;
   text-decoration: none;
-  text-align: inherit; /* buttonのUAスタイル(center)を打ち消し、divと同じく親から継承させる */
+  text-align: inherit; /* buttonのUAスタイルを打ち消す */
   border-radius: 0;
 }

--- a/packages/lism-css/src/scss/base/set/_plain.scss
+++ b/packages/lism-css/src/scss/base/set/_plain.scss
@@ -16,5 +16,6 @@
   margin: 0;
   border: none;
   text-decoration: none;
+  text-align: inherit; /* buttonのUAスタイル(center)を打ち消し、divと同じく親から継承させる */
   border-radius: 0;
 }

--- a/packages/lism-css/src/scss/reset.scss
+++ b/packages/lism-css/src/scss/reset.scss
@@ -118,6 +118,9 @@
     font: inherit;
     color: inherit;
 
+    /* UAスタイルの letter-spacing: normal を打ち消して本文から継承する ( font ショートハンドには含まれないため個別指定 ) */
+    letter-spacing: inherit;
+
     /* iOSで入力時の拡大を防ぐ. ( button には必要ないが、フォーム全体のフォントサイズを揃えるために一括で適用する ) */
     font-size: max(16px, 1em);
   }

--- a/packages/lism-css/src/scss/reset.scss
+++ b/packages/lism-css/src/scss/reset.scss
@@ -117,8 +117,6 @@
     /* 基本要素のフォントとカラーを本文から継承 */
     font: inherit;
     color: inherit;
-
-    /* UAスタイルの letter-spacing: normal を打ち消して本文から継承する ( font ショートハンドには含まれないため個別指定 ) */
     letter-spacing: inherit;
 
     /* iOSで入力時の拡大を防ぐ. ( button には必要ないが、フォーム全体のフォントサイズを揃えるために一括で適用する ) */


### PR DESCRIPTION
Closes #516

## 変更内容

ブラウザのUAスタイルシートが`button`等のフォーム系要素に指定している宣言のうち、Lism側で打ち消されていなかった2つに対応した。

1. **`set--plain`に`text-align: inherit`を追加**（`base/set/_plain.scss`）
   - UAの`button { text-align: center }`を打ち消し、divと同じく親から継承させる
   - `w="100%"`等で幅を広げたボタンや、テキストが折り返した時に中央揃えが残っていた問題の修正
2. **`reset.scss`のフォーム系ブロックに`letter-spacing: inherit`を追加**
   - UAの`letter-spacing: normal`が継承をブロックし、bodyの`--lts--base`がフォーム系要素内に効かなかった問題の修正
   - 既存の`font: inherit`はfontショートハンドのため`letter-spacing`を含まない

値を`start`ではなく`inherit`にした理由、`reset.scss`側で`text-align`をリセットしない理由はIssueの「やらないこと」を参照。

Issueの確認事項にある`word-spacing: normal`への対応は、現状実害がないため本PRには含めていない（必要になれば別途対応）。

## 動作確認

- `build:css` 成功
- `lint:style` エラーなし
- `lism-css`パッケージのテスト 716件すべて合格
- ビルド成果物`main.css` / `main_no_layer.css`の両方に`text-align:inherit`（`.set--plain`）と`letter-spacing:inherit`（フォーム系リセット）が反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
