### PR TITLE
templates/lp・blogをb--/c--の最新命名規約へ追随させる

### DIFF
--- a/templates/blog/astro/minimal/src/components/Pager.astro
+++ b/templates/blog/astro/minimal/src/components/Pager.astro
@@ -75,7 +75,7 @@ const nextHref = currentPage < lastPage ? getPageHref(currentPage + 1) : null;
   </Cluster>
 </Lism>
 <style>
-  @layer lism-component {
+  @layer lism-custom {
     .c--pager_nav,
     .c--pager_num {
       min-width: 28px;

--- a/templates/blog/astro/minimal/src/posts/lism-css-intro.md
+++ b/templates/blog/astro/minimal/src/posts/lism-css-intro.md
@@ -11,7 +11,7 @@ Lism CSS は、ユーティリティクラスとコンポーネント、デザ�
 
 ## CSS Layers
 
-Lism CSS のスタイルは複数の `@layer` に分かれて配置されており、レイヤの宣言順がそのまま優先度になる。`lism-base` → `lism-component` → `lism-utility` の順で重ねられているため、詳細度を気にせず Property Class で上書きできる。
+Lism CSS のスタイルは複数の `@layer` に分かれて配置されており、レイヤの宣言順がそのまま優先度になる。`lism-base` → `lism-custom` → `lism-utility` の順で重ねられているため、詳細度を気にせず Property Class で上書きできる。
 
 カスタム CSS を追加する際も、用途に合わせていずれかのレイヤに乗せる。
 
@@ -24,7 +24,7 @@ Lism CSS のスタイルは複数の `@layer` に分かれて配置されてお�
   }
 }
 
-@layer lism-component {
+@layer lism-custom {
   .c--postList > li {
     border-block-end: 1px solid var(--divider);
   }
@@ -94,16 +94,16 @@ import { Stack, Flex, Heading, Text } from 'lism-css/astro';
 
 ステート切替（active 等）やバリエーションには使わない。状態は `data-*` 属性、バリエーションは `c--{name}--{variant}` の BEM Modifier で表現する。
 
-## コンポーネントクラス（c--）
+## カスタムクラス（c--）
 
-プロジェクト固有のコンポーネントは `c--{name}` プレフィックスのクラスで定義する。Property Class で書ける宣言はマークアップに移し、CSS には擬似クラス・状態切替・子孫セレクタなど CSS でしか書けない宣言だけを残す。
+プロジェクト固有の要素やコンポーネントには `c--{name}` プレフィックスのカスタムクラスを定義する。Property Class で書ける宣言はマークアップに移し、CSS には擬似クラス・状態切替・子孫セレクタなど CSS でしか書けない宣言だけを残す。
 
 ```html
 <span class="c--tag -fz:xs -px:10 -py:5 -bgc:base-2 -bdrs:10">React</span>
 ```
 
 ```css
-@layer lism-component {
+@layer lism-custom {
   .c--tag:hover {
     background-color: var(--divider);
   }

--- a/templates/blog/astro/personal/src/components/Pager.astro
+++ b/templates/blog/astro/personal/src/components/Pager.astro
@@ -75,7 +75,7 @@ const nextHref = currentPage < lastPage ? getPageHref(currentPage + 1) : null;
   </Cluster>
 </Lism>
 <style>
-  @layer lism-component {
+  @layer lism-custom {
     .c--pager_nav,
     .c--pager_num {
       min-width: 28px;

--- a/templates/blog/astro/personal/src/components/ShareButtons.astro
+++ b/templates/blog/astro/personal/src/components/ShareButtons.astro
@@ -45,7 +45,7 @@ const { title } = Astro.props;
 </Lism>
 
 <style>
-  @layer lism-component {
+  @layer lism-custom {
     .c--shareBtn[data-is-copied] {
       color: var(--brand);
       --bdc: var(--brand);

--- a/templates/blog/astro/techlog/src/components/CategoryTabs.astro
+++ b/templates/blog/astro/techlog/src/components/CategoryTabs.astro
@@ -38,7 +38,7 @@ const linkProps = { c: 'text-2', hov: { c: 'brand' } };
 </Lism>
 
 <style>
-  @layer lism-component {
+  @layer lism-custom {
     .c--categoryTabs_item {
       margin-bottom: -1px;
       border-bottom: 2px solid transparent;

--- a/templates/blog/astro/techlog/src/components/Pager.astro
+++ b/templates/blog/astro/techlog/src/components/Pager.astro
@@ -75,7 +75,7 @@ const nextHref = currentPage < lastPage ? getPageHref(currentPage + 1) : null;
   </Cluster>
 </Lism>
 <style>
-  @layer lism-component {
+  @layer lism-custom {
     .c--pager_nav,
     .c--pager_num {
       min-width: 28px;

--- a/templates/blog/astro/techlog/src/components/ShareButtons.astro
+++ b/templates/blog/astro/techlog/src/components/ShareButtons.astro
@@ -45,7 +45,7 @@ const { title } = Astro.props;
 </Lism>
 
 <style>
-  @layer lism-component {
+  @layer lism-custom {
     .c--shareBtn[data-is-copied] {
       color: var(--brand);
       --bdc: var(--brand);

--- a/templates/blog/astro/techlog/src/components/TocItem.astro
+++ b/templates/blog/astro/techlog/src/components/TocItem.astro
@@ -42,7 +42,7 @@ const { item, ...rest } = Astro.props;
 </li>
 
 <style>
-  @layer lism-components {
+  @layer lism-custom {
     .c--toc_item > a {
       --duration: 0.2s;
       --transitionProps: color;

--- a/templates/blog/astro/techlog/src/components/linkCard.css
+++ b/templates/blog/astro/techlog/src/components/linkCard.css
@@ -1,5 +1,5 @@
 /* === リンクカード（LinkCard / LinkCardExternal / LinkCardInternal 共通スタイル） === */
-@layer lism-component {
+@layer lism-custom {
   .c--linkCard_thumb {
     width: 240px;
     max-width: 40%;

--- a/templates/blog/astro/techlog/src/posts/tech/lism-css-intro.mdx
+++ b/templates/blog/astro/techlog/src/posts/tech/lism-css-intro.mdx
@@ -15,7 +15,7 @@ Lism CSS は、ユーティリティクラスとコンポーネント、デザ�
 
 ## CSS Layers
 
-Lism CSS のスタイルは複数の `@layer` に分かれて配置されており、レイヤの宣言順がそのまま優先度になる。`lism-base` → `lism-component` → `lism-utility` の順で重ねられているため、詳細度を気にせず Property Class で上書きできる。
+Lism CSS のスタイルは複数の `@layer` に分かれて配置されており、レイヤの宣言順がそのまま優先度になる。`lism-base` → `lism-custom` → `lism-utility` の順で重ねられているため、詳細度を気にせず Property Class で上書きできる。
 
 カスタム CSS を追加する際も、用途に合わせていずれかのレイヤに乗せる。
 
@@ -28,7 +28,7 @@ Lism CSS のスタイルは複数の `@layer` に分かれて配置されてお�
   }
 }
 
-@layer lism-component {
+@layer lism-custom {
   .c--postList > li {
     border-block-end: 1px solid var(--divider);
   }
@@ -98,16 +98,16 @@ import { Stack, Flex, Heading, Text } from 'lism-css/astro';
 
 ステート切替（active 等）やバリエーションには使わない。状態は `data-*` 属性、バリエーションは `c--{name}--{variant}` の BEM Modifier で表現する。
 
-## コンポーネントクラス（c--）
+## カスタムクラス（c--）
 
-プロジェクト固有のコンポーネントは `c--{name}` プレフィックスのクラスで定義する。Property Class で書ける宣言はマークアップに移し、CSS には擬似クラス・状態切替・子孫セレクタなど CSS でしか書けない宣言だけを残す。
+プロジェクト固有の要素やコンポーネントには `c--{name}` プレフィックスのカスタムクラスを定義する。Property Class で書ける宣言はマークアップに移し、CSS には擬似クラス・状態切替・子孫セレクタなど CSS でしか書けない宣言だけを残す。
 
 ```html
 <span class="c--tag -fz:xs -px:10 -py:5 -bgc:base-2 -bdrs:10">React</span>
 ```
 
 ```css
-@layer lism-component {
+@layer lism-custom {
   .c--tag:hover {
     background-color: var(--divider);
   }

--- a/templates/lp/astro/src/components/corporate/Header.astro
+++ b/templates/lp/astro/src/components/corporate/Header.astro
@@ -20,34 +20,34 @@ const headerOthersNavItems = [
 ] as const;
 ---
 
-<Container as="header" class="z--header" pos="fixed" t="0" l="0" w="100%" z="1" hasGutter>
-  <Grid class="z--header_inner" gtc="10rem 1fr" ai="center" h="100%" px={['0', null, '40']}>
-    <Stack class="z--header_logo">
-      <Link class="z--header_logoLink" href="#" set="plain" fz="xl" lts="l" td="none">
+<Container as="header" class="c--header" pos="fixed" t="0" l="0" w="100%" z="1" hasGutter>
+  <Grid class="c--header_inner" gtc="10rem 1fr" ai="center" h="100%" px={['0', null, '40']}>
+    <Stack class="c--header_logo">
+      <Link class="c--header_logoLink" href="#" set="plain" fz="xl" lts="l" td="none">
         <Inline fw="200">Lism</Inline>Corp
       </Link>
     </Stack>
     <Flex jc="fe" g="30">
-      <List class="z--headerNav" layout="flex" d={['none', null, 'flex']} ai="center" g="30" lts="l">
+      <List class="c--headerNav" layout="flex" d={['none', null, 'flex']} ai="center" g="30" lts="l">
         {
           headerNavItems.map(({ href, en }) => (
             <ListItem>
-              <Link class="z--headerNav_link" href={href} set="plain" d="block" o="mp" py="10" hasTransition hov="-o">
+              <Link class="c--headerNav_link" href={href} set="plain" d="block" o="mp" py="10" hasTransition hov="-o">
                 {en}
               </Link>
             </ListItem>
           ))
         }
         <ListItem set="hov" pos="relative" data-has-submenu>
-          <Link class="z--headerNav_link" href="#others" set="plain" hasTransition d="inline-flex" g="10" ai="center" o="mp" px="0" py="10" hov="-o">
+          <Link class="c--headerNav_link" href="#others" set="plain" hasTransition d="inline-flex" g="10" ai="center" o="mp" px="0" py="10" hov="-o">
             Others
             <Icon icon="caret-down" fz="s" o="p" />
           </Link>
-          <Lism id="others-child" class="z--header_subMenu" hasTransition pos="absolute" pbs="5" t="100%" r="calc(0px - var(--s40))">
+          <Lism id="others-child" class="c--header_subMenu" hasTransition pos="absolute" pbs="5" t="100%" r="calc(0px - var(--s40))">
             <List bgc="base" c="text" min-w="14rem" p="20" py="15" bxsh="30" bdrs="20">
               {
                 headerOthersNavItems.map(({ href, en }, index) => (
-                  <ListItem className="z--header_subMenu_item" bd-bs={index === 0 ? '' : true}>
+                  <ListItem className="c--header_subMenu_item" bd-bs={index === 0 ? '' : true}>
                     <BoxLink href={href} py="15" px="10" hasTransition hov="-o">
                       <Inline>{en}</Inline>
                     </BoxLink>
@@ -60,7 +60,7 @@ const headerOthersNavItems = [
       </List>
       <Modal.OpenBtn modalId="menu" d={['block', null, 'none']}>
         <Center p="5" bdrs="10">
-          <Icon class="z--header_subMenu_buttonIcon" icon="menu" size="1.25rem" />
+          <Icon class="c--header_subMenu_buttonIcon" icon="menu" size="1.25rem" />
         </Center>
       </Modal.OpenBtn>
     </Flex>
@@ -68,7 +68,7 @@ const headerOthersNavItems = [
       <Modal.Inner layout="stack" me="0" pos="relative" w="100%" p="30" bdrs="20" bxsh="50" c="text" bgc="base">
         <Modal.CloseBtn modalId="menu" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
         <Modal.Body layout="stack" g="30" my="10" mbs="40">
-          <Stack class="z--header_menuNav u--divide" bd-y>
+          <Stack class="c--header_menuNav u--divide" bd-y>
             {
               headerNavItems.map(({ href, en }) => (
                 <BoxLink href={href} layout="grid" gtc="1fr auto" ai="center" fz="l" td="none" py="15" px="5">
@@ -85,7 +85,7 @@ const headerOthersNavItems = [
                   </Accordion.Button>
                 </Accordion.Heading>
                 <Accordion.Panel p="0" ov="clip">
-                  <Stack class="z--header_menuNav_sub u--divide" ml="20" p="0" ov="clip">
+                  <Stack class="c--header_menuNav_sub u--divide" ml="20" p="0" ov="clip">
                     {
                       headerOthersNavItems.map(({ href, en }) => (
                         <BoxLink href={href} layout="grid" gtc="1fr auto" ai="center" fz="l" td="none" py="15" px="5">

--- a/templates/lp/astro/src/components/en/corporate/Header.astro
+++ b/templates/lp/astro/src/components/en/corporate/Header.astro
@@ -20,34 +20,34 @@ const headerOthersNavItems = [
 ] as const;
 ---
 
-<Container as="header" class="z--header" pos="fixed" t="0" l="0" w="100%" z="1" hasGutter>
-  <Grid class="z--header_inner" gtc="10rem 1fr" ai="center" h="100%" px={['0', null, '40']}>
-    <Stack class="z--header_logo">
-      <Link class="z--header_logoLink" href="#" set="plain" fz="xl" lts="l" td="none">
+<Container as="header" class="c--header" pos="fixed" t="0" l="0" w="100%" z="1" hasGutter>
+  <Grid class="c--header_inner" gtc="10rem 1fr" ai="center" h="100%" px={['0', null, '40']}>
+    <Stack class="c--header_logo">
+      <Link class="c--header_logoLink" href="#" set="plain" fz="xl" lts="l" td="none">
         <Inline fw="200">Lism</Inline>Corp
       </Link>
     </Stack>
     <Flex jc="fe" g="30">
-      <List class="z--headerNav" layout="flex" d={['none', null, 'flex']} ai="center" g="30" lts="l">
+      <List class="c--headerNav" layout="flex" d={['none', null, 'flex']} ai="center" g="30" lts="l">
         {
           headerNavItems.map(({ href, en }) => (
             <ListItem>
-              <Link class="z--headerNav_link" href={href} set="plain" d="block" o="mp" py="10" hasTransition hov="-o">
+              <Link class="c--headerNav_link" href={href} set="plain" d="block" o="mp" py="10" hasTransition hov="-o">
                 {en}
               </Link>
             </ListItem>
           ))
         }
         <ListItem set="hov" pos="relative" data-has-submenu>
-          <Link class="z--headerNav_link" href="#others" set="plain" hasTransition d="inline-flex" g="10" ai="center" o="mp" px="0" py="10" hov="-o">
+          <Link class="c--headerNav_link" href="#others" set="plain" hasTransition d="inline-flex" g="10" ai="center" o="mp" px="0" py="10" hov="-o">
             Others
             <Icon icon="caret-down" fz="s" o="p" />
           </Link>
-          <Lism id="others-child" class="z--header_subMenu" hasTransition pos="absolute" pbs="5" t="100%" r="calc(0px - var(--s40))">
+          <Lism id="others-child" class="c--header_subMenu" hasTransition pos="absolute" pbs="5" t="100%" r="calc(0px - var(--s40))">
             <List bgc="base" c="text" min-w="14rem" p="20" py="15" bxsh="30" bdrs="20">
               {
                 headerOthersNavItems.map(({ href, en }, index) => (
-                  <ListItem className="z--header_subMenu_item" bd-bs={index === 0 ? '' : true}>
+                  <ListItem className="c--header_subMenu_item" bd-bs={index === 0 ? '' : true}>
                     <BoxLink href={href} py="15" px="10" hasTransition hov="-o">
                       <Inline>{en}</Inline>
                     </BoxLink>
@@ -60,7 +60,7 @@ const headerOthersNavItems = [
       </List>
       <Modal.OpenBtn modalId="menu" d={['block', null, 'none']}>
         <Center p="5" bdrs="10">
-          <Icon class="z--header_subMenu_buttonIcon" icon="menu" size="1.25rem" />
+          <Icon class="c--header_subMenu_buttonIcon" icon="menu" size="1.25rem" />
         </Center>
       </Modal.OpenBtn>
     </Flex>
@@ -68,7 +68,7 @@ const headerOthersNavItems = [
       <Modal.Inner layout="stack" me="0" pos="relative" w="100%" p="30" bdrs="20" bxsh="50" c="text" bgc="base">
         <Modal.CloseBtn modalId="menu" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
         <Modal.Body layout="stack" g="30" my="10" mbs="40">
-          <Stack class="z--header_menuNav u--divide" bd-y>
+          <Stack class="c--header_menuNav u--divide" bd-y>
             {
               headerNavItems.map(({ href, en }) => (
                 <BoxLink href={href} layout="grid" gtc="1fr auto" ai="center" fz="l" td="none" py="15" px="5">
@@ -85,7 +85,7 @@ const headerOthersNavItems = [
                   </Accordion.Button>
                 </Accordion.Heading>
                 <Accordion.Panel p="0" ov="clip">
-                  <Stack class="z--header_menuNav_sub u--divide" ml="20" p="0" ov="clip">
+                  <Stack class="c--header_menuNav_sub u--divide" ml="20" p="0" ov="clip">
                     {
                       headerOthersNavItems.map(({ href, en }) => (
                         <BoxLink href={href} layout="grid" gtc="1fr auto" ai="center" fz="l" td="none" py="15" px="5">

--- a/templates/lp/astro/src/components/en/interior/Header.astro
+++ b/templates/lp/astro/src/components/en/interior/Header.astro
@@ -26,17 +26,17 @@ const headerMenuNavItems = [
 ];
 ---
 
-<Container as="header" class="z--header" isWrapper="xl" hasGutter pos="fixed" t="0" l="0" w="100%" z="1">
-  <Grid class="z--header_inner" gtc="auto 1fr" ai="center" h="100%">
+<Container as="header" class="c--header" isWrapper="xl" hasGutter pos="fixed" t="0" l="0" w="100%" z="1">
+  <Grid class="c--header_inner" gtc="auto 1fr" ai="center" h="100%">
     <Stack class="c--logo">
       <Link href="#top" fz="2xl" fw="bold" lts="l" c="text" td="none" ff="accent">LISM Life</Link>
     </Stack>
 
-    <Flex class="z--nav" as="ul" d={['none', null, 'flex']} ai="center" ms="auto" g={['15', null, null, '25']} fz="s" lts="l">
+    <Flex class="c--nav" as="ul" d={['none', null, 'flex']} ai="center" ms="auto" g={['15', null, null, '25']} fz="s" lts="l">
       {
         headerPrimaryNavItems.map(({ href, en }) => (
           <ListItem>
-            <Link class="z--nav_link" href={href} set="plain" d="block" hl="s" p="5" hasTransition hov="-o">
+            <Link class="c--nav_link" href={href} set="plain" d="block" hl="s" p="5" hasTransition hov="-o">
               {en}
             </Link>
           </ListItem>
@@ -55,11 +55,11 @@ const headerMenuNavItems = [
       </Modal.OpenBtn>
     </Box>
 
-    <Modal.Root id="menu" class="z--header_menuModal" isContainer min-h="100svh" p="0">
+    <Modal.Root id="menu" class="c--header_menuModal" isContainer min-h="100svh" p="0">
       <Modal.Inner layout="stack" g="0" pos="relative" py="30" ms="auto" bxsh="50" max-w="xs" w="100%" h="100%" offset="100% 0">
         <Modal.CloseBtn modalId="menu" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
         <Modal.Body layout="stack" g="30" py="40" fx="1" min-h="0" ov-y="auto" w="100%">
-          <Stack class="z--header_menuNav u--divide">
+          <Stack class="c--header_menuNav u--divide">
             {
               headerMenuNavItems.map(({ href, en }) => (
                 <Link href={href} set="plain" layout="grid" gtc="1fr auto" ai="center" hl="s" py="20" px="25">

--- a/templates/lp/astro/src/components/interior/Header.astro
+++ b/templates/lp/astro/src/components/interior/Header.astro
@@ -26,17 +26,17 @@ const headerMenuNavItems = [
 ];
 ---
 
-<Container as="header" class="z--header" isWrapper="xl" hasGutter pos="fixed" t="0" l="0" w="100%" z="1">
-  <Grid class="z--header_inner" gtc="auto 1fr" ai="center" h="100%">
+<Container as="header" class="c--header" isWrapper="xl" hasGutter pos="fixed" t="0" l="0" w="100%" z="1">
+  <Grid class="c--header_inner" gtc="auto 1fr" ai="center" h="100%">
     <Stack class="c--logo">
       <Link href="#top" fz="2xl" fw="bold" lts="l" c="text" td="none" ff="accent">LISM Life</Link>
     </Stack>
 
-    <Flex class="z--nav" as="ul" d={['none', null, 'flex']} ai="center" ms="auto" g={['15', null, null, '25']} fz="s" lts="l">
+    <Flex class="c--nav" as="ul" d={['none', null, 'flex']} ai="center" ms="auto" g={['15', null, null, '25']} fz="s" lts="l">
       {
         headerPrimaryNavItems.map(({ href, ja }) => (
           <ListItem>
-            <Link class="z--nav_link" href={href} set="plain" d="block" hl="s" p="5" hasTransition hov="-o">
+            <Link class="c--nav_link" href={href} set="plain" d="block" hl="s" p="5" hasTransition hov="-o">
               {ja}
             </Link>
           </ListItem>
@@ -55,11 +55,11 @@ const headerMenuNavItems = [
       </Modal.OpenBtn>
     </Box>
 
-    <Modal.Root id="menu" class="z--header_menuModal" isContainer min-h="100svh" p="0">
+    <Modal.Root id="menu" class="c--header_menuModal" isContainer min-h="100svh" p="0">
       <Modal.Inner layout="stack" g="0" pos="relative" py="30" ms="auto" bxsh="50" max-w="xs" w="100%" h="100%" offset="100% 0">
         <Modal.CloseBtn modalId="menu" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
         <Modal.Body layout="stack" g="30" py="40" fx="1" min-h="0" ov-y="auto" w="100%">
-          <Stack class="z--header_menuNav u--divide">
+          <Stack class="c--header_menuNav u--divide">
             {
               headerMenuNavItems.map(({ href, ja }) => (
                 <Link href={href} set="plain" layout="grid" gtc="1fr auto" ai="center" hl="s" py="20" px="25">

--- a/templates/lp/astro/src/pages/corporate/_animations.css
+++ b/templates/lp/astro/src/pages/corporate/_animations.css
@@ -86,13 +86,13 @@
   }
 
   /* MV: スクロールで先頭セクション全体をぼかし＋拡大 */
-  .z--mv {
+  .c--mv {
     view-timeline: --mv y;
-    animation: z--mv linear both;
+    animation: c--mv linear both;
     animation-timeline: --mv;
     animation-range: exit;
   }
-  @keyframes z--mv {
+  @keyframes c--mv {
     from {
       filter: blur(0px);
       opacity: 1;
@@ -103,12 +103,12 @@
       transform: scale(1.05);
     }
   }
-  .z--mv_media {
-    animation: z--mv_media linear both;
+  .c--mv_media {
+    animation: c--mv_media linear both;
     animation-timeline: --mv;
     animation-range: exit;
   }
-  @keyframes z--mv_media {
+  @keyframes c--mv_media {
     from {
       transform: translateY(0);
     }
@@ -116,12 +116,12 @@
       transform: translateY(15%) scale(1.1);
     }
   }
-  .z--mv_content {
-    animation: z--mv_content linear both;
+  .c--mv_content {
+    animation: c--mv_content linear both;
     animation-timeline: --mv;
     animation-range: exit;
   }
-  @keyframes z--mv_content {
+  @keyframes c--mv_content {
     from {
       transform: scale(1);
     }

--- a/templates/lp/astro/src/pages/corporate/_style.css
+++ b/templates/lp/astro/src/pages/corporate/_style.css
@@ -8,7 +8,7 @@
   }
 
   /* Header） */
-  .z--header {
+  .c--header {
     height: var(--header-h--init);
     color: var(--white);
     transition:
@@ -17,7 +17,7 @@
       color 0.4s;
   }
 
-  :root[data-scrolled] .z--header {
+  :root[data-scrolled] .c--header {
     height: var(--header-h);
     background-color: var(--base);
     color: var(--text);
@@ -27,13 +27,13 @@
     Memo: animation-timelineで実装する場合:
     80px スクロールしてからヘッダー変化アニメーションを開始（終了は +240px スクロール地点）
   */
-  /* .z--header {
+  /* .c--header {
     --header-animRange: 80px calc(80px + 240px);
-    animation: z--header linear both;
+    animation: c--header linear both;
     animation-timeline: scroll(root);
     animation-range: var(--header-animRange);
   }
-  @keyframes z--header {
+  @keyframes c--header {
     to {
       background-color: var(--base);
       color: var(--text);
@@ -41,31 +41,31 @@
     }
   } */
 
-  .z--header_subMenu {
+  .c--header_subMenu {
     opacity: var(--_notHov, 0);
     visibility: var(--_notHov, hidden);
     transform: var(--_isHov, translateY(8px));
     transition-property: visibility, transform, opacity;
   }
 
-  .z--headerNav_link,
-  .z--header_subMenu_item > a {
+  .c--headerNav_link,
+  .c--header_subMenu_item > a {
     --hov-o: var(--o--pp);
     transition-property: opacity;
   }
 
-  .z--header_menuNav :is(.c--accordion_icon, .a--icon) {
+  .c--header_menuNav :is(.c--accordion_icon, .a--icon) {
     font-size: var(--fz--s);
     opacity: var(--o--p);
   }
 
   /* モバイルメニュー: +/- を caret-right（fz--s）に近い視覚サイズへ */
-  .z--header_menuNav .c--accordion_icon {
+  .c--header_menuNav .c--accordion_icon {
     transform: scale(0.925);
     /*transform-origin: center;*/
   }
 
-  .z--mv_content {
+  .c--mv_content {
     /* header分少し下げる */
     padding-top: calc(var(--header-h) / 2);
   }
@@ -88,23 +88,23 @@
     }
   }
 
-  .z--about {
+  .c--about {
     isolation: isolate;
   }
-  .z--about .z--about_visuals {
+  .c--about .c--about_visuals {
     pointer-events: none;
   }
-  .z--about .z--about_visual:nth-child(1) {
+  .c--about .c--about_visual:nth-child(1) {
     top: -2rem;
     right: 100%;
     translate: calc(25% - 10vw) 0;
   }
-  .z--about .z--about_visual:nth-child(2) {
+  .c--about .c--about_visual:nth-child(2) {
     top: 6rem;
     left: 100%;
     translate: calc(-20% + (10vw - 80px)) 0;
   }
-  .z--about .z--about_visual:nth-child(3) {
+  .c--about .c--about_visual:nth-child(3) {
     bottom: -6rem;
     right: 100%;
     translate: calc(50% - (4vw - 40px)) 0;

--- a/templates/lp/astro/src/pages/corporate/index.astro
+++ b/templates/lp/astro/src/pages/corporate/index.astro
@@ -244,10 +244,10 @@ const footerSnsLinks = [
     <!-- Header -->
     <Header />
     <!-- Main -->
-    <Container as="main" class="z--main">
-      <Box class="z--mv" pos="relative" pos="relative" h="min(100svh,1200px)">
-        <Frame class="z--mv_frame" isLayer>
-          <Media class="z--mv_media" src={mvImage} alt="" w="100%" h="100%" width="960" height="640" loading="eager" />
+    <Container as="main" class="c--main">
+      <Box class="c--mv" pos="relative" pos="relative" h="min(100svh,1200px)">
+        <Frame class="c--mv_frame" isLayer>
+          <Media class="c--mv_media" src={mvImage} alt="" w="100%" h="100%" width="960" height="640" loading="eager" />
           <Layer
             style={{
               backdropFilter: 'grayscale(25%)',
@@ -255,7 +255,7 @@ const footerSnsLinks = [
             }}
           />
         </Frame>
-        <Layer layout="center" class="z--mv_content" g="10" c="white" hasGutter>
+        <Layer layout="center" class="c--mv_content" g="10" c="white" hasGutter>
           <Heading level="1" fz="4xl" fw="normal" ta="center" lts="l">Order and Harmony</Heading>
           <Text fz="l" fw="light" ta="center" lts="l">Lorem ipsum dolor sit amet.</Text>
         </Layer>
@@ -265,13 +265,13 @@ const footerSnsLinks = [
         </BoxLink>
       </Box>
 
-      <Container id="about" class="z--about" isWrapper="s" pos="relative" py="70" hasGutter>
+      <Container id="about" class="c--about" isWrapper="s" pos="relative" py="70" hasGutter>
         <Stack ai="center" jc="center" g="40" pos="relative">
           <SectionHeading en="About" ja="Lism CSSとは" />
-          <Box class="z--about_visuals" pos="absolute" w="100%" h="100%" z="0">
+          <Box class="c--about_visuals" pos="absolute" w="100%" h="100%" z="0">
             {
               aboutPhotos.map((photo, i) => (
-                <Box class="z--about_visual u--pullBack" pos="absolute" w={i === 0 ? '20rem' : '16rem'}>
+                <Box class="c--about_visual u--pullBack" pos="absolute" w={i === 0 ? '20rem' : '16rem'}>
                   <Frame class="u--bgParallax" pos="relative" ar="4/3" bdrs="20">
                     <Media src={photo} alt="" width="800" height="600" loading="lazy" o="ppp" />
                   </Frame>
@@ -279,7 +279,7 @@ const footerSnsLinks = [
               ))
             }
           </Box>
-          <Flow class="z--about_body u--fadeIn" flow="s" pos="relative" z="1">
+          <Flow class="c--about_body u--fadeIn" flow="s" pos="relative" z="1">
             <Text>
               Lism
               CSSは、Webサイトの骨組みをテンポ良く美しく作るための、軽量なCSS設計フレームワークです。設計理論に沿った一つのCSSが本体で、特別なビルド工程は必須ではありません。
@@ -300,7 +300,7 @@ const footerSnsLinks = [
         </Stack>
       </Container>
 
-      <Box id="feature" class="z--feature" pos="relative" bgc="base-2">
+      <Box id="feature" class="c--feature" pos="relative" bgc="base-2">
         <Container isWrapper="l" py="60" hasGutter>
           <Stack g="40">
             <SectionHeading en="Feature" ja="Lism CSSの特徴" />
@@ -308,7 +308,7 @@ const footerSnsLinks = [
               {
                 featureCards.map((card) => {
                   return (
-                    <WithSide sideW="40%" mainW="24rem" class="z--feature_item u--fadeInL" g={['30', null, '40']} ai="center">
+                    <WithSide sideW="40%" mainW="24rem" class="c--feature_item u--fadeInL" g={['30', null, '40']} ai="center">
                       <Frame isSide ar="16/9" pos="relative" bdrs="20" class="u--bgParallax">
                         <Media src={card.src} alt="" width="960" height="540" loading="lazy" />
                       </Frame>
@@ -329,7 +329,7 @@ const footerSnsLinks = [
         </Container>
       </Box>
 
-      <Container id="works" class="z--works" isWrapper="l" py="60" hasGutter>
+      <Container id="works" class="c--works" isWrapper="l" py="60" hasGutter>
         <Stack g="40">
           <SectionHeading en="Works" ja="制作実績" />
           <Text class="u--fadeIn">
@@ -338,8 +338,8 @@ const footerSnsLinks = [
           <AutoColumns cols="20rem" g="40">
             {
               worksItems.map((item) => (
-                <BoxLink class="z--works_item u--fadeIn" href="#" layout="stack" set="hov" g="20">
-                  <Frame class="z--works_frame" ar="16/9" pos="relative" bdrs="20">
+                <BoxLink class="c--works_item u--fadeIn" href="#" layout="stack" set="hov" g="20">
+                  <Frame class="c--works_frame" ar="16/9" pos="relative" bdrs="20">
                     <Media class="u--pullBack" src={item.src} alt="" width="960" height="540" loading="lazy" hasTransition hov="in:zoom" />
                     <Layer layout="center" hasTransition hov="in:show" h="100%" c="white" bgc="black:30%" style={{ backdropFilter: 'blur(4px)' }}>
                       <Inline fz="xl" fs="italic" fw="light" lts="l">
@@ -362,7 +362,7 @@ const footerSnsLinks = [
         </Stack>
       </Container>
 
-      <Box id="news" class="z--news" pos="relative">
+      <Box id="news" class="c--news" pos="relative">
         <Frame isLayer class="u--bgParallax">
           <Media src={newsBg} alt="" width="960" height="640" loading="lazy" />
         </Frame>
@@ -372,7 +372,7 @@ const footerSnsLinks = [
           <Stack g="30">
             {
               newsItems.map((row) => (
-                <BoxLink class="z--news_item u--fadeInL" href="#" layout="grid" gtc={['auto', 'auto 1fr']} g={['10', '30', '40']} py="10" set="hov">
+                <BoxLink class="c--news_item u--fadeInL" href="#" layout="grid" gtc={['auto', 'auto 1fr']} g={['10', '30', '40']} py="10" set="hov">
                   <Inline>{row.date}</Inline>
                   <Stack g="10">
                     <Text hov="in:underline" td="none">
@@ -390,7 +390,7 @@ const footerSnsLinks = [
         </Container>
       </Box>
 
-      <Container id="faq" class="z--faq" isWrapper layout="stack" g="40" py="60" hasGutter>
+      <Container id="faq" class="c--faq" isWrapper layout="stack" g="40" py="60" hasGutter>
         <SectionHeading en="FAQ" ja="よくある質問" />
         <Accordion.Root class="u--divide u--fadeIn" p="0" ov="clip">
           {
@@ -410,12 +410,12 @@ const footerSnsLinks = [
         </Accordion.Root>
       </Container>
 
-      <Container id="testimonials" class="z--testimonials" isWrapper="l" layout="stack" g="40" bgc="base-2" py="60" hasGutter>
+      <Container id="testimonials" class="c--testimonials" isWrapper="l" layout="stack" g="40" bgc="base-2" py="60" hasGutter>
         <SectionHeading en="Testimonials" ja="お客様の声" />
         <AutoColumns cols="20rem" g="40">
           {
             testimonials.map((item) => (
-              <Grid class="z--testimonials_item u--fadeIn" gtr="subgrid" gr="span 3" g="30">
+              <Grid class="c--testimonials_item u--fadeIn" gtr="subgrid" gr="span 3" g="30">
                 <Flex ai="center" g="20">
                   <Frame as="figure" ar="1/1" w="3.5rem" fxsh="0" bdrs="99">
                     <Media src={item.src} alt="" width="256" height="256" loading="lazy" />
@@ -438,7 +438,7 @@ const footerSnsLinks = [
         </AutoColumns>
       </Container>
 
-      <Container id="information" class="z--information" isWrapper layout="stack" g="40" py="60" hasGutter>
+      <Container id="information" class="c--information" isWrapper layout="stack" g="40" py="60" hasGutter>
         <SectionHeading en="Information" ja="企業情報" />
         <Grid as="dl" class="u--divide u--fadeIn" gtc="auto 1fr">
           {
@@ -462,7 +462,7 @@ const footerSnsLinks = [
         </Frame>
       </Container>
 
-      <Box id="contact" class="z--contact" pos="relative">
+      <Box id="contact" class="c--contact" pos="relative">
         <Frame isLayer class="u--bgParallax">
           <Media src={contactBg} alt="" width="960" height="640" loading="lazy" />
         </Frame>

--- a/templates/lp/astro/src/pages/en/corporate/_animations.css
+++ b/templates/lp/astro/src/pages/en/corporate/_animations.css
@@ -86,13 +86,13 @@
   }
 
   /* MV: スクロールで先頭セクション全体をぼかし＋拡大 */
-  .z--mv {
+  .c--mv {
     view-timeline: --mv y;
-    animation: z--mv linear both;
+    animation: c--mv linear both;
     animation-timeline: --mv;
     animation-range: exit;
   }
-  @keyframes z--mv {
+  @keyframes c--mv {
     from {
       filter: blur(0px);
       opacity: 1;
@@ -103,12 +103,12 @@
       transform: scale(1.05);
     }
   }
-  .z--mv_media {
-    animation: z--mv_media linear both;
+  .c--mv_media {
+    animation: c--mv_media linear both;
     animation-timeline: --mv;
     animation-range: exit;
   }
-  @keyframes z--mv_media {
+  @keyframes c--mv_media {
     from {
       transform: translateY(0);
     }
@@ -116,12 +116,12 @@
       transform: translateY(15%) scale(1.1);
     }
   }
-  .z--mv_content {
-    animation: z--mv_content linear both;
+  .c--mv_content {
+    animation: c--mv_content linear both;
     animation-timeline: --mv;
     animation-range: exit;
   }
-  @keyframes z--mv_content {
+  @keyframes c--mv_content {
     from {
       transform: scale(1);
     }

--- a/templates/lp/astro/src/pages/en/corporate/_style.css
+++ b/templates/lp/astro/src/pages/en/corporate/_style.css
@@ -8,7 +8,7 @@
   }
 
   /* Header） */
-  .z--header {
+  .c--header {
     height: var(--header-h--init);
     color: var(--white);
     transition:
@@ -17,7 +17,7 @@
       color 0.4s;
   }
 
-  :root[data-scrolled] .z--header {
+  :root[data-scrolled] .c--header {
     height: var(--header-h);
     background-color: var(--base);
     color: var(--text);
@@ -27,13 +27,13 @@
     Memo: animation-timelineで実装する場合:
     80px スクロールしてからヘッダー変化アニメーションを開始（終了は +240px スクロール地点）
   */
-  /* .z--header {
+  /* .c--header {
     --header-animRange: 80px calc(80px + 240px);
-    animation: z--header linear both;
+    animation: c--header linear both;
     animation-timeline: scroll(root);
     animation-range: var(--header-animRange);
   }
-  @keyframes z--header {
+  @keyframes c--header {
     to {
       background-color: var(--base);
       color: var(--text);
@@ -41,31 +41,31 @@
     }
   } */
 
-  .z--header_subMenu {
+  .c--header_subMenu {
     opacity: var(--_notHov, 0);
     visibility: var(--_notHov, hidden);
     transform: var(--_isHov, translateY(8px));
     transition-property: visibility, transform, opacity;
   }
 
-  .z--headerNav_link,
-  .z--header_subMenu_item > a {
+  .c--headerNav_link,
+  .c--header_subMenu_item > a {
     --hov-o: var(--o--pp);
     transition-property: opacity;
   }
 
-  .z--header_menuNav :is(.c--accordion_icon, .a--icon) {
+  .c--header_menuNav :is(.c--accordion_icon, .a--icon) {
     font-size: var(--fz--s);
     opacity: var(--o--p);
   }
 
   /* モバイルメニュー: +/- を caret-right（fz--s）に近い視覚サイズへ */
-  .z--header_menuNav .c--accordion_icon {
+  .c--header_menuNav .c--accordion_icon {
     transform: scale(0.925);
     /*transform-origin: center;*/
   }
 
-  .z--mv_content {
+  .c--mv_content {
     /* header分少し下げる */
     padding-top: calc(var(--header-h) / 2);
   }
@@ -88,23 +88,23 @@
     }
   }
 
-  .z--about {
+  .c--about {
     isolation: isolate;
   }
-  .z--about .z--about_visuals {
+  .c--about .c--about_visuals {
     pointer-events: none;
   }
-  .z--about .z--about_visual:nth-child(1) {
+  .c--about .c--about_visual:nth-child(1) {
     top: -2rem;
     right: 100%;
     translate: calc(25% - 10vw) 0;
   }
-  .z--about .z--about_visual:nth-child(2) {
+  .c--about .c--about_visual:nth-child(2) {
     top: 6rem;
     left: 100%;
     translate: calc(-20% + (10vw - 80px)) 0;
   }
-  .z--about .z--about_visual:nth-child(3) {
+  .c--about .c--about_visual:nth-child(3) {
     bottom: -6rem;
     right: 100%;
     translate: calc(50% - (4vw - 40px)) 0;

--- a/templates/lp/astro/src/pages/en/corporate/index.astro
+++ b/templates/lp/astro/src/pages/en/corporate/index.astro
@@ -245,10 +245,10 @@ const footerSnsLinks = [
     <!-- Header -->
     <Header />
     <!-- Main -->
-    <Container as="main" class="z--main">
-      <Box class="z--mv" pos="relative" pos="relative" h="min(100svh,1200px)">
-        <Frame class="z--mv_frame" isLayer>
-          <Media class="z--mv_media" src={mvImage} alt="" w="100%" h="100%" width="960" height="640" loading="eager" />
+    <Container as="main" class="c--main">
+      <Box class="c--mv" pos="relative" pos="relative" h="min(100svh,1200px)">
+        <Frame class="c--mv_frame" isLayer>
+          <Media class="c--mv_media" src={mvImage} alt="" w="100%" h="100%" width="960" height="640" loading="eager" />
           <Layer
             style={{
               backdropFilter: 'grayscale(25%)',
@@ -256,7 +256,7 @@ const footerSnsLinks = [
             }}
           />
         </Frame>
-        <Layer layout="center" class="z--mv_content" g="10" c="white" hasGutter>
+        <Layer layout="center" class="c--mv_content" g="10" c="white" hasGutter>
           <Heading level="1" fz="4xl" fw="normal" ta="center" lts="l">Order and Harmony</Heading>
           <Text fz="l" fw="light" ta="center" lts="l">Lorem ipsum dolor sit amet.</Text>
         </Layer>
@@ -266,13 +266,13 @@ const footerSnsLinks = [
         </BoxLink>
       </Box>
 
-      <Container id="about" class="z--about" isWrapper="s" pos="relative" py="70" hasGutter>
+      <Container id="about" class="c--about" isWrapper="s" pos="relative" py="70" hasGutter>
         <Stack ai="center" jc="center" g="40" pos="relative">
           <SectionHeading en="About" ja="What is Lism CSS?" />
-          <Box class="z--about_visuals" pos="absolute" w="100%" h="100%" z="0">
+          <Box class="c--about_visuals" pos="absolute" w="100%" h="100%" z="0">
             {
               aboutPhotos.map((photo, i) => (
-                <Box class="z--about_visual u--pullBack" pos="absolute" w={i === 0 ? '20rem' : '16rem'}>
+                <Box class="c--about_visual u--pullBack" pos="absolute" w={i === 0 ? '20rem' : '16rem'}>
                   <Frame class="u--bgParallax" pos="relative" ar="4/3" bdrs="20">
                     <Media src={photo} alt="" width="800" height="600" loading="lazy" o="ppp" />
                   </Frame>
@@ -280,7 +280,7 @@ const footerSnsLinks = [
               ))
             }
           </Box>
-          <Flow class="z--about_body u--fadeIn" flow="s" pos="relative" z="1">
+          <Flow class="c--about_body u--fadeIn" flow="s" pos="relative" z="1">
             <Text>
               Lism CSS is a lightweight CSS design framework for building beautiful, well-structured websites with rhythm and precision. A single
               stylesheet grounded in design theory is at its core — no special build process is required to get started.
@@ -303,7 +303,7 @@ const footerSnsLinks = [
         </Stack>
       </Container>
 
-      <Box id="feature" class="z--feature" pos="relative" bgc="base-2">
+      <Box id="feature" class="c--feature" pos="relative" bgc="base-2">
         <Container isWrapper="l" py="60" hasGutter>
           <Stack g="40">
             <SectionHeading en="Feature" ja="Core Capabilities" />
@@ -311,7 +311,7 @@ const footerSnsLinks = [
               {
                 featureCards.map((card) => {
                   return (
-                    <WithSide sideW="40%" mainW="24rem" class="z--feature_item u--fadeInL" g={['30', null, '40']} ai="center">
+                    <WithSide sideW="40%" mainW="24rem" class="c--feature_item u--fadeInL" g={['30', null, '40']} ai="center">
                       <Frame isSide ar="16/9" pos="relative" bdrs="20" class="u--bgParallax">
                         <Media src={card.src} alt="" width="960" height="540" loading="lazy" />
                       </Frame>
@@ -332,7 +332,7 @@ const footerSnsLinks = [
         </Container>
       </Box>
 
-      <Container id="works" class="z--works" isWrapper="l" py="60" hasGutter>
+      <Container id="works" class="c--works" isWrapper="l" py="60" hasGutter>
         <Stack g="40">
           <SectionHeading en="Works" ja="Selected Projects" />
           <Text class="u--fadeIn">
@@ -342,8 +342,8 @@ const footerSnsLinks = [
           <AutoColumns cols="20rem" g="40">
             {
               worksItems.map((item) => (
-                <BoxLink class="z--works_item u--fadeIn" href="#" layout="stack" set="hov" g="20">
-                  <Frame class="z--works_frame" ar="16/9" pos="relative" bdrs="20">
+                <BoxLink class="c--works_item u--fadeIn" href="#" layout="stack" set="hov" g="20">
+                  <Frame class="c--works_frame" ar="16/9" pos="relative" bdrs="20">
                     <Media class="u--pullBack" src={item.src} alt="" width="960" height="540" loading="lazy" hasTransition hov="in:zoom" />
                     <Layer layout="center" hasTransition hov="in:show" h="100%" c="white" bgc="black:30%" style={{ backdropFilter: 'blur(4px)' }}>
                       <Inline fz="xl" fs="italic" fw="light" lts="l">
@@ -366,7 +366,7 @@ const footerSnsLinks = [
         </Stack>
       </Container>
 
-      <Box id="news" class="z--news" pos="relative">
+      <Box id="news" class="c--news" pos="relative">
         <Frame isLayer class="u--bgParallax">
           <Media src={newsBg} alt="" width="960" height="640" loading="lazy" />
         </Frame>
@@ -376,7 +376,7 @@ const footerSnsLinks = [
           <Stack g="30">
             {
               newsItems.map((row) => (
-                <BoxLink class="z--news_item u--fadeInL" href="#" layout="grid" gtc={['auto', 'auto 1fr']} g={['10', '30', '40']} py="10" set="hov">
+                <BoxLink class="c--news_item u--fadeInL" href="#" layout="grid" gtc={['auto', 'auto 1fr']} g={['10', '30', '40']} py="10" set="hov">
                   <Inline>{row.date}</Inline>
                   <Stack g="10">
                     <Text hov="in:underline" td="none">
@@ -394,7 +394,7 @@ const footerSnsLinks = [
         </Container>
       </Box>
 
-      <Container id="faq" class="z--faq" isWrapper layout="stack" g="40" py="60" hasGutter>
+      <Container id="faq" class="c--faq" isWrapper layout="stack" g="40" py="60" hasGutter>
         <SectionHeading en="FAQ" ja="Common Questions" />
         <Accordion.Root class="u--divide u--fadeIn" p="0" ov="clip">
           {
@@ -414,12 +414,12 @@ const footerSnsLinks = [
         </Accordion.Root>
       </Container>
 
-      <Container id="testimonials" class="z--testimonials" isWrapper="l" layout="stack" g="40" bgc="base-2" py="60" hasGutter>
+      <Container id="testimonials" class="c--testimonials" isWrapper="l" layout="stack" g="40" bgc="base-2" py="60" hasGutter>
         <SectionHeading en="Testimonials" ja="What Users Say" />
         <AutoColumns cols="20rem" g="40">
           {
             testimonials.map((item) => (
-              <Grid class="z--testimonials_item u--fadeIn" gtr="subgrid" gr="span 3" g="30">
+              <Grid class="c--testimonials_item u--fadeIn" gtr="subgrid" gr="span 3" g="30">
                 <Flex ai="center" g="20">
                   <Frame as="figure" ar="1/1" w="3.5rem" fxsh="0" bdrs="99">
                     <Media src={item.src} alt="" width="256" height="256" loading="lazy" />
@@ -442,7 +442,7 @@ const footerSnsLinks = [
         </AutoColumns>
       </Container>
 
-      <Container id="information" class="z--information" isWrapper layout="stack" g="40" py="60" hasGutter>
+      <Container id="information" class="c--information" isWrapper layout="stack" g="40" py="60" hasGutter>
         <SectionHeading en="Information" ja="Company Overview" />
         <Grid as="dl" class="u--divide u--fadeIn" gtc="auto 1fr">
           {
@@ -466,7 +466,7 @@ const footerSnsLinks = [
         </Frame>
       </Container>
 
-      <Box id="contact" class="z--contact" pos="relative">
+      <Box id="contact" class="c--contact" pos="relative">
         <Frame isLayer class="u--bgParallax">
           <Media src={contactBg} alt="" width="960" height="640" loading="lazy" />
         </Frame>

--- a/templates/lp/astro/src/pages/en/interior/_style.css
+++ b/templates/lp/astro/src/pages/en/interior/_style.css
@@ -6,7 +6,7 @@
     --header-h: 64px;
   }
 
-  .z--header {
+  .c--header {
     height: var(--header-h--init);
     border-block-end: 1px solid transparent;
     transition:
@@ -16,7 +16,7 @@
       border-block-end-color 0.4s;
   }
 
-  :root[data-scrolled] .z--header {
+  :root[data-scrolled] .c--header {
     height: var(--header-h);
     background-color: color-mix(in srgb, var(--white) 68%, transparent);
     backdrop-filter: blur(12px) saturate(1.08);
@@ -24,14 +24,14 @@
   }
 
   /*
-   * .z--mv 設計トークン
-   *   .z--mv 側でfont-sizeを定義し、 h1 の font-size は inheritする。（全体を em で位置調整をしている。）
+   * .c--mv 設計トークン
+   *   .c--mv 側でfont-sizeを定義し、 h1 の font-size は inheritする。（全体を em で位置調整をしている。）
    *
    * [見出し・画像の配置]
    *   --_title-offset … 固定ヘッダーを考慮した値
    *   --_mv-offset … 見出しに少し入り込むためのオフセット値
    */
-  .z--mv {
+  .c--mv {
     --_title-offset: calc(var(--header-h--init) + 0.5em);
     --_mv-offset: 1.75em;
     font-size: clamp(2.75rem, 1.5rem + 9vw, 6rem);
@@ -39,13 +39,13 @@
     background: linear-gradient(to bottom, var(--base-2) 80%, var(--base) 80%);
   }
 
-  .z--mv_title {
+  .c--mv_title {
     font-size: inherit;
     line-height: 1.1;
     margin-top: var(--_title-offset);
   }
 
-  .z--mv_visual {
+  .c--mv_visual {
     padding: var(--gutter--base);
     padding-block-start: calc(var(--_title-offset) + var(--_mv-offset));
   }
@@ -54,7 +54,7 @@
    * Feature / Step セクションは「テキスト列 + 画像レール（sticky）」の同型レイアウト。
    */
   @container (min-width: 800px) {
-    :is(.z--point, .z--step) .-pos\:sticky {
+    :is(.c--point, .c--step) .-pos\:sticky {
       top: var(--header-h, 64px);
       height: min(calc(100dvh - var(--header-h, 64px)), 100%);
     }
@@ -64,12 +64,12 @@
    * 横リール: 中央スナップ（has--snap の子へ --snapAlign が効く）
    * @see https://lism-css.com/ui/examples/reel/
    */
-  .z--voice_reel {
+  .c--voice_reel {
     --snapType: x mandatory;
     --snapAlign: center;
   }
 
-  .z--contact_field {
+  .c--contact_field {
     padding: var(--s15) var(--s20);
     color: var(--text);
     background-color: var(--base);
@@ -78,10 +78,10 @@
     box-shadow: var(--bxsh--20);
   }
 
-  .z--contact_field::placeholder {
+  .c--contact_field::placeholder {
     opacity: var(--o--pp);
   }
-  textarea.z--contact_field {
+  textarea.c--contact_field {
     min-height: 10rem;
   }
 }

--- a/templates/lp/astro/src/pages/en/interior/index.astro
+++ b/templates/lp/astro/src/pages/en/interior/index.astro
@@ -296,22 +296,22 @@ const contactFields = [
     <!-- Header -->
     <Header />
     <!-- Main -->
-    <Container as="main" class="z--main" iso="isolate">
-      <Box as="section" class="z--mv" hasGutter pos="relative" ov="hidden" aria-label="Main visual">
-        <Heading level="1" class="z--mv_title" pos="relative" z="1" ta="center" c="white" lts="l" fw="700" ff="accent" ovw="break-word">
+    <Container as="main" class="c--main" iso="isolate">
+      <Box as="section" class="c--mv" hasGutter pos="relative" ov="hidden" aria-label="Main visual">
+        <Heading level="1" class="c--mv_title" pos="relative" z="1" ta="center" c="white" lts="l" fw="700" ff="accent" ovw="break-word">
           Simple<br />
           <Inline>LP Design</Inline>
         </Heading>
-        <Layer class="z--mv_visual" isWrapper="l">
+        <Layer class="c--mv_visual" isWrapper="l">
           <Frame w="100%" h="100%">
             <Media src={mvImage.src} alt={mvImage.alt} width="1920" height="1080" loading="eager" fetchpriority="high" />
           </Frame>
         </Layer>
       </Box>
 
-      <Container as="section" id="mission" class="z--mission" set="bleed" contentSize="l" pos="relative" py="50" mbs="60">
-        <Layer class="z--mission_bg" bgc="base-2" ms="calc(10rem + var(--bleed))" />
-        <Columns class="z--mission_content" cols={[1, null, 2]} g={['40', null, '10', '30']} pos="relative" w="100%">
+      <Container as="section" id="mission" class="c--mission" set="bleed" contentSize="l" pos="relative" py="50" mbs="60">
+        <Layer class="c--mission_bg" bgc="base-2" ms="calc(10rem + var(--bleed))" />
+        <Columns class="c--mission_content" cols={[1, null, 2]} g={['40', null, '10', '30']} pos="relative" w="100%">
           <Stack fx="1" hasGutter ps="var(--bleed)">
             <Stack g="40">
               <Stack g="10">
@@ -325,7 +325,7 @@ const contactFields = [
           </Stack>
           <Frame
             as="figure"
-            class="z--mission_figure"
+            class="c--mission_figure"
             set="bleed"
             contentSize="xl"
             pos="relative"
@@ -378,9 +378,9 @@ const contactFields = [
         </Flex>
       </Container>
 
-      <Container as="section" id="feature" class="z--point" ov-x="clip" mbs="60">
+      <Container as="section" id="feature" class="c--point" ov-x="clip" mbs="60">
         <Columns cols={[1, null, 2]} g={['40', null, '10', '30']} set="bleed" contentSize="l">
-          <Stack class="z--point_main" g="40" jc="start" hasGutter ps="var(--bleed)">
+          <Stack class="c--point_main" g="40" jc="start" hasGutter ps="var(--bleed)">
             <SectionHeading en="Point" ja="What makes us different" />
             <Stack g="40">
               {
@@ -404,7 +404,7 @@ const contactFields = [
         </Columns>
       </Container>
 
-      <Container as="section" id="service" isWrapper="l" hasGutter class="z--service" bgc="base-2" py="60" mbs="70">
+      <Container as="section" id="service" isWrapper="l" hasGutter class="c--service" bgc="base-2" py="60" mbs="70">
         <Stack g="50" mbs="-60">
           <SectionHeading en="Service" ja="Tailored to what you need" hasOffset />
           <Columns cols={[1, null, 3]} g="40" ai="start">
@@ -420,7 +420,7 @@ const contactFields = [
                         {item.index}
                       </Inline>
                       <Decorator aslf="stretch" w="1px" bgc="text" fxsh="0" />
-                      <Stack g="10" class="z--service_cardTitles" util="trimAll">
+                      <Stack g="10" class="c--service_cardTitles" util="trimAll">
                         <Heading level="3" fz="m">
                           {item.titleJa}
                         </Heading>
@@ -462,7 +462,7 @@ const contactFields = [
         </Stack>
       </Container>
 
-      <Container as="section" id="step" class="z--step" ov-x="clip" py="60">
+      <Container as="section" id="step" class="c--step" ov-x="clip" py="60">
         <Columns cols={[1, null, 2]} g={['40', null, '10', '30']} set="bleed" contentSize="l">
           <Stack g="40" jc="start" hasGutter pe="var(--bleed)">
             <SectionHeading en="Step" ja="From first contact to final delivery" />
@@ -475,9 +475,9 @@ const contactFields = [
                         <Icon icon="caret-down-fill" fz="2xl" o="ppp" />
                       </Center>
                     )}
-                    <Stack class="z--step_card" g="30" p="30" bdrs="20" bxsh="20">
+                    <Stack class="c--step_card" g="30" p="30" bdrs="20" bxsh="20">
                       {card.image && (
-                        <Frame class="z--step_cardFrame" ar="21/9" ov="hidden" bdrs="10">
+                        <Frame class="c--step_cardFrame" ar="21/9" ov="hidden" bdrs="10">
                           <Media src={card.image.src} alt={card.image.alt} width="1920" height="1280" loading="lazy" />
                         </Frame>
                       )}
@@ -499,7 +499,7 @@ const contactFields = [
         </Columns>
       </Container>
 
-      <Container as="section" id="voice" isWrapper="l" hasGutter class="z--voice">
+      <Container as="section" id="voice" isWrapper="l" hasGutter class="c--voice">
         <Stack g="40">
           <SectionHeading en="Voice" ja="Words from our clients" />
           <Columns hasSnap ov="auto" g={['20', null, '30']} pbe="10" gaf={['column', 'row']} gac="85%" cols={[0, 2, null, 3]}>
@@ -513,7 +513,7 @@ const contactFields = [
                   <Text fz="s" c="text-2" hl="l" util="trim">
                     {card.body}
                   </Text>
-                  <Text class="z--voice_attribution" fz="2xs" c="text-2" o="p" ta="end" w="100%" mt="auto" util="trim">
+                  <Text class="c--voice_attribution" fz="2xs" c="text-2" o="p" ta="end" w="100%" mt="auto" util="trim">
                     {card.attribution}
                   </Text>
                 </Stack>
@@ -523,11 +523,11 @@ const contactFields = [
         </Stack>
       </Container>
 
-      <Container as="section" id="faq" class="z--faq" isWrapper hasGutter py="60" bgc="base-2" mbs="60">
+      <Container as="section" id="faq" class="c--faq" isWrapper hasGutter py="60" bgc="base-2" mbs="60">
         <Stack g="40">
           <SectionHeading en="FAQ" ja="Common questions" />
 
-          <Accordion.Root class="z--faq_acc" g="20">
+          <Accordion.Root class="c--faq_acc" g="20">
             {
               faqItems.map((item) => (
                 <Accordion.Item bgc="base" bdrs="20" bxsh="10" isOpen={item.defaultOpen === true}>
@@ -548,7 +548,7 @@ const contactFields = [
         </Stack>
       </Container>
 
-      <Container as="section" id="contact" class="z--contact" py="60" pos="relative" ov="hidden">
+      <Container as="section" id="contact" class="c--contact" py="60" pos="relative" ov="hidden">
         <Frame isLayer>
           <Media src={contactBg.src} alt={contactBg.alt} width="1920" height="1080" loading="lazy" />
         </Frame>
@@ -558,7 +558,7 @@ const contactFields = [
           <Text fz="s" c="white" ta="center" hl="l">
             First-time inquiries are always welcome — feel free to reach out.<br />This form is a dummy.
           </Text>
-          <Box as="form" class="z--contact_form" method="post" action="#">
+          <Box as="form" class="c--contact_form" method="post" action="#">
             <Stack g="30">
               {
                 contactFields.map((field) => (
@@ -569,7 +569,7 @@ const contactFields = [
                     {field.type === 'textarea' ? (
                       <textarea
                         id={field.id}
-                        class="z--contact_field"
+                        class="c--contact_field"
                         name={field.name}
                         rows={field.rows}
                         placeholder={field.placeholder}
@@ -579,7 +579,7 @@ const contactFields = [
                     ) : (
                       <input
                         id={field.id}
-                        class="z--contact_field"
+                        class="c--contact_field"
                         name={field.name}
                         type={field.type}
                         placeholder={field.placeholder}
@@ -595,7 +595,7 @@ const contactFields = [
               <Lism
                 as="button"
                 type="submit"
-                class="z--contact_submit"
+                class="c--contact_submit"
                 set="plain"
                 fw="500"
                 hl="xs"
@@ -614,13 +614,13 @@ const contactFields = [
       </Container>
     </Container>
     <!-- Footer -->
-    <Container as="footer" class="z--footer" isWrapper py="50" hasGutter bgc="base-2">
+    <Container as="footer" class="c--footer" isWrapper py="50" hasGutter bgc="base-2">
       <Stack g="30" ai="center" jc="center">
         <Stack class="c--logo">
           <Link href="#top" fz="2xl" fw="bold" lts="l" c="text" td="none" ff="accent">LISM Life</Link>
         </Stack>
         <List
-          class="z--footerNav"
+          class="c--footerNav"
           fz="s"
           lts="l"
           d={['block', null, 'flex']}

--- a/templates/lp/astro/src/pages/interior/_style.css
+++ b/templates/lp/astro/src/pages/interior/_style.css
@@ -6,7 +6,7 @@
     --header-h: 64px;
   }
 
-  .z--header {
+  .c--header {
     height: var(--header-h--init);
     border-block-end: 1px solid transparent;
     transition:
@@ -16,7 +16,7 @@
       border-block-end-color 0.4s;
   }
 
-  :root[data-scrolled] .z--header {
+  :root[data-scrolled] .c--header {
     height: var(--header-h);
     background-color: color-mix(in srgb, var(--white) 68%, transparent);
     backdrop-filter: blur(12px) saturate(1.08);
@@ -24,14 +24,14 @@
   }
 
   /*
-   * .z--mv 設計トークン
-   *   .z--mv 側でfont-sizeを定義し、 h1 の font-size は inheritする。（全体を em で位置調整をしている。）
+   * .c--mv 設計トークン
+   *   .c--mv 側でfont-sizeを定義し、 h1 の font-size は inheritする。（全体を em で位置調整をしている。）
    *
    * [見出し・画像の配置]
    *   --_title-offset … 固定ヘッダーを考慮した値
    *   --_mv-offset … 見出しに少し入り込むためのオフセット値
    */
-  .z--mv {
+  .c--mv {
     --_title-offset: calc(var(--header-h--init) + 0.5em);
     --_mv-offset: 1.75em;
     font-size: clamp(2.75rem, 1.5rem + 9vw, 6rem);
@@ -39,13 +39,13 @@
     background: linear-gradient(to bottom, var(--base-2) 80%, var(--base) 80%);
   }
 
-  .z--mv_title {
+  .c--mv_title {
     font-size: inherit;
     line-height: 1.1;
     margin-top: var(--_title-offset);
   }
 
-  .z--mv_visual {
+  .c--mv_visual {
     padding: var(--gutter--base);
     padding-block-start: calc(var(--_title-offset) + var(--_mv-offset));
   }
@@ -54,7 +54,7 @@
    * Feature / Step セクションは「テキスト列 + 画像レール（sticky）」の同型レイアウト。
    */
   @container (min-width: 800px) {
-    :is(.z--point, .z--step) .-pos\:sticky {
+    :is(.c--point, .c--step) .-pos\:sticky {
       top: var(--header-h, 64px);
       height: min(calc(100dvh - var(--header-h, 64px)), 100%);
     }
@@ -64,12 +64,12 @@
    * 横リール: 中央スナップ（has--snap の子へ --snapAlign が効く）
    * @see https://lism-css.com/ui/examples/reel/
    */
-  .z--voice_reel {
+  .c--voice_reel {
     --snapType: x mandatory;
     --snapAlign: center;
   }
 
-  .z--contact_field {
+  .c--contact_field {
     padding: var(--s15) var(--s20);
     color: var(--text);
     background-color: var(--base);
@@ -78,10 +78,10 @@
     box-shadow: var(--bxsh--20);
   }
 
-  .z--contact_field::placeholder {
+  .c--contact_field::placeholder {
     opacity: var(--o--pp);
   }
-  textarea.z--contact_field {
+  textarea.c--contact_field {
     min-height: 10rem;
   }
 }

--- a/templates/lp/astro/src/pages/interior/index.astro
+++ b/templates/lp/astro/src/pages/interior/index.astro
@@ -296,22 +296,22 @@ const contactFields = [
     <!-- Header -->
     <Header />
     <!-- Main -->
-    <Container as="main" class="z--main" iso="isolate">
-      <Box as="section" class="z--mv" hasGutter pos="relative" ov="hidden" aria-label="メインビジュアル">
-        <Heading level="1" class="z--mv_title" pos="relative" z="1" ta="center" c="white" lts="l" fw="700" ff="accent" ovw="break-word">
+    <Container as="main" class="c--main" iso="isolate">
+      <Box as="section" class="c--mv" hasGutter pos="relative" ov="hidden" aria-label="メインビジュアル">
+        <Heading level="1" class="c--mv_title" pos="relative" z="1" ta="center" c="white" lts="l" fw="700" ff="accent" ovw="break-word">
           Simple<br />
           <Inline>LP Design</Inline>
         </Heading>
-        <Layer class="z--mv_visual" isWrapper="l">
+        <Layer class="c--mv_visual" isWrapper="l">
           <Frame w="100%" h="100%">
             <Media src={mvImage.src} alt={mvImage.alt} width="1920" height="1080" loading="eager" fetchpriority="high" />
           </Frame>
         </Layer>
       </Box>
 
-      <Container as="section" id="mission" class="z--mission" set="bleed" contentSize="l" pos="relative" py="50" mbs="60">
-        <Layer class="z--mission_bg" bgc="base-2" ms="calc(10rem + var(--bleed))" />
-        <Columns class="z--mission_content" cols={[1, null, 2]} g={['40', null, '10', '30']} pos="relative" w="100%">
+      <Container as="section" id="mission" class="c--mission" set="bleed" contentSize="l" pos="relative" py="50" mbs="60">
+        <Layer class="c--mission_bg" bgc="base-2" ms="calc(10rem + var(--bleed))" />
+        <Columns class="c--mission_content" cols={[1, null, 2]} g={['40', null, '10', '30']} pos="relative" w="100%">
           <Stack fx="1" hasGutter ps="var(--bleed)">
             <Stack g="40">
               <Stack g="10">
@@ -325,7 +325,7 @@ const contactFields = [
           </Stack>
           <Frame
             as="figure"
-            class="z--mission_figure"
+            class="c--mission_figure"
             set="bleed"
             contentSize="xl"
             pos="relative"
@@ -375,9 +375,9 @@ const contactFields = [
         </Flex>
       </Container>
 
-      <Container as="section" id="feature" class="z--point" ov-x="clip" mbs="60">
+      <Container as="section" id="feature" class="c--point" ov-x="clip" mbs="60">
         <Columns cols={[1, null, 2]} g={['40', null, '10', '30']} set="bleed" contentSize="l">
-          <Stack class="z--point_main" g="40" jc="start" hasGutter ps="var(--bleed)">
+          <Stack class="c--point_main" g="40" jc="start" hasGutter ps="var(--bleed)">
             <SectionHeading en="Point" ja="暮らしに寄り添う特長" />
             <Stack g="40">
               {
@@ -401,7 +401,7 @@ const contactFields = [
         </Columns>
       </Container>
 
-      <Container as="section" id="service" isWrapper="l" hasGutter class="z--service" bgc="base-2" py="60" mbs="70">
+      <Container as="section" id="service" isWrapper="l" hasGutter class="c--service" bgc="base-2" py="60" mbs="70">
         <Stack g="50" mbs="-60">
           <SectionHeading en="Service" ja="ご要望に合わせたサービス" hasOffset />
           <Columns cols={[1, null, 3]} g="40" ai="start">
@@ -417,7 +417,7 @@ const contactFields = [
                         {item.index}
                       </Inline>
                       <Decorator aslf="stretch" w="1px" bgc="text" fxsh="0" />
-                      <Stack g="10" class="z--service_cardTitles" util="trimAll">
+                      <Stack g="10" class="c--service_cardTitles" util="trimAll">
                         <Heading level="3" fz="m">
                           {item.titleJa}
                         </Heading>
@@ -457,7 +457,7 @@ const contactFields = [
         </Stack>
       </Container>
 
-      <Container as="section" id="step" class="z--step" ov-x="clip" py="60">
+      <Container as="section" id="step" class="c--step" ov-x="clip" py="60">
         <Columns cols={[1, null, 2]} g={['40', null, '10', '30']} set="bleed" contentSize="l">
           <Stack g="40" jc="start" hasGutter pe="var(--bleed)">
             <SectionHeading en="Step" ja="ご依頼から納品までの流れ" />
@@ -470,9 +470,9 @@ const contactFields = [
                         <Icon icon="caret-down-fill" fz="2xl" o="ppp" />
                       </Center>
                     )}
-                    <Stack class="z--step_card" g="30" p="30" bdrs="20" bxsh="20">
+                    <Stack class="c--step_card" g="30" p="30" bdrs="20" bxsh="20">
                       {card.image && (
-                        <Frame class="z--step_cardFrame" ar="21/9" ov="hidden" bdrs="10">
+                        <Frame class="c--step_cardFrame" ar="21/9" ov="hidden" bdrs="10">
                           <Media src={card.image.src} alt={card.image.alt} width="1920" height="1280" loading="lazy" />
                         </Frame>
                       )}
@@ -494,7 +494,7 @@ const contactFields = [
         </Columns>
       </Container>
 
-      <Container as="section" id="voice" isWrapper="l" hasGutter class="z--voice">
+      <Container as="section" id="voice" isWrapper="l" hasGutter class="c--voice">
         <Stack g="40">
           <SectionHeading en="Voice" ja="お客様の声です" />
           <Columns hasSnap ov="auto" g={['20', null, '30']} pbe="10" gaf={['column', 'row']} gac="85%" cols={[0, 2, null, 3]}>
@@ -508,7 +508,7 @@ const contactFields = [
                   <Text fz="s" c="text-2" hl="l" util="trim">
                     {card.body}
                   </Text>
-                  <Text class="z--voice_attribution" fz="2xs" c="text-2" o="p" ta="end" w="100%" mt="auto" util="trim">
+                  <Text class="c--voice_attribution" fz="2xs" c="text-2" o="p" ta="end" w="100%" mt="auto" util="trim">
                     {card.attribution}
                   </Text>
                 </Stack>
@@ -518,11 +518,11 @@ const contactFields = [
         </Stack>
       </Container>
 
-      <Container as="section" id="faq" class="z--faq" isWrapper hasGutter py="60" bgc="base-2" mbs="60">
+      <Container as="section" id="faq" class="c--faq" isWrapper hasGutter py="60" bgc="base-2" mbs="60">
         <Stack g="40">
           <SectionHeading en="FAQ" ja="よくあるご質問" />
 
-          <Accordion.Root class="z--faq_acc" g="20">
+          <Accordion.Root class="c--faq_acc" g="20">
             {
               faqItems.map((item) => (
                 <Accordion.Item bgc="base" bdrs="20" bxsh="10" isOpen={item.defaultOpen === true}>
@@ -543,7 +543,7 @@ const contactFields = [
         </Stack>
       </Container>
 
-      <Container as="section" id="contact" class="z--contact" py="60" pos="relative" ov="hidden">
+      <Container as="section" id="contact" class="c--contact" py="60" pos="relative" ov="hidden">
         <Frame isLayer>
           <Media src={contactBg.src} alt={contactBg.alt} width="1920" height="1080" loading="lazy" />
         </Frame>
@@ -553,7 +553,7 @@ const contactFields = [
           <Text fz="s" c="white" ta="center" hl="l">
             初めての方もどうぞお気軽にお問い合わせください。<br />このフォームはダミーです。
           </Text>
-          <Box as="form" class="z--contact_form" method="post" action="#">
+          <Box as="form" class="c--contact_form" method="post" action="#">
             <Stack g="30">
               {
                 contactFields.map((field) => (
@@ -564,7 +564,7 @@ const contactFields = [
                     {field.type === 'textarea' ? (
                       <textarea
                         id={field.id}
-                        class="z--contact_field"
+                        class="c--contact_field"
                         name={field.name}
                         rows={field.rows}
                         placeholder={field.placeholder}
@@ -574,7 +574,7 @@ const contactFields = [
                     ) : (
                       <input
                         id={field.id}
-                        class="z--contact_field"
+                        class="c--contact_field"
                         name={field.name}
                         type={field.type}
                         placeholder={field.placeholder}
@@ -590,7 +590,7 @@ const contactFields = [
               <Lism
                 as="button"
                 type="submit"
-                class="z--contact_submit"
+                class="c--contact_submit"
                 set="plain"
                 fw="500"
                 hl="xs"
@@ -609,13 +609,13 @@ const contactFields = [
       </Container>
     </Container>
     <!-- Footer -->
-    <Container as="footer" class="z--footer" isWrapper py="50" hasGutter bgc="base-2">
+    <Container as="footer" class="c--footer" isWrapper py="50" hasGutter bgc="base-2">
       <Stack g="30" ai="center" jc="center">
         <Stack class="c--logo">
           <Link href="#top" fz="2xl" fw="bold" lts="l" c="text" td="none" ff="accent">LISM Life</Link>
         </Stack>
         <List
-          class="z--footerNav"
+          class="c--footerNav"
           fz="s"
           lts="l"
           d={['block', null, 'flex']}

--- a/templates/lp/astro/src/pages/ryokan/_style.css
+++ b/templates/lp/astro/src/pages/ryokan/_style.css
@@ -151,7 +151,6 @@
       transform: scale(1);
     }
     to {
-      /* 3xl 時も以前（2xl×0.9 相当）のスクロール後サイズ感に近づける */
       transform: scale(0.75);
     }
   }

--- a/templates/lp/astro/src/pages/ryokan/_style.css
+++ b/templates/lp/astro/src/pages/ryokan/_style.css
@@ -1,6 +1,6 @@
 @layer lism-custom {
   /* ryokan: 明朝ベース（Google Fonts / Noto Serif JP） */
-  .z--ryokan-root {
+  .c--ryokan-root {
     font-family: 'Noto Serif JP', 'Yu Mincho', YuMincho, 'Hiragino Mincho ProN', 'Hiragino Mincho Pro', serif;
     font-optical-sizing: auto;
     /* Lism の `ff:base`（既定はゴシック系）— ryokan では日本語明朝に統一 */
@@ -10,11 +10,11 @@
     /* Feature ほか和紙調のベージュ背景（セマンティック `--base` を上書き） */
     --base: hsl(38 32% 92%);
     /* #reservation の named view timeline を兄弟の FAB から参照可能に */
-    timeline-scope: --z--ryokan-reservation;
+    timeline-scope: --c--ryokan-reservation;
   }
   /* Reservation がビューポートに入る進行に合わせて FAB を非表示 */
   #reservation {
-    view-timeline-name: --z--ryokan-reservation;
+    view-timeline-name: --c--ryokan-reservation;
     view-timeline-axis: block;
   }
   @keyframes ryokan_reservationFab_hide {
@@ -29,13 +29,13 @@
       visibility: hidden;
     }
   }
-  .z--ryokan-reservationFab {
+  .c--ryokan-reservationFab {
     animation: ryokan_reservationFab_hide linear both;
-    animation-timeline: --z--ryokan-reservation;
+    animation-timeline: --c--ryokan-reservation;
     animation-range: entry 0% entry 30%;
   }
   @media (prefers-reduced-motion: reduce) {
-    .z--ryokan-reservationFab {
+    .c--ryokan-reservationFab {
       animation: none;
       opacity: 1;
       visibility: visible;
@@ -87,20 +87,20 @@
     }
   }
 
-  .z--ryokan-header {
+  .c--ryokan-header {
     height: var(--header-h);
     color: var(--white);
     background-color: transparent;
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
     box-sizing: border-box;
-    --z--header-scroll-animation-start: 80px;
-    --z--header-animation-range: var(--z--header-scroll-animation-start) calc(var(--z--header-scroll-animation-start) + 140px);
-    animation: z--header_ryokan linear both;
+    --c--header-scroll-animation-start: 80px;
+    --c--header-animation-range: var(--c--header-scroll-animation-start) calc(var(--c--header-scroll-animation-start) + 140px);
+    animation: c--header_ryokan linear both;
     animation-timeline: scroll(root);
-    animation-range: var(--z--header-animation-range);
+    animation-range: var(--c--header-animation-range);
   }
-  .z--ryokan-header :where(a) {
+  .c--ryokan-header :where(a) {
     color: inherit;
   }
   /**
@@ -108,33 +108,33 @@
    * フッターは黒地へ `color-mix(…, var(--white) 38%, …)`。モーダルは `.c--modal_inner` の `var(--base)` 地のため `var(--text)` を使用
    * @see Footer.astro / tokens.md --text / `color-mix`
    */
-  .z--ryokan-header_menuNav {
+  .c--ryokan-header_menuNav {
     list-style: none;
   }
-  .z--ryokan-header_menuNav > li {
+  .c--ryokan-header_menuNav > li {
     list-style: none;
   }
-  .z--ryokan-header_menuNav > li:not(:last-child) {
+  .c--ryokan-header_menuNav > li:not(:last-child) {
     border-block-end: 1px dashed color-mix(in srgb, var(--text) 38%, transparent);
   }
   /* md 以上: has--gutter の左右に s20 を上乗せ（Lism: `--gutter--base` 既定は `--s30`） */
   @media (min-width: 800px) {
-    .z--ryokan-header_bar {
+    .c--ryokan-header_bar {
       padding-inline: calc(var(--gutter--base) + var(--s20));
     }
   }
-  .z--ryokan-header_logoLink {
+  .c--ryokan-header_logoLink {
     transform-origin: left center;
-    animation: z--ryokan-header_logo_ryokan linear both;
+    animation: c--ryokan-header_logo_ryokan linear both;
     animation-timeline: scroll(root);
-    /* 継承: 先祖 `.z--ryokan-header` の `--z--header-animation-range` */
-    animation-range: var(--z--header-animation-range);
+    /* 継承: 先祖 `.c--ryokan-header` の `--c--header-animation-range` */
+    animation-range: var(--c--header-animation-range);
   }
   /**
    * スクロール後: 黒ベースの半透明 + backdrop-filter で奥行きをぼかし視認性を確保。
    * 下端の極細ハイライトで帯として切り分ける。
    */
-  @keyframes z--header_ryokan {
+  @keyframes c--header_ryokan {
     to {
       background-color: hsl(0 0% 0% / 0.78);
       color: var(--white);
@@ -146,7 +146,7 @@
         inset 0 -1px 0 hsl(0 0% 100% / 0.07);
     }
   }
-  @keyframes z--ryokan-header_logo_ryokan {
+  @keyframes c--ryokan-header_logo_ryokan {
     from {
       transform: scale(1);
     }
@@ -155,14 +155,14 @@
       transform: scale(0.75);
     }
   }
-  .z--ryokan-headerNav_en {
+  .c--ryokan-headerNav_en {
     max-height: 2.5em;
     overflow: hidden;
-    animation: z--ryokan-headerNav_en_ryokan linear both;
+    animation: c--ryokan-headerNav_en_ryokan linear both;
     animation-timeline: scroll(root);
-    animation-range: var(--z--header-animation-range);
+    animation-range: var(--c--header-animation-range);
   }
-  @keyframes z--ryokan-headerNav_en_ryokan {
+  @keyframes c--ryokan-headerNav_en_ryokan {
     to {
       opacity: 0;
       max-height: 0;
@@ -171,31 +171,31 @@
     }
   }
 
-  .z--ryokan-mv {
+  .c--ryokan-mv {
     background-color: #000;
   }
 
-  .z--ryokan-mv_bg {
+  .c--ryokan-mv_bg {
     inset: 0;
   }
 
-  .z--ryokan-mv_layer {
+  .c--ryokan-mv_layer {
     position: absolute;
     inset: 0;
-    background-image: var(--z--ryokan-mv-layerBgImage);
+    background-image: var(--c--ryokan-mv-layerBgImage);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
     transform-origin: center center;
     opacity: 0;
     transform: scale(1);
-    animation: ryokan-mv-bgFade var(--z--ryokan-mv-bgCycleDuration) infinite;
+    animation: ryokan-mv-bgFade var(--c--ryokan-mv-bgCycleDuration) infinite;
     animation-timing-function: linear;
-    animation-delay: var(--z--ryokan-mv-layerDelay);
+    animation-delay: var(--c--ryokan-mv-layerDelay);
   }
 
   /* MVSimple と同一の縦書きブロック */
-  .z--ryokan-mv_copy {
+  .c--ryokan-mv_copy {
     font-feature-settings: 'palt' 1;
     font-size: clamp(1.1rem, 3.4vw, 1.75rem);
     line-height: 1.85;
@@ -208,18 +208,18 @@
     align-items: stretch;
     gap: clamp(1.4rem, 4vw, 3rem);
   }
-  .z--ryokan-mv_copy .z--ryokan-mv_line:first-child {
+  .c--ryokan-mv_copy .c--ryokan-mv_line:first-child {
     transform: translateY(-1em);
   }
-  .z--ryokan-mv_copy .z--ryokan-mv_line:last-child:not(:first-child) {
+  .c--ryokan-mv_copy .c--ryokan-mv_line:last-child:not(:first-child) {
     transform: translateY(1em);
   }
 
-  /* コピー行: ブラー＋フェード（開始は --z--ryokan-mv-lineIndex でスタガード） */
+  /* コピー行: ブラー＋フェード（開始は --c--ryokan-mv-lineIndex でスタガード） */
   @keyframes ryokan-mv-lineReveal {
     from {
       opacity: 0;
-      filter: blur(var(--z--ryokan-mv-lineBlurMax, 12px));
+      filter: blur(var(--c--ryokan-mv-lineBlurMax, 12px));
     }
     to {
       opacity: 1;
@@ -227,23 +227,23 @@
     }
   }
 
-  .z--ryokan-mv_copy .z--ryokan-mv_line {
+  .c--ryokan-mv_copy .c--ryokan-mv_line {
     opacity: 0;
-    filter: blur(var(--z--ryokan-mv-lineBlurMax, 12px));
-    animation: ryokan-mv-lineReveal var(--z--ryokan-mv-lineDuration, 1s) ease forwards;
-    animation-delay: calc(var(--z--ryokan-mv-lineStartDelay, 0s) + var(--z--ryokan-mv-lineStagger, 0.2s) * var(--z--ryokan-mv-lineIndex, 0));
+    filter: blur(var(--c--ryokan-mv-lineBlurMax, 12px));
+    animation: ryokan-mv-lineReveal var(--c--ryokan-mv-lineDuration, 1s) ease forwards;
+    animation-delay: calc(var(--c--ryokan-mv-lineStartDelay, 0s) + var(--c--ryokan-mv-lineStagger, 0.2s) * var(--c--ryokan-mv-lineIndex, 0));
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .z--ryokan-mv_layer {
+    .c--ryokan-mv_layer {
       animation: none;
       opacity: 0;
       transform: none;
     }
-    .z--ryokan-mv_layer:first-child {
+    .c--ryokan-mv_layer:first-child {
       opacity: 1;
     }
-    .z--ryokan-mv_copy .z--ryokan-mv_line {
+    .c--ryokan-mv_copy .c--ryokan-mv_line {
       animation: none;
       opacity: 1;
       filter: none;
@@ -253,9 +253,9 @@
   /*
    * ビューポート全幅: 親の max-width に依存しないよう、自身を 100vw で中央に置く。
    */
-  .z--ryokan-about {
-    --z--ryokan-about-l-inset: max(var(--gutter--base), calc((100vw - var(--sz--l)) / 2));
-    --z--ryokan-about-xl-inset: max(var(--gutter--base), calc((100vw - var(--sz--xl)) / 2));
+  .c--ryokan-about {
+    --c--ryokan-about-l-inset: max(var(--gutter--base), calc((100vw - var(--sz--l)) / 2));
+    --c--ryokan-about-xl-inset: max(var(--gutter--base), calc((100vw - var(--sz--xl)) / 2));
     position: relative;
     left: 50%;
     transform: translateX(-50%);
@@ -264,34 +264,34 @@
     max-width: 100vw;
     overflow-x: clip;
   }
-  .z--ryokan-about_mediaRightImg {
+  .c--ryokan-about_mediaRightImg {
     display: block;
     object-fit: cover;
   }
-  .z--ryokan-about_figureLeft,
-  .z--ryokan-about_figureRight {
+  .c--ryokan-about_figureLeft,
+  .c--ryokan-about_figureRight {
     margin: 0;
   }
   @media (min-width: 800px) {
-    .z--ryokan-about_col--left {
+    .c--ryokan-about_col--left {
       box-sizing: border-box;
       min-width: 0;
       /* 見出し・本文: グローバルな size=l の左端（Lism の ps はカスタム計算のため CSS のみ） */
-      padding-inline-start: var(--z--ryokan-about-l-inset);
+      padding-inline-start: var(--c--ryokan-about-l-inset);
     }
-    .z--ryokan-about_stack {
+    .c--ryokan-about_stack {
       align-self: start;
       width: min(100%, var(--sz--l));
       min-width: 0;
     }
-    .z--ryokan-about_body {
+    .c--ryokan-about_body {
       padding-inline-start: var(--s50);
     }
-    .z--ryokan-about_figureLeft {
+    .c--ryokan-about_figureLeft {
       align-self: start;
       margin-block-start: auto;
       padding-block-start: var(--s30);
-      margin-inline-start: calc(var(--z--ryokan-about-xl-inset) - var(--z--ryokan-about-l-inset));
+      margin-inline-start: calc(var(--c--ryokan-about-xl-inset) - var(--c--ryokan-about-l-inset));
       box-sizing: border-box;
       min-inline-size: 0;
       max-inline-size: 100%;
@@ -299,129 +299,129 @@
     }
   }
   @media (max-width: 799px) {
-    .z--ryokan-about_grid {
+    .c--ryokan-about_grid {
       padding-inline: var(--gutter--base);
       box-sizing: border-box;
     }
-    .z--ryokan-about_figureLeft {
+    .c--ryokan-about_figureLeft {
       inline-size: 100%;
       max-inline-size: none;
     }
-    .z--ryokan-about_mediaRightImg {
+    .c--ryokan-about_mediaRightImg {
       aspect-ratio: 4 / 3;
       block-size: auto;
     }
   }
 
   /* 左端プル: コンテナ幅 l + gutter と整合 */
-  .z--ryokan-feature {
-    --z--ryokan-feature-pull: max(var(--gutter--base, 0px), calc((100vw - min(100vw, var(--sz--l))) / 2));
-    --z--ryokan-feature-figure-max-h: 540px;
+  .c--ryokan-feature {
+    --c--ryokan-feature-pull: max(var(--gutter--base, 0px), calc((100vw - min(100vw, var(--sz--l))) / 2));
+    --c--ryokan-feature-figure-max-h: 540px;
     position: relative;
   }
   /* isContainer 祖先幅: Lism md と同じ (min-width: 800px) / not で補集合（max-width:799 との境目ギャップを避ける） */
   @container not (min-width: 800px) {
-    .z--ryokan-feature_textCol {
+    .c--ryokan-feature_textCol {
       order: 1;
     }
-    .z--ryokan-feature_figure {
+    .c--ryokan-feature_figure {
       order: 2;
       margin-inline: 0;
       inline-size: 100%;
       max-inline-size: none;
       aspect-ratio: 16 / 10;
-      max-block-size: var(--z--ryokan-feature-figure-max-h);
+      max-block-size: var(--c--ryokan-feature-figure-max-h);
     }
-    .z--ryokan-feature_bodyStack {
+    .c--ryokan-feature_bodyStack {
       align-self: stretch;
       margin-inline-start: 0;
       max-inline-size: 100%;
     }
-    .z--ryokan-feature_lead,
-    .z--ryokan-feature_body {
+    .c--ryokan-feature_lead,
+    .c--ryokan-feature_body {
       text-align: start;
       text-wrap: pretty;
     }
-    .z--ryokan-feature_title {
+    .c--ryokan-feature_title {
       align-self: end;
     }
   }
-  .z--ryokan-feature_figure {
+  .c--ryokan-feature_figure {
     margin: 0;
     position: relative;
     box-sizing: border-box;
     align-self: stretch;
-    max-block-size: var(--z--ryokan-feature-figure-max-h);
+    max-block-size: var(--c--ryokan-feature-figure-max-h);
   }
-  .z--ryokan-feature_figure > img {
+  .c--ryokan-feature_figure > img {
     display: block;
     width: 100%;
     height: 100%;
     object-fit: cover;
   }
   @container (min-width: 800px) {
-    .z--ryokan-feature_figure {
-      margin-inline-start: calc(-1 * var(--z--ryokan-feature-pull));
-      width: calc(100% + var(--z--ryokan-feature-pull));
+    .c--ryokan-feature_figure {
+      margin-inline-start: calc(-1 * var(--c--ryokan-feature-pull));
+      width: calc(100% + var(--c--ryokan-feature-pull));
       max-width: none;
       border-radius: 0 var(--bdrs--10) var(--bdrs--10) 0;
-      min-height: min(22rem, 52vw, var(--z--ryokan-feature-figure-max-h));
+      min-height: min(22rem, 52vw, var(--c--ryokan-feature-figure-max-h));
     }
-    .z--ryokan-feature_figure > img {
-      min-height: min(22rem, 52vw, var(--z--ryokan-feature-figure-max-h));
+    .c--ryokan-feature_figure > img {
+      min-height: min(22rem, 52vw, var(--c--ryokan-feature-figure-max-h));
     }
   }
-  .z--ryokan-feature_textCol {
+  .c--ryokan-feature_textCol {
     min-height: 0;
     overflow-x: visible;
   }
   /* 2列時: 見出しは上・本文は下（上端・下端揃え） */
   @container (min-width: 800px) {
-    .z--ryokan-feature_copyRow {
+    .c--ryokan-feature_copyRow {
       display: grid;
       grid-template-columns: 1fr auto;
       grid-template-rows: 1fr auto;
       min-height: min(22rem, 52vw);
     }
-    .z--ryokan-feature_title {
+    .c--ryokan-feature_title {
       grid-column: 2;
       grid-row: 1 / -1;
       align-self: start;
       justify-self: end;
     }
-    .z--ryokan-feature_bodyStack {
+    .c--ryokan-feature_bodyStack {
       grid-column: 1;
       grid-row: 2;
       align-self: end;
       max-inline-size: min(100%, 26rem);
     }
-    .z--ryokan-feature_lead,
-    .z--ryokan-feature_body {
+    .c--ryokan-feature_lead,
+    .c--ryokan-feature_body {
       text-align: start;
     }
   }
-  .z--ryokan-feature_title {
+  .c--ryokan-feature_title {
     flex-shrink: 0;
     line-height: 1.65;
   }
   /* 縦書き2列: 横書きの flex 列＋子に writing-mode: vertical-rl */
-  .z--ryokan-feature_titleInner {
+  .c--ryokan-feature_titleInner {
     display: flex;
     flex-direction: row-reverse;
     align-items: flex-start;
     gap: 0.65em;
   }
-  .z--ryokan-feature_titleLine1,
-  .z--ryokan-feature_titleLine2 {
+  .c--ryokan-feature_titleLine1,
+  .c--ryokan-feature_titleLine2 {
     display: block;
     writing-mode: vertical-rl;
     text-orientation: mixed;
   }
-  .z--ryokan-feature_titleLine2 {
+  .c--ryokan-feature_titleLine2 {
     transform: translateY(1em);
   }
   /* 共有。左右位置は Lism md（@container 800px）に同期 */
-  .z--ryokan-feature_watermark {
+  .c--ryokan-feature_watermark {
     position: absolute;
     z-index: 0;
     margin: 0;
@@ -440,7 +440,7 @@
     unicode-bidi: isolate;
   }
   @container (min-width: 800px) {
-    .z--ryokan-feature_watermark {
+    .c--ryokan-feature_watermark {
       inset-inline-start: 0;
       inset-inline-end: auto;
       transform-origin: left center;
@@ -448,7 +448,7 @@
     }
   }
   @container not (min-width: 800px) {
-    .z--ryokan-feature_watermark {
+    .c--ryokan-feature_watermark {
       inset-inline-start: auto;
       inset-inline-end: 0;
       transform-origin: right center;
@@ -461,17 +461,17 @@
    * また -max-w:100%（max-width）と max-inline-size の併用や、flex 子の % 解決で上限が効かないことがあるため、
    * コンテナクエリ内で max-width + cqi を使い、fxd の row 切替と同じ基準で min(32rem, 40cqi) に揃える（40cqi はクエリコンテナ行内幅の 40% 相当の上限）。
    */
-  .z--ryokan-plans_media {
+  .c--ryokan-plans_media {
     max-width: 100%;
   }
   @container (min-width: 800px) {
-    .z--ryokan-plans_media {
+    .c--ryokan-plans_media {
       max-width: min(32rem, 40cqi);
     }
   }
 
   /* UI Button のデフォルト（--text 地）を上書きし、デザインどおり白ピル＋黒字に */
-  .z--ryokan-plans_reserve.c--button {
+  .c--ryokan-plans_reserve.c--button {
     --bgc: var(--white);
     --c: var(--black);
     --bdc: var(--white);
@@ -481,22 +481,22 @@
    * 見出し＋（画像｜質問）をひとつの Grid で管理。
    * md 以上: 画像列と質問列を repeat(2, 1fr) で 1:1。
    */
-  .z--ryokan-faq_layout {
+  .c--ryokan-faq_layout {
     display: grid;
     grid-template-areas: 'head' 'acc' 'img';
     grid-template-columns: minmax(0, 1fr);
   }
-  .z--ryokan-faq_head {
+  .c--ryokan-faq_head {
     grid-area: head;
   }
-  .z--ryokan-faq_acc {
+  .c--ryokan-faq_acc {
     grid-area: acc;
   }
-  .z--ryokan-faq_media {
+  .c--ryokan-faq_media {
     grid-area: img;
   }
   @container (min-width: 800px) {
-    .z--ryokan-faq_layout {
+    .c--ryokan-faq_layout {
       grid-template-columns: repeat(2, minmax(0, 1fr));
       grid-template-areas:
         'head head'
@@ -504,31 +504,31 @@
     }
   }
 
-  .z--ryokan-faq_acc .c--accordion_item {
+  .c--ryokan-faq_acc .c--accordion_item {
     border-block-end: 1px solid var(--divider);
   }
-  .z--ryokan-faq_acc .c--accordion_item:last-of-type {
+  .c--ryokan-faq_acc .c--accordion_item:last-of-type {
     border-block-end: none;
   }
 
-  .z--ryokan-footer :where(a) {
+  .c--ryokan-footer :where(a) {
     color: inherit;
   }
-  .z--ryokan-footer_nav li {
+  .c--ryokan-footer_nav li {
     list-style: none;
   }
 
   /* md 未満: 縦並びの項目間に区切り（最後の行の下には付けない） */
-  .z--ryokan-footer_nav > li:not(:last-child) {
+  .c--ryokan-footer_nav > li:not(:last-child) {
     border-block-end: 1px dashed color-mix(in srgb, var(--white) 38%, transparent);
   }
 
   /* md 以上: 縦の区切りをやめ、項目の「間」だけ左に縦線（先頭左・末尾右には付けない） */
   @container (min-width: 800px) {
-    .z--ryokan-footer_nav > li:not(:last-child) {
+    .c--ryokan-footer_nav > li:not(:last-child) {
       border-block-end: none;
     }
-    .z--ryokan-footer_nav > li + li {
+    .c--ryokan-footer_nav > li + li {
       border-inline-start: 1px dashed color-mix(in srgb, var(--white) 38%, transparent);
       padding-inline-start: var(--s20);
       margin-inline-start: var(--s20);
@@ -536,34 +536,34 @@
   }
 
   /* md 未満: 左寄せ。`ta` プロパティのインラインが CSS より優先するため、指定はここに集約 */
-  .z--ryokan-footer_navStack {
+  .c--ryokan-footer_navStack {
     text-align: start;
     align-items: flex-start;
   }
   @container (min-width: 800px) {
-    .z--ryokan-footer_navStack {
+    .c--ryokan-footer_navStack {
       text-align: center;
       align-items: center;
     }
   }
 
   /* md 以上: caret は非表示 */
-  .z--ryokan-footer_navCaret {
+  .c--ryokan-footer_navCaret {
     display: block;
   }
   @container (min-width: 800px) {
-    .z--ryokan-footer_navCaret {
+    .c--ryokan-footer_navCaret {
       display: none;
     }
   }
 
   /* ピル型 FAB: UI Button のセマンティック色を上書き */
-  .z--ryokan-reservationFab.c--button {
+  .c--ryokan-reservationFab.c--button {
     --bgc: var(--black);
     --c: var(--white);
     min-width: 12rem;
   }
-  .z--ryokan-reservationFab:focus-visible {
+  .c--ryokan-reservationFab:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--white) 50%, transparent);
     outline-offset: 3px;
   }

--- a/templates/lp/astro/src/pages/ryokan/index.astro
+++ b/templates/lp/astro/src/pages/ryokan/index.astro
@@ -97,7 +97,6 @@ const mvLayeredKeyframesStyle = `@layer lism-custom {
 
 /**
  * 左右の高さ: Grid の `ai` stretch + 右列 `Flex` 内 `fx:1` の img（`min-h:0`）。
- * 旧実装: `syncAboutRightMaxHeight` + `--c--ryokan-about-right-max-h`（復元は git 履歴参照）
  */
 
 const aboutImgLeft = {
@@ -138,7 +137,7 @@ const feature2Bg = {
   height: 1080,
 } as const;
 
-/** 各要素の `src` に任意の画像URLを直指定（下記は従来どおりのプレースホルダー）。 */
+/** 各要素の `src` に任意の画像URLを直指定（下記はプレースホルダー）。 */
 const feature2GalleryPhotos = [
   { src: 'https://cdn.lism-css.com/img/random-2510?category=japan&r=lp003feature2-a', alt: '富士と朝焼けの風景' },
   { src: 'https://cdn.lism-css.com/img/random-2510?category=japan&r=lp003feature2-b', alt: '日本の山並みと雲海' },
@@ -555,7 +554,7 @@ const reservationSites: readonly SiteCard[] = [
           </Lism>
         </Stack>
       </Container>
-      <!-- MV の動的 @keyframes はマージで抽出されないため、元コンポーネントと同じ set:html を明示注入 -->
+      <!-- MV の動的 @keyframes はマージで抽出されないため、set:html で明示注入 -->
       <style set:html={mvLayeredKeyframesStyle}></style>
 
       <Lism as="section" id="about" class="c--ryokan-about" isContainer pbs="60" pbe="60" bgc="black" c="white">

--- a/templates/lp/astro/src/pages/ryokan/index.astro
+++ b/templates/lp/astro/src/pages/ryokan/index.astro
@@ -97,7 +97,7 @@ const mvLayeredKeyframesStyle = `@layer lism-custom {
 
 /**
  * 左右の高さ: Grid の `ai` stretch + 右列 `Flex` 内 `fx:1` の img（`min-h:0`）。
- * 旧実装: `syncAboutRightMaxHeight` + `--z--ryokan-about-right-max-h`（復元は git 履歴参照）
+ * 旧実装: `syncAboutRightMaxHeight` + `--c--ryokan-about-right-max-h`（復元は git 履歴参照）
  */
 
 const aboutImgLeft = {
@@ -239,19 +239,7 @@ const plans = [
 
 /** Lism プリセットアイコン名（ https://lism-css.com/docs/primitives/a--icon/ ） */
 type InformationIcon =
-  | 'home'
-  | 'clock'
-  | 'cart'
-  | 'gear'
-  | 'book'
-  | 'chat'
-  | 'heart'
-  | 'lightbulb'
-  | 'search'
-  | 'note'
-  | 'bookmark'
-  | 'user'
-  | 'lock';
+  'home' | 'clock' | 'cart' | 'gear' | 'book' | 'chat' | 'heart' | 'lightbulb' | 'search' | 'note' | 'bookmark' | 'user' | 'lock';
 
 type InformationItem = {
   icon: InformationIcon;
@@ -414,14 +402,14 @@ const reservationSites: readonly SiteCard[] = [
   <link rel="preconnect" href="https://fonts.googleapis.com" slot="head" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin slot="head" />
   <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400..700&family=Yuji+Syuku&display=swap" rel="stylesheet" slot="head" />
-  <Container class="z--ryokan-root">
+  <Container class="c--ryokan-root">
     <!-- Header -->
-    <Lism as="header" class="z--ryokan-header" pos="fixed" i="0" w="100%" z="1" hasTransition>
-      <Container class="z--ryokan-header_bar" isWrapper="xl" mx="auto" hasGutter h="100%">
-        <Grid class="z--ryokan-header_inner" gtc="minmax(0,auto) 1fr" ai="center" h="100%" g="20">
-          <Stack class="z--ryokan-header_logo">
+    <Lism as="header" class="c--ryokan-header" pos="fixed" i="0" w="100%" z="1" hasTransition>
+      <Container class="c--ryokan-header_bar" isWrapper="xl" mx="auto" hasGutter h="100%">
+        <Grid class="c--ryokan-header_inner" gtc="minmax(0,auto) 1fr" ai="center" h="100%" g="20">
+          <Stack class="c--ryokan-header_logo">
             <Link
-              class="z--ryokan-header_logoLink"
+              class="c--ryokan-header_logoLink"
               href="#"
               td="none"
               fw="normal"
@@ -435,13 +423,13 @@ const reservationSites: readonly SiteCard[] = [
               {logoLabel}
             </Link>
           </Stack>
-          <Flex class="z--ryokan-header_actions" jc="fe" g="20" ai="center">
-            <Flex class="z--ryokan-headerNav" as="ul" d={['none', null, 'inline-flex']} ai="center" p="0" fxw="nowrap" g={['15', null, '30']}>
+          <Flex class="c--ryokan-header_actions" jc="fe" g="20" ai="center">
+            <Flex class="c--ryokan-headerNav" as="ul" d={['none', null, 'inline-flex']} ai="center" p="0" fxw="nowrap" g={['15', null, '30']}>
               {
                 headerNavItems.map(({ href, ja, en }) => (
                   <ListItem>
                     <Link
-                      class="z--ryokan-headerNav_link"
+                      class="c--ryokan-headerNav_link"
                       href={href}
                       d="grid"
                       jc="center"
@@ -455,7 +443,7 @@ const reservationSites: readonly SiteCard[] = [
                       g="5"
                     >
                       <Inline>{ja}</Inline>
-                      <Inline as="span" class="z--ryokan-headerNav_en" fz="2xs" fw="normal" lts="l" hl="xs" ta="c" d="block">
+                      <Inline as="span" class="c--ryokan-headerNav_en" fz="2xs" fw="normal" lts="l" hl="xs" ta="c" d="block">
                         {en}
                       </Inline>
                     </Link>
@@ -476,14 +464,14 @@ const reservationSites: readonly SiteCard[] = [
       <Modal.Inner layout="stack" pos="relative" w="100%" p="30" bdrs="20" bxsh="50">
         <Modal.CloseBtn modalId="ryokan-menu" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="15" />
         <Modal.Body layout="stack" g="30" py="40">
-          <Stack as="ul" class="z--ryokan-header_menuNav" g="0" p="0" ov="clip">
+          <Stack as="ul" class="c--ryokan-header_menuNav" g="0" p="0" ov="clip">
             {
               headerNavItems.map(({ href, ja, en }) => (
                 <ListItem>
                   <BoxLink href={href} layout="grid" gtc="1fr auto" ai="center" fz="l" td="none" py="15" px="5" w="100%">
                     <Stack g="5">
                       <Inline>{ja}</Inline>
-                      <Inline as="span" class="z--ryokan-header_menuNav_en" fz="s" o="pp">
+                      <Inline as="span" class="c--ryokan-header_menuNav_en" fz="s" o="pp">
                         {en}
                       </Inline>
                     </Stack>
@@ -496,7 +484,7 @@ const reservationSites: readonly SiteCard[] = [
               <BoxLink href="#reservation" layout="grid" gtc="1fr auto" ai="center" fz="l" td="none" py="15" px="5" w="100%">
                 <Stack g="5">
                   <Inline>ご予約はこちら</Inline>
-                  <Inline as="span" class="z--ryokan-header_menuNav_en" fz="s" o="pp"> Reservation </Inline>
+                  <Inline as="span" class="c--ryokan-header_menuNav_en" fz="s" o="pp"> Reservation </Inline>
                 </Stack>
                 <Icon icon="caret-right" fz="s" o="pp" />
               </BoxLink>
@@ -506,9 +494,9 @@ const reservationSites: readonly SiteCard[] = [
       </Modal.Inner>
     </Modal.Root>
     <!-- Main Content -->
-    <Container as="main" class="z--ryokan-main" pos="relative" z="0">
+    <Container as="main" class="c--ryokan-main" pos="relative" z="0">
       <Container
-        class="z--ryokan-mv"
+        class="c--ryokan-mv"
         as="section"
         pos="relative"
         w="100%"
@@ -517,24 +505,24 @@ const reservationSites: readonly SiteCard[] = [
         ov="clip"
         style={{
           minHeight: '100svh',
-          '--z--ryokan-mv-bgCycleDuration': `${mvBgCycleDuration}s`,
-          '--z--ryokan-mv-lineBlurMax': `${mvLineRevealBlurPx}px`,
-          '--z--ryokan-mv-lineDuration': `${mvLineRevealDuration}s`,
-          '--z--ryokan-mv-lineStartDelay': `${mvLineRevealStartDelay}s`,
-          '--z--ryokan-mv-lineStagger': `${mvLineRevealStagger}s`,
+          '--c--ryokan-mv-bgCycleDuration': `${mvBgCycleDuration}s`,
+          '--c--ryokan-mv-lineBlurMax': `${mvLineRevealBlurPx}px`,
+          '--c--ryokan-mv-lineDuration': `${mvLineRevealDuration}s`,
+          '--c--ryokan-mv-lineStartDelay': `${mvLineRevealStartDelay}s`,
+          '--c--ryokan-mv-lineStagger': `${mvLineRevealStagger}s`,
         }}
       >
-        <Frame isLayer class="z--ryokan-mv_bg">
+        <Frame isLayer class="c--ryokan-mv_bg">
           {
             mvResolvedImages.map((src, index) => {
               const mvLayerDelay = index * mvDurationPerImage - mvBgCycleDuration;
 
               return (
                 <div
-                  class="z--ryokan-mv_layer"
+                  class="c--ryokan-mv_layer"
                   style={{
-                    '--z--ryokan-mv-layerBgImage': `url('${src}')`,
-                    '--z--ryokan-mv-layerDelay': `${mvLayerDelay}s`,
+                    '--c--ryokan-mv-layerBgImage': `url('${src}')`,
+                    '--c--ryokan-mv-layerDelay': `${mvLayerDelay}s`,
                   }}
                 />
               );
@@ -556,10 +544,10 @@ const reservationSites: readonly SiteCard[] = [
           c="white"
           style={{ paddingBlockStart: 'calc(var(--header-h) + var(--s30))' }}
         >
-          <Lism as="p" class="z--ryokan-mv_copy">
+          <Lism as="p" class="c--ryokan-mv_copy">
             {
               mvResolvedCopyLines.map((line, i) => (
-                <span class="z--ryokan-mv_line" style={{ '--z--ryokan-mv-lineIndex': i }}>
+                <span class="c--ryokan-mv_line" style={{ '--c--ryokan-mv-lineIndex': i }}>
                   {line}
                 </span>
               ))
@@ -570,24 +558,24 @@ const reservationSites: readonly SiteCard[] = [
       <!-- MV の動的 @keyframes はマージで抽出されないため、元コンポーネントと同じ set:html を明示注入 -->
       <style set:html={mvLayeredKeyframesStyle}></style>
 
-      <Lism as="section" id="about" class="z--ryokan-about" isContainer pbs="60" pbe="60" bgc="black" c="white">
-        <Grid class="z--ryokan-about_grid" gtc={['1fr', null, 'minmax(0, 1fr) minmax(0, 50%)']} g={['30', null, '0']} ai={['start', null, 'stretch']}>
+      <Lism as="section" id="about" class="c--ryokan-about" isContainer pbs="60" pbe="60" bgc="black" c="white">
+        <Grid class="c--ryokan-about_grid" gtc={['1fr', null, 'minmax(0, 1fr) minmax(0, 50%)']} g={['30', null, '0']} ai={['start', null, 'stretch']}>
           <Stack
-            class="z--ryokan-about_col z--ryokan-about_col--left"
+            class="c--ryokan-about_col c--ryokan-about_col--left"
             g={['40', null, '50']}
             pe={['0', null, '50']}
             h={['auto', null, '100%']}
             min-h="0"
             min-w="0"
           >
-            <Stack class="z--ryokan-about_stack" g="0" ai="start">
+            <Stack class="c--ryokan-about_stack" g="0" ai="start">
               <Text as="p" fz={['l', null, 'xl']} mb="10" lts="l" ff="base" c="white" o="pp"> About us </Text>
               <Heading level="2" fz={['2xl', null, '4xl']} fw="500" mb="50" lts="l"> 当宿について </Heading>
-              <Text class="z--ryokan-about_body" as="p" fz="m" hl="l" lts="s" c="white" o="p">
+              <Text class="c--ryokan-about_body" as="p" fz="m" hl="l" lts="s" c="white" o="p">
                 {aboutBodyCopy}
               </Text>
             </Stack>
-            <Frame as="figure" class="z--ryokan-about_figureLeft" ar={['16/10', null, '4/3']} ov="hidden">
+            <Frame as="figure" class="c--ryokan-about_figureLeft" ar={['16/10', null, '4/3']} ov="hidden">
               <img
                 src={aboutImgLeft.src}
                 alt={aboutImgLeft.alt}
@@ -598,10 +586,10 @@ const reservationSites: readonly SiteCard[] = [
               />
             </Frame>
           </Stack>
-          <Flex as="figure" class="z--ryokan-about_figureRight" fxd="column" h={['auto', null, '100%']} min-h="0" pbe={['0', null, '50']} ov="hidden">
+          <Flex as="figure" class="c--ryokan-about_figureRight" fxd="column" h={['auto', null, '100%']} min-h="0" pbe={['0', null, '50']} ov="hidden">
             <Lism
               as="img"
-              class="z--ryokan-about_mediaRightImg"
+              class="c--ryokan-about_mediaRightImg"
               src={aboutImgRight.src}
               alt={aboutImgRight.alt}
               fx={['0', null, '1']}
@@ -613,16 +601,16 @@ const reservationSites: readonly SiteCard[] = [
         </Grid>
       </Lism>
 
-      <Lism as="section" id="feature" class="z--ryokan-feature" bgc="base" c="text" py="60">
+      <Lism as="section" id="feature" class="c--ryokan-feature" bgc="base" c="text" py="60">
         <Container isWrapper="l" hasGutter isContainer pos="relative">
-          <Grid class="z--ryokan-feature_grid" gtc={['1fr', null, 'minmax(0, 1.05fr) minmax(0, 1fr)']} g={['40', null, '50']} ai="stretch">
-            <Lism as="figure" class="z--ryokan-feature_figure" ov="hidden" bdrs="10">
+          <Grid class="c--ryokan-feature_grid" gtc={['1fr', null, 'minmax(0, 1.05fr) minmax(0, 1fr)']} g={['40', null, '50']} ai="stretch">
+            <Lism as="figure" class="c--ryokan-feature_figure" ov="hidden" bdrs="10">
               <img src={featureImg.src} alt={featureImg.alt} width={featureImg.width} height={featureImg.height} loading="lazy" decoding="async" />
             </Lism>
-            <Stack class="z--ryokan-feature_textCol" pos="relative" g="0" ai="stretch" min-w="0" h="100%">
-              <Lism as="span" class="z--ryokan-feature_watermark" exProps={{ 'aria-hidden': 'true' }}> Experience </Lism>
+            <Stack class="c--ryokan-feature_textCol" pos="relative" g="0" ai="stretch" min-w="0" h="100%">
+              <Lism as="span" class="c--ryokan-feature_watermark" exProps={{ 'aria-hidden': 'true' }}> Experience </Lism>
               <Flex
-                class="z--ryokan-feature_copyRow"
+                class="c--ryokan-feature_copyRow"
                 fxd={['column', null, 'row']}
                 g={['50', null, '40']}
                 ai="stretch"
@@ -631,17 +619,17 @@ const reservationSites: readonly SiteCard[] = [
                 min-h="0"
                 w="100%"
               >
-                <Heading level="2" class="z--ryokan-feature_title" fz={['2xl', null, '3xl']} fw="600" lts="l">
-                  <Box class="z--ryokan-feature_titleInner" lts="l">
-                    <Inline class="z--ryokan-feature_titleLine1">特別な旅と</Inline>
-                    <Inline class="z--ryokan-feature_titleLine2">静寂の体験</Inline>
+                <Heading level="2" class="c--ryokan-feature_title" fz={['2xl', null, '3xl']} fw="600" lts="l">
+                  <Box class="c--ryokan-feature_titleInner" lts="l">
+                    <Inline class="c--ryokan-feature_titleLine1">特別な旅と</Inline>
+                    <Inline class="c--ryokan-feature_titleLine2">静寂の体験</Inline>
                   </Box>
                 </Heading>
-                <Stack class="z--ryokan-feature_bodyStack" g="30" ai="start" min-w="0">
-                  <Text as="p" class="z--ryokan-feature_lead" fz={['l', null, 'xl']} fw="600" lts="l" c="text">
+                <Stack class="c--ryokan-feature_bodyStack" g="30" ai="start" min-w="0">
+                  <Text as="p" class="c--ryokan-feature_lead" fz={['l', null, 'xl']} fw="600" lts="l" c="text">
                     {featureLead}
                   </Text>
-                  <Text as="p" class="z--ryokan-feature_body" fz="m" hl="l" lts="s" c="text" max-w="100%">
+                  <Text as="p" class="c--ryokan-feature_body" fz="m" hl="l" lts="s" c="text" max-w="100%">
                     {featureBody}
                   </Text>
                 </Stack>
@@ -651,7 +639,7 @@ const reservationSites: readonly SiteCard[] = [
         </Container>
       </Lism>
 
-      <Lism as="section" id="feature2" class="z--ryokan-feature2" pos="relative" ov-x="clip" c="white">
+      <Lism as="section" id="feature2" class="c--ryokan-feature2" pos="relative" ov-x="clip" c="white">
         <Frame isLayer>
           <Lism
             as="img"
@@ -718,7 +706,7 @@ const reservationSites: readonly SiteCard[] = [
               {
                 plans.map((plan) => (
                   <Flex fxd={['column', null, 'row-reverse']} ai="stretch" g={['30', null, '50']} w="100%">
-                    <Frame as="figure" class="z--ryokan-plans_media" ar="16/10" ov="hidden" bdrs="10" w="100%" min-w="0">
+                    <Frame as="figure" class="c--ryokan-plans_media" ar="16/10" ov="hidden" bdrs="10" w="100%" min-w="0">
                       <img
                         src={plan.image.src}
                         alt={plan.image.alt}
@@ -755,7 +743,7 @@ const reservationSites: readonly SiteCard[] = [
 
                         <Lism isContainer w="100%" min-w="0">
                           <Button
-                            class="z--ryokan-plans_reserve"
+                            class="c--ryokan-plans_reserve"
                             href="#contact"
                             layout="flex"
                             w="100%"
@@ -830,17 +818,17 @@ const reservationSites: readonly SiteCard[] = [
 
       <Lism as="section" id="faq" bgc="base" c="text" py="60">
         <Container isWrapper="l" hasGutter>
-          <Grid class="z--ryokan-faq_layout" w="100%" g="50" ai="stretch">
-            <Stack class="z--ryokan-faq_head" g="10" ai="center" ta="center">
+          <Grid class="c--ryokan-faq_layout" w="100%" g="50" ai="stretch">
+            <Stack class="c--ryokan-faq_head" g="10" ai="center" ta="center">
               <Text as="p" fz="m" lts="l" ff="base" c="text-2" o="pp"> FAQ </Text>
               <Heading level="2" fz={['2xl', null, '3xl']} fw="500" lts="l"> よくあるご質問 </Heading>
             </Stack>
 
-            <Frame as="figure" class="z--ryokan-faq_media" ar={['16/10', null, '1/1']} ov="hidden" bdrs="10" w="100%" min-w="0">
+            <Frame as="figure" class="c--ryokan-faq_media" ar={['16/10', null, '1/1']} ov="hidden" bdrs="10" w="100%" min-w="0">
               <img src={faqImage.src} alt={faqImage.alt} width={faqImage.width} height={faqImage.height} loading="lazy" decoding="async" />
             </Frame>
 
-            <Lism class="z--ryokan-faq_acc" min-w="0">
+            <Lism class="c--ryokan-faq_acc" min-w="0">
               <Accordion.Root g="0" p="0" ov="visible">
                 {
                   faqItems.map((item) => (
@@ -942,7 +930,7 @@ const reservationSites: readonly SiteCard[] = [
     </Container>
     <!-- Footer -->
 
-    <Lism as="footer" id="footer" class="z--ryokan-footer" bgc="black" c="white" py={['50', null, '60']}>
+    <Lism as="footer" id="footer" class="c--ryokan-footer" bgc="black" c="white" py={['50', null, '60']}>
       <Container isContainer isWrapper="xl" hasGutter>
         <Stack g={['40', null, '50']} ai="stretch" w="100%">
           <!-- キャッチコピーをロゴの左隣に。下揃え（flex-end） -->
@@ -957,7 +945,7 @@ const reservationSites: readonly SiteCard[] = [
           <Flex fxd={['column', null, 'row']} ai="end" jc="between" g={['30', null, '40']} w="100%">
             <Flex
               as="ul"
-              class="z--ryokan-footer_nav"
+              class="c--ryokan-footer_nav"
               fxd={['column', null, 'row']}
               ai="stretch"
               p="0"
@@ -971,7 +959,7 @@ const reservationSites: readonly SiteCard[] = [
                 footerNavItems.map(({ href, ja, en }) => (
                   <ListItem>
                     <BoxLink
-                      class="z--ryokan-footer_navLink"
+                      class="c--ryokan-footer_navLink"
                       href={href}
                       layout="grid"
                       gtc={['1fr auto', null, '1fr']}
@@ -984,13 +972,13 @@ const reservationSites: readonly SiteCard[] = [
                       c="inherit"
                       hov="-o"
                     >
-                      <Stack class="z--ryokan-footer_navStack" g="5">
+                      <Stack class="c--ryokan-footer_navStack" g="5">
                         <Inline>{ja}</Inline>
-                        <Inline as="span" class="z--ryokan-footer_navEn" fz="s" o="pp">
+                        <Inline as="span" class="c--ryokan-footer_navEn" fz="s" o="pp">
                           {en}
                         </Inline>
                       </Stack>
-                      <Icon class="z--ryokan-footer_navCaret" icon="caret-right" fz="s" o="pp" />
+                      <Icon class="c--ryokan-footer_navCaret" icon="caret-right" fz="s" o="pp" />
                     </BoxLink>
                   </ListItem>
                 ))
@@ -1015,7 +1003,7 @@ const reservationSites: readonly SiteCard[] = [
 
     <Lism pos="fixed" r="max(var(--s30), env(safe-area-inset-right))" b="max(var(--s30), env(safe-area-inset-bottom))" w="fit">
       <Button
-        class="z--ryokan-reservationFab"
+        class="c--ryokan-reservationFab"
         href="#reservation"
         z="99"
         layout="center"


### PR DESCRIPTION
## 概要

#546 で統一した `b--` / `c--` 命名規約へ、`templates/lp` と `templates/blog/*` を追随させます。

## 変更内容

### templates/lp/astro

- `z--*` クラス（111種類・16ファイル）を `c--*` へ移行（プレフィックスのみ変更し、名前本体は維持）
- Astroのclass属性・CSSセレクタ・styleオブジェクト内の参照を同期
- クラス以外に残っていた `z--` 識別子も `c--` へ統一
  - `@keyframes` 名と `animation` 参照
  - CSSカスタムプロパティ（`--z--*` → `--c--*`）
  - view timeline名（`--z--ryokan-reservation` → `--c--ryokan-reservation`）
  - コメント内の参照
- 日本語・英語ページを同時に更新（対応ペアで変更行数の一致を確認）
- `p--` クラスはクラス以外の識別子を含めて存在しなかったため変更なし

### templates/blog/*

- techlog / minimal / personal の `@layer lism-component` を `@layer lism-custom` へ変更
- `TocItem.astro` の `@layer lism-components`（複数形の誤記）も `lism-custom` へ修正
- lism-css-intro 記事のレイヤー説明とコード例を現行規約へ更新
  - レイヤー順の説明を `lism-base` → `lism-custom` → `lism-utility` へ
  - 見出し「コンポーネントクラス（c--）」を「カスタムクラス（c--）」へ

## 検証

- `templates/` 全体で `z--` / `p--` / `lism-component(s)` の残存ゼロを確認（残る `z--` の部分一致は `--fz--s` / `--sz--l` 等のトークン変数のみ）
- 移行後の `c--*` 名が既存の `c--*` クラスと衝突しないこと、コア側に `--c--*` 変数がないことを確認
- LP側の差分が純粋な `z--` → `c--` 置換のみであることを機械的に検証（置換前後のdiff照合）
- `pnpm build:templates` で全テンプレートのビルド成功、ビルド成果物（HTML/purge後CSS）にも旧名の残存なし

## 補足

- ryokanのクラス名は `ryokan-` プレフィックスをそのまま維持しています（例: `c--ryokan-header`）。Issueの方針に従いプレフィックス移行のみとし、camelCase化などの名前本体の変更は行っていません。
- ryokanの「旧実装」参照コメント内の変数名もリネームしています。git履歴上の実際の名前は旧名ですが、併記された関数名 `syncAboutRightMaxHeight` で履歴検索できます。
- `ryokan/index.astro` のアイコン名union型が1行へ整形されていますが、コミット時のlint-staged（prettier）による自動整形です。

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFC3eAzNHLxzwKPVRTWoxJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **スタイル**
  * サイトテンプレート全体のCSSクラス接頭辞を `z--` から `c--` に統一しました。
  * カスタムCSSレイヤー名を `lism-component` から `lism-custom` に更新しました。
  * メインビジュアルのスクロール連動アニメーションを新しいクラス名に対応させました。
  * 英語・日本語ページの表示内容や操作性に変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->