### PR TITLE
test(mockup): dev.test.ts の afterAll が CI で不定期にハングする問題を修正

### DIFF
--- a/packages/mockup/src/commands/dev.test.ts
+++ b/packages/mockup/src/commands/dev.test.ts
@@ -64,7 +64,10 @@ beforeAll(async () => {
 }, 60_000);
 
 afterAll(async () => {
-  await server?.close();
+  // vitejs/vite#18224: 変換中に close するとウォッチャーが残り、close が返ってこないことがある。
+  // テストは全て完了しているので、返ってこない場合は待たずに次へ進む。
+  // タイマーは unref する。ref 付きのままだと close が即座に返ってもプロセスの終了が 5 秒延びる。
+  await Promise.race([server?.close(), new Promise((resolve) => setTimeout(resolve, 5_000).unref())]);
   runtime?.cleanup();
   // 共有の cacheDir / configDir は cleanup() では消えない（次回起動で使い回すため）。テストが作った分だけ片付ける。
   // cacheDir は cleanup() の返却で共有パスへ戻っているので、占有パスではなく共有パスを消す。


### PR DESCRIPTION
## 概要

`packages/mockup/src/commands/dev.test.ts` の `afterAll` が CI で不定期にハングし、60秒のフックタイムアウトでファイル単位の FAIL になる問題を修正します。

原因は Vite 本体の未修正バグ [vitejs/vite#18224](https://github.com/vitejs/vite/issues/18224)。変換の途中で `server.close()` を呼ぶとウォッチャーが残り、`close()` が返ってこなくなります。テスト自体は全件パスしており、失敗しているのは後片付けだけでした。

## 変更内容

`afterAll` の `server.close()` に `Promise.race` で5秒の上限を設けました。

```ts
await Promise.race([server?.close(), new Promise((resolve) => setTimeout(resolve, 5_000).unref())]);
```

- ハングしても5秒で抜けるため、CI が60秒待たされない
- テストは全件パス済みなので、close の完了を待てなくても検証結果に影響しない
- 影響範囲は `dev.test.ts` の1ファイルのみ（dev サーバーを立てるテストは他にない）

タイマーは `unref()` しています。ref 付きのままだと `Promise.race` が即座に解決してもタイマーがイベントループに残り、プロセスの終了が5秒延びるためです。

## 確認したこと

| 項目 | 結果 |
| --- | --- |
| `vitest run src/commands/dev.test.ts` × 3回 | 全て pass / `real` 1.06〜1.08秒（5秒の上乗せなし） |
| `vitest run`（パッケージ全体） | 17ファイル・249件 pass |
| `tsc --noEmit` | エラーなし（`.unref()` は `NodeJS.Timeout` として解決） |
| `eslint` / `prettier --check` | 指摘なし |

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7Y1iQDjjwg8z1LyPxyumm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 開発サーバーの終了処理が最大5秒でタイムアウトするようになり、停止が完了しない場合でも次のクリーンアップに進めるようになりました。
  * 終了待機のタイマーがバックグラウンドで残らないようになり、後続処理が止まりにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->