### PR TITLE
fix: full.cssでborder用Property Class(.-bd系)が機能しない競合を修正 (#513)

### DIFF
--- a/apps/docs/src/content/en/customize/build.mdx
+++ b/apps/docs/src/content/en/customize/build.mdx
@@ -30,7 +30,8 @@ import 'lism-css/full.css'; // For the version without @layer, use 'lism-css/ful
 
 In addition to everything in `main.css`, `full.css` includes:
 
-- Breakpoint support classes (such as `-pl_lg`) for all Property Classes except variable-only properties (`isVar` — these emit only a CSS variable, not a class)
+- Breakpoint support classes (such as `-pl_lg`) for all Property Classes except variable-only properties (`isVar` — these emit only a CSS variable, not a class) and border shorthands (`bd` and directional variants like `bd-x`)
+- Breakpoint support classes for the border sub-properties `bds` / `bdc` (`bdw` supports breakpoints in `main.css` already). Responsive borders are handled via sub-properties, not the shorthands
 - `SPACE` token utility classes (such as `-pl:20`) for directional spacing properties like `pl` / `mt` / `cg`
 
 This makes the CSS larger than `main.css`, so **this build is intended to be used together with [CSS Purge](/en/docs/customize/purge/), which removes unused classes at build time**.

--- a/apps/docs/src/content/en/customize/purge.mdx
+++ b/apps/docs/src/content/en/customize/purge.mdx
@@ -96,7 +96,7 @@ In SSR / hybrid setups (`output: 'server'`, or when some routes have `prerender 
 
 ## Pairing with full.css
 
-`lism-css/full.css` is an **everything-included build** that adds breakpoint-aware classes for every Property Class except variable-only (`isVar`) ones (`sm` / `md` / `lg`), plus `SPACE` token utilities for spacing properties. It is large when loaded as-is, so it ships as a build **meant to be paired with purge**.
+`lism-css/full.css` is an **everything-included build** that adds breakpoint-aware classes (`sm` / `md` / `lg`) for every Property Class except variable-only (`isVar`) ones and border shorthands (the `bd` family), plus `SPACE` token utilities for spacing properties. It is large when loaded as-is, so it ships as a build **meant to be paired with purge**.
 
 ```js
 // Load full.css instead of main.css

--- a/apps/docs/src/content/en/customize/purge.mdx
+++ b/apps/docs/src/content/en/customize/purge.mdx
@@ -96,7 +96,7 @@ In SSR / hybrid setups (`output: 'server'`, or when some routes have `prerender 
 
 ## Pairing with full.css
 
-`lism-css/full.css` is an **everything-included build** that adds breakpoint-aware classes (`sm` / `md` / `lg`) for every Property Class except variable-only (`isVar`) ones and border shorthands (the `bd` family), plus `SPACE` token utilities for spacing properties. It is large when loaded as-is, so it ships as a build **meant to be paired with purge**.
+`lism-css/full.css` is an **everything-included build** that adds breakpoint-aware classes (`sm` / `md` / `lg`) for every Property Class except variable-only (`isVar`) ones and border shorthands (the `bd` family), plus `SPACE` token utilities for spacing properties. As an exception, responsive borders are provided through the variable-only sub-properties (`bds` / `bdc`; `bdw` supports breakpoints in `main.css` already). It is large when loaded as-is, so it ships as a build **meant to be paired with purge**.
 
 ```js
 // Load full.css instead of main.css

--- a/apps/docs/src/content/ja/customize/build.mdx
+++ b/apps/docs/src/content/ja/customize/build.mdx
@@ -28,7 +28,8 @@ import 'lism-css/full.css'; // @layer なし版は 'lism-css/full_no_layer.css'
 
 `full.css` には、`main.css` の内容に加えて以下が含まれます。
 
-- 変数出力専用（`isVar` 系＝クラスを出力せず CSS変数だけを出すプロパティ）を除く、全 Property Class のブレイクポイント対応クラス（`-pl_lg` など）
+- 変数出力専用（`isVar` 系＝クラスを出力せず CSS変数だけを出すプロパティ）と border ショートハンド系（`bd` と `bd-x` などの方向指定）を除く、全 Property Class のブレイクポイント対応クラス（`-pl_lg` など）
+- border サブプロパティ `bds` / `bdc` のブレイクポイント対応クラス（`bdw` は `main.css` から対応済み）。border のブレイクポイント対応は、ショートハンドではなくサブプロパティで行います
 - `pl` / `mt` / `cg` など、スペーシング系の方向指定プロパティに対する `SPACE` トークンのユーティリティクラス（`-pl:20` など）
 
 そのぶんCSSサイズは `main.css` より大きくなるため、**未使用のクラスをビルド時に削除する [CSS Purge](/docs/customize/purge/) との併用を前提とした配布物**です。

--- a/apps/docs/src/content/ja/customize/purge.mdx
+++ b/apps/docs/src/content/ja/customize/purge.mdx
@@ -96,7 +96,7 @@ SSR / hybrid 構成（`output: 'server'`、または `prerender = false` のル�
 
 ## full.css と組み合わせる
 
-`lism-css/full.css` は、変数出力専用（`isVar` 系）を除く全 Property Class のブレイクポイント対応クラス（`sm` / `md` / `lg`）と、スペーシング系プロパティの `SPACE` トークンユーティリティまで含めた**全部入りビルド**です。素のまま読み込むとサイズが大きいため、**purge との併用を前提**にした配布物です。
+`lism-css/full.css` は、変数出力専用（`isVar` 系）と border ショートハンド系（`bd` 系）を除く全 Property Class のブレイクポイント対応クラス（`sm` / `md` / `lg`）と、スペーシング系プロパティの `SPACE` トークンユーティリティまで含めた**全部入りビルド**です。素のまま読み込むとサイズが大きいため、**purge との併用を前提**にした配布物です。
 
 ```js
 // main.css の代わりに full.css を読み込む

--- a/apps/docs/src/content/ja/customize/purge.mdx
+++ b/apps/docs/src/content/ja/customize/purge.mdx
@@ -96,7 +96,7 @@ SSR / hybrid 構成（`output: 'server'`、または `prerender = false` のル�
 
 ## full.css と組み合わせる
 
-`lism-css/full.css` は、変数出力専用（`isVar` 系）と border ショートハンド系（`bd` 系）を除く全 Property Class のブレイクポイント対応クラス（`sm` / `md` / `lg`）と、スペーシング系プロパティの `SPACE` トークンユーティリティまで含めた**全部入りビルド**です。素のまま読み込むとサイズが大きいため、**purge との併用を前提**にした配布物です。
+`lism-css/full.css` は、変数出力専用（`isVar` 系）と border ショートハンド系（`bd` 系）を除く全 Property Class のブレイクポイント対応クラス（`sm` / `md` / `lg`）と、スペーシング系プロパティの `SPACE` トークンユーティリティまで含めた**全部入りビルド**です。border のブレイクポイント対応は、例外的に `isVar` 系のサブプロパティ（`bds` / `bdc`。`bdw` は `main.css` から対応済み）側で提供されます。素のまま読み込むとサイズが大きいため、**purge との併用を前提**にした配布物です。
 
 ```js
 // main.css の代わりに full.css を読み込む

--- a/packages/lism-css/config/index.test.ts
+++ b/packages/lism-css/config/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, afterEach, vi } from 'vitest';
+import { FULL_BP_EXCLUDED_KEYS, FULL_BP_ISVAR_KEYS } from './presets/props-full';
 
 // config/index.ts はモジュール初期化時に lism-css/config.js（= lism.config.js）を読むため、
 // doMock で差し替えてから resetModules + 動的 import する
@@ -42,13 +43,15 @@ describe('isFullMode', () => {
     const { PROPS } = await importConfig({ isFullMode: true });
     const props = PROPS as unknown as LoosePropConfig;
 
-    // border ショートハンド系は _border.scss の特殊実装と競合するため bp 拡張から除外される
-    expect(props.bd.bp).toBeUndefined();
-    expect(props['bd-x'].bp).toBeUndefined();
-    expect(props['bd-be'].bp).toBeUndefined();
+    // border ショートハンド系11キーは _border.scss の特殊実装と競合するため bp 拡張から除外される
+    expect(FULL_BP_EXCLUDED_KEYS).toHaveLength(11);
+    for (const key of FULL_BP_EXCLUDED_KEYS) {
+      expect(props[key].bp, key).toBeUndefined();
+    }
     // 代わりにサブプロパティ（isVar 系）が full 限定で bp:1 になる
-    expect(props.bds.bp).toBe(1);
-    expect(props.bdc.bp).toBe(1);
+    for (const key of FULL_BP_ISVAR_KEYS) {
+      expect(props[key].bp, key).toBe(1);
+    }
     expect(props.bdw.bp).toBe(1); // defaults で対応済み
   });
 

--- a/packages/lism-css/config/index.test.ts
+++ b/packages/lism-css/config/index.test.ts
@@ -38,6 +38,20 @@ describe('isFullMode', () => {
     expect(props.cols.tokenClass).toBeUndefined();
   });
 
+  test('isFullMode でも border ショートハンド系は bp 対象外、bds / bdc は bp:1 になる（#513）', async () => {
+    const { PROPS } = await importConfig({ isFullMode: true });
+    const props = PROPS as unknown as LoosePropConfig;
+
+    // border ショートハンド系は _border.scss の特殊実装と競合するため bp 拡張から除外される
+    expect(props.bd.bp).toBeUndefined();
+    expect(props['bd-x'].bp).toBeUndefined();
+    expect(props['bd-be'].bp).toBeUndefined();
+    // 代わりにサブプロパティ（isVar 系）が full 限定で bp:1 になる
+    expect(props.bds.bp).toBe(1);
+    expect(props.bdc.bp).toBe(1);
+    expect(props.bdw.bp).toBe(1); // defaults で対応済み
+  });
+
   test('ユーザー設定の props 上書きが full preset より優先される（opt-out 可能）', async () => {
     const { PROPS } = await importConfig({ isFullMode: true, props: { pl: { bp: 0 } } });
     const props = PROPS as unknown as LoosePropConfig;

--- a/packages/lism-css/config/presets/props-full.ts
+++ b/packages/lism-css/config/presets/props-full.ts
@@ -24,7 +24,8 @@ type FullPropKey = Exclude<NonVarPropKey, FullBpExcludedKey> | FullBpIsVarKey;
 /**
  * full.css 用の props オーバーライド設定（defaults/props.ts への差分のみ）。
  * isVar 系・border ショートハンド系を除く全 props の BP サポートを有効化する
- * （出力BPは $breakpoints の有効BPに従う）。
+ * （出力BPは $breakpoints の有効BPに従う）。ただし isVar 系のうち
+ * border サブプロパティ（FULL_BP_ISVAR_KEYS）のみ例外として、導出後に個別で BP サポートを追加する。
  *
  * キーを列挙せず defaults から導出しているのは、props 追加時に
  * このファイルの追従漏れで full.css から抜け落ちるのを防ぐため。

--- a/packages/lism-css/config/presets/props-full.ts
+++ b/packages/lism-css/config/presets/props-full.ts
@@ -2,13 +2,29 @@ import PROPS from '../defaults/props';
 
 type PropKey = keyof typeof PROPS;
 
+// border ショートハンド系（bd + 方向指定）は BP 拡張の対象外。
+// _border.scss が --bds / --bdw / --bdc の3変数で管理する特殊実装を持ち、bp:1 が出力する
+// 汎用ベースルール（.-bd { border: var(--bd) } 等）とカスケードで競合するため（#513）。
+// border の BP 対応はサブプロパティ（bds / bdw / bdc）で行う。
+export const FULL_BP_EXCLUDED_KEYS = ['bd', 'bd-x', 'bd-y', 'bd-s', 'bd-e', 'bd-bs', 'bd-be', 'bd-t', 'bd-b', 'bd-l', 'bd-r'] as const;
+
+// isVar 系のうち、full 限定で BP サポートを追加するキー（border サブプロパティ）。
+// bdw は defaults で bp:1 対応済み。isVar 系の BP クラスは
+// `.-bds_sm { --bds: var(--bds_sm) !important }` のように変数を上書きするだけなので競合しない。
+export const FULL_BP_ISVAR_KEYS = ['bds', 'bdc'] as const;
+
+export type FullBpExcludedKey = (typeof FULL_BP_EXCLUDED_KEYS)[number];
+export type FullBpIsVarKey = (typeof FULL_BP_ISVAR_KEYS)[number];
+
 // isVar 系（state 変数扱いの props）は BP 拡張の対象外。
 // デフォルトで bp を持つもの（bdw, cols, rows）はデフォルト値のまま維持される。
-type FullPropKey = { [K in PropKey]: (typeof PROPS)[K] extends { isVar: 1 } ? never : K }[PropKey];
+type NonVarPropKey = { [K in PropKey]: (typeof PROPS)[K] extends { isVar: 1 } ? never : K }[PropKey];
+type FullPropKey = Exclude<NonVarPropKey, FullBpExcludedKey> | FullBpIsVarKey;
 
 /**
  * full.css 用の props オーバーライド設定（defaults/props.ts への差分のみ）。
- * isVar 系を除く全 props の BP サポートを有効化する（出力BPは $breakpoints の有効BPに従う）。
+ * isVar 系・border ショートハンド系を除く全 props の BP サポートを有効化する
+ * （出力BPは $breakpoints の有効BPに従う）。
  *
  * キーを列挙せず defaults から導出しているのは、props 追加時に
  * このファイルの追従漏れで full.css から抜け落ちるのを防ぐため。
@@ -16,9 +32,14 @@ type FullPropKey = { [K in PropKey]: (typeof PROPS)[K] extends { isVar: 1 } ? ne
  */
 const propsFull = Object.fromEntries(
   Object.entries(PROPS)
-    .filter(([, config]) => !('isVar' in config && config.isVar === 1))
+    .filter(([key, config]) => !('isVar' in config && config.isVar === 1) && !(FULL_BP_EXCLUDED_KEYS as readonly string[]).includes(key))
     .map(([key]) => [key, { bp: 1 }])
 ) as Record<FullPropKey, { bp: 1; tokenClass?: 1 }>;
+
+// border サブプロパティ（isVar 系）は導出フィルタの対象外のため、個別に BP サポートを追加する。
+for (const key of FULL_BP_ISVAR_KEYS) {
+  propsFull[key] = { bp: 1 };
+}
 
 // スペーシング系の方向指定 props（padding / margin / gap）にも space トークンの
 // ユーティリティクラスを出力する（inset 系は position 用途のため対象外）。

--- a/packages/lism-css/src/lib/types/PropValueTypes.ts
+++ b/packages/lism-css/src/lib/types/PropValueTypes.ts
@@ -1,4 +1,5 @@
 import { TOKENS, PROPS } from '../../../config/index';
+import type { FullBpExcludedKey, FullBpIsVarKey } from '../../../config/presets/props-full';
 import type { WithArbitraryString, ArrayElement, ExtractArrayValues, ExtractObjectKeys, ExtractPropertyValue } from './utils';
 import type { MakeResponsive } from './ResponsiveProps';
 import type { FullModeRegistry } from './FullModeRegistry';
@@ -147,11 +148,23 @@ type IsVarProp<T> = 1 extends ExtractPropertyValue<T, 'isVar'> ? true : false;
 
 /**
  * full モードでレスポンシブになる prop のキー。
- * - isVar 系以外: full preset が bp:1 にするため常にレスポンシブ
- * - isVar 系: props-full.ts の対象外なのでデフォルトの bp 判定のまま
+ * - FullBpIsVarKey（bds / bdc）: isVar 系だが full preset が bp:1 を追加するためレスポンシブ
+ * - FullBpExcludedKey（border ショートハンド系）: full preset の対象外なのでデフォルトの bp 判定のまま（#513）
+ * - その他の isVar 系: props-full.ts の対象外なのでデフォルトの bp 判定のまま
+ * - 上記以外: full preset が bp:1 にするため常にレスポンシブ
  */
 type FullPropsWithBreakpoint = {
-  [K in AllPropKeys]: IsVarProp<PropsConfig[K]> extends true ? (HasBreakpointSupport<PropsConfig[K]> extends true ? K : never) : K;
+  [K in AllPropKeys]: K extends FullBpIsVarKey
+    ? K
+    : K extends FullBpExcludedKey
+      ? HasBreakpointSupport<PropsConfig[K]> extends true
+        ? K
+        : never
+      : IsVarProp<PropsConfig[K]> extends true
+        ? HasBreakpointSupport<PropsConfig[K]> extends true
+          ? K
+          : never
+        : K;
 }[AllPropKeys];
 
 type FullPropsWithoutBreakpoint = Exclude<AllPropKeys, FullPropsWithBreakpoint>;

--- a/packages/lism-css/src/lib/types/ResponsiveProps.module-augmentation.spec-d.ts
+++ b/packages/lism-css/src/lib/types/ResponsiveProps.module-augmentation.spec-d.ts
@@ -75,6 +75,28 @@ describe('BreakpointRegistry module augmentation', () => {
     expectTypeOf(withTrait).toExtend<LismPropsBase>();
   });
 
+  it('full モードでも border ショートハンド（bd 系）はレスポンシブ化されず、サブプロパティが解禁される（#513）', () => {
+    // bd 系11キーは full preset の bp 拡張から除外されるため、レスポンシブ記法は型エラーになる
+    const invalidBd: PropValueTypes = {
+      // @ts-expect-error bd はレスポンシブ非対応（bds / bdw / bdc を使う）
+      bd: ['1px solid red', '2px solid blue'],
+    };
+    const invalidBdX: PropValueTypes = {
+      // @ts-expect-error bd-x はレスポンシブ非対応
+      'bd-x': { base: '1px solid red', md: '2px solid blue' },
+    };
+    // 代わりに border サブプロパティ（bds / bdc、bdw は defaults から対応済み）がレスポンシブ化される
+    const validSubProps: PropValueTypes = {
+      bds: ['dashed', 'dotted'],
+      bdc: { base: 'divider', md: 'accent' },
+      bdw: ['1px', '2px'],
+    };
+
+    expectTypeOf(invalidBd).toExtend<PropValueTypes>();
+    expectTypeOf(invalidBdX).toExtend<PropValueTypes>();
+    expectTypeOf(validSubProps).toExtend<PropValueTypes>();
+  });
+
   it('FullModeRegistry 拡張で bp:0 だった props も responsive 指定が解禁される（#425）', () => {
     // defaults では pl/ml/cg は bp:0、bg は bp 未設定（いずれも非レスポンシブ）。
     // full モードを型に反映すると、配列・オブジェクト記法が型エラーにならなくなる。

--- a/packages/lism-css/src/scss/_prop-config-full.gen.scss
+++ b/packages/lism-css/src/scss/_prop-config-full.gen.scss
@@ -341,7 +341,6 @@ $props: (
     utilities: (
       'none': 'none',
     ),
-    bp: 1,
   ),
   'bds': (
     prop: '--bds',
@@ -350,6 +349,7 @@ $props: (
       'dotted': 'dotted',
       'double': 'double',
     ),
+    bp: 1,
     isVar: 1,
   ),
   'bdc': (
@@ -362,52 +362,13 @@ $props: (
       'transparent': 'transparent',
       'current': 'currentColor',
     ),
+    bp: 1,
     isVar: 1,
   ),
   'bdw': (
     prop: '--bdw',
     bp: 1,
     isVar: 1,
-  ),
-  'bd-x': (
-    prop: 'border-inline',
-    bp: 1,
-  ),
-  'bd-y': (
-    prop: 'border-block',
-    bp: 1,
-  ),
-  'bd-s': (
-    prop: 'border-inline-start',
-    bp: 1,
-  ),
-  'bd-e': (
-    prop: 'border-inline-end',
-    bp: 1,
-  ),
-  'bd-bs': (
-    prop: 'border-block-start',
-    bp: 1,
-  ),
-  'bd-be': (
-    prop: 'border-block-end',
-    bp: 1,
-  ),
-  'bd-t': (
-    prop: 'border-top',
-    bp: 1,
-  ),
-  'bd-b': (
-    prop: 'border-bottom',
-    bp: 1,
-  ),
-  'bd-l': (
-    prop: 'border-left',
-    bp: 1,
-  ),
-  'bd-r': (
-    prop: 'border-right',
-    bp: 1,
   ),
   'bdrs': (
     prop: 'border-radius',

--- a/packages/mcp/src/data/docs-index.json
+++ b/packages/mcp/src/data/docs-index.json
@@ -457,7 +457,7 @@
       "main_no_layer.css",
       "full_no_layer.css"
     ],
-    "snippet": "lism-css パッケージに同梱された複数のビルド済みCSSの使い分けを解説。main.css（標準）/ main_no_layer.css（@layerなし）/ full.css（全部入り、purge前提）/ full_no_layer.css から選択可能。full.css には main.css 非収録の全 Property Class ブレイクポイント対応クラスやスペーシング系トークンユーティリティを含む。isFullMode（lism.config.js で設定）でコンポーネント出力も full.css に合わせられる。@lism-css/plugin の統合プラグイン使用時は型も isFullMode に自動追従（lism-env.d.ts 生成）。"
+    "snippet": "lism-css パッケージに同梱された複数のビルド済みCSSの使い分けを解説。main.css（標準）/ main_no_layer.css（@layerなし）/ full.css（全部入り、purge前提）/ full_no_layer.css から選択可能。full.css には main.css 非収録の Property Class ブレイクポイント対応クラス（isVar 系・border ショートハンド系を除く。border は bds / bdc のサブプロパティで BP 対応）やスペーシング系トークンユーティリティを含む。isFullMode（lism.config.js で設定）でコンポーネント出力も full.css に合わせられる。@lism-css/plugin の統合プラグイン使用時は型も isFullMode に自動追従（lism-env.d.ts 生成）。"
   },
   {
     "sourcePath": "customize/config.mdx",

--- a/packages/plugin/src/builder/compile-entry.test.ts
+++ b/packages/plugin/src/builder/compile-entry.test.ts
@@ -116,6 +116,24 @@ describe('createCssCompiler', () => {
     expect(fullCss).not.toContain('360px');
   });
 
+  test('full エントリでは border ショートハンドは BP 化されず、サブプロパティの BP クラスが出力される（#513）', async () => {
+    const c = makeCompiler();
+    const { mainConfig, fullConfig } = configs({});
+    const fullCss = await c.compile('full', mainConfig, fullConfig);
+
+    // 汎用ベースルール .-bd { border: var(--bd) } は _border.scss の特殊実装と競合するため出力されない
+    expect(fullCss).not.toMatch(/\.-bd\s*\{\s*border:/);
+    // border ショートハンド系の BP クラスも出力されない
+    expect(fullCss).not.toContain('.-bd_sm');
+    expect(fullCss).not.toContain('.-bd-x_sm');
+    // 代わりに border サブプロパティの BP クラス（変数上書き）が出力される
+    expect(fullCss).toContain('.-bds_sm');
+    expect(fullCss).toContain('.-bdc_sm');
+    expect(fullCss).toContain('.-bdw_sm');
+    // _border.scss の特殊実装（--bds 参照）は維持される
+    expect(fullCss).toContain('border-style: var(--bds)');
+  });
+
   test('同一 config・同一エントリはキャッシュされ同一結果を返す', async () => {
     const c = makeCompiler();
     const { mainConfig, fullConfig } = configs({});


### PR DESCRIPTION
## 概要

full.css / full_no_layer.css で、border用Property Class（`.-bd` と方向指定10クラス）を付けてもborderが表示されないバグを修正します。

Closes #513

## 原因

`config/presets/props-full.ts` が isVar系以外の全propsへ一括で `bp: 1` を付与しており、`bd` 系11キーにも適用されていました。その結果、`_auto_output.scss` が汎用ベースルール `.-bd { border: var(--bd) }` を出力し、`_border.scss` の特殊実装（`--bds` / `--bdw` / `--bdc` の3変数管理）による `.-bd { border-style: var(--bds) }` を同一詳細度のカスケードで打ち消していました。`--bd` はCSS内で未定義のため、borderの全longhandが初期値扱い（`border-style: none`）になり、borderが表示されませんでした。

## 変更内容

- `props-full.ts`: 一括 `bp: 1` 導出から bd系11キー（`bd` + 方向指定10種）を除外（`FULL_BP_EXCLUDED_KEYS`）
- `props-full.ts`: 代わりに isVar系サブプロパティ `bds` / `bdc` へ full限定で `bp: 1` を追加（`FULL_BP_ISVAR_KEYS`。`bdw` はdefaultsで対応済み。isVar系のBPクラスは `.-bds_sm { --bds: var(--bds_sm) !important }` のように変数を上書きするだけなので競合しない）
- `PropValueTypes.ts`: fullモード型（`FullPropsWithBreakpoint`）へ除外・追加を反映（除外リストの型は `props-full.ts` から共有）
- `pnpm build:css` で `_prop-config-full.gen.scss` を再生成
- docs追従: ja/en の `customize/build.mdx`・`customize/purge.mdx` の「isVar系を除く全Property ClassがBP対応」という記述を修正し、borderサブプロパティ経由のBP対応を追記。MCPの `docs-index.json` の該当snippetも同様に修正
- テスト追加:
  - `config/index.test.ts`: isFullMode時に bd系が `bp` 対象外・`bds` / `bdc` が `bp: 1` になることを確認
  - `ResponsiveProps.module-augmentation.spec-d.ts`: fullモード型で `bd` / `bd-x` のレスポンシブ記法が型エラーになり、`bds` / `bdc` / `bdw` が解禁されることを確認

## 仕様変更（意図的）

fullモードで `bd` にレスポンシブ値（配列 / オブジェクト）を渡す使い方は非対応になります。borderのレスポンシブ対応はサブプロパティ（`bds` / `bdw` / `bdc`）に統一します。型レベルでも `bd={[...]}` はエラーになり、ランタイムでは開発時に `warnUnsupportedBp` の警告が出ます。

なお、従来のfullモードでの `bd` レスポンシブ指定は `-bd` / `-bd_sm` クラス + インライン `--bd` / `--bd_sm` 変数として出力されており、インラインで `--bd` が定義される場合に限り動作していました（Issueの確認事項を実装前に確認済み）。

## 検証

- full.css / full_no_layer.css から `.-bd { border: var(--bd) }` と bd系のBPクラス（`.-bd_sm` 等）が消えたことを確認
- `.-bds_sm/md/lg` / `.-bdc_sm/md/lg`（変数上書きのみ）が追加されたことを確認
- main.css / main_no_layer.css に差分がないことを確認
- packages/lism-css: 717テストpass（型fixtureテスト含む）/ packages/plugin: 197テストpass / `pnpm typecheck` / `pnpm lint` pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * フルモードでのレスポンシブなボーダー指定を見直しました。
  * ボーダーのサブプロパティ（線種・色・幅）はブレークポイントに対応し、短縮指定は対象外になりました。

* **ドキュメント**
  * 対応するボーダー指定と対象外の指定について、英語・日本語の説明を更新しました。

* **テスト**
  * レスポンシブ指定の有効・無効なパターンを追加検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->