### PR TITLE
fix(test): Modal.stories.tsxとwebpack.test.tsのタイムアウトをCI実測に合わせて延長

### DIFF
--- a/packages/lism-ui/src/components/Modal/Modal.stories.tsx
+++ b/packages/lism-ui/src/components/Modal/Modal.stories.tsx
@@ -44,7 +44,7 @@ export const Default: Story = {
     await userEvent.click(closeBtn);
 
     // モーダルが閉じている（アニメーション完了待ち）
-    await waitFor(() => expect(dialog).not.toHaveAttribute('open'), { timeout: 2000 });
+    await waitFor(() => expect(dialog).not.toHaveAttribute('open'), { timeout: 5000 });
   },
 };
 

--- a/packages/plugin/src/builder/webpack.test.ts
+++ b/packages/plugin/src/builder/webpack.test.ts
@@ -151,7 +151,7 @@ describe('withLismWebpack', () => {
       // watchRun: 再生成が throw せず走り、CSS が出力される。
       await expect(captured.watch?.()).resolves.not.toThrow();
       expect(fs.existsSync(path.join(root, '.lism-css/css/main.css'))).toBe(true);
-    });
+    }, 15000);
 
     test('css: false: watchRun は CSS を再生成しない（.lism-css/css を作らない）が、config は fileDependencies へ登録する', async () => {
       const root = tmpDir();
@@ -187,7 +187,7 @@ describe('withLismWebpack', () => {
 
       await expect(captured.watch?.()).resolves.not.toThrow();
       expect(fs.existsSync(fullCss)).toBe(true);
-    });
+    }, 15000);
   });
 
   describe('typegen オプション', () => {


### PR DESCRIPTION
## 概要

CIで2回連続、別々のテストがタイムアウトぎりぎりで失敗した（flaky）ため、タイムアウト値をCI実測に合わせて延長する。

Closes #512

## 変更内容

- `packages/lism-ui/src/components/Modal/Modal.stories.tsx`
  - `Default`ストーリー末尾のクローズアニメーション完了待ちの`waitFor`を `timeout: 2000` → `5000` に延長（CI実測で2129msかかりタイムアウトした）
- `packages/plugin/src/builder/webpack.test.ts`
  - 「css: true / full: true なら watchRun 再生成でも full.css を更新する」テストにタイムアウト`15000`を指定（vitestデフォルト5000msで失敗した）
  - 同じく実際に`watchRun`を実行する「css: trueでwatchRun再生成→main.css確認」テストにも予防として`15000`を指定

## 対象外

- webpack.test.ts の「css: falseでwatchRunがタップされないこと」を確認するテストは、`watchRun`自体を実行しないため延長不要（Issueの判断どおり）

## 確認

- `packages/plugin` で `vitest run src/builder/webpack.test.ts` を実行し、14件すべてパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ab1QTCJWwdUFNvmkBCeW4
