### PR TITLE
旧レイヤー名・旧クラス表記の残存箇所を修正する

### DIFF
--- a/packages/mcp/src/data/docs-index.json
+++ b/packages/mcp/src/data/docs-index.json
@@ -762,7 +762,7 @@
     "category": "core-components",
     "headings": ["Import", "Lism Props"],
     "keywords": ["Lism", "core", "コア", "基盤", "コンポーネント", "className", "layout", "atomic", "as", "exProps"],
-    "snippet": "全コンポーネントの基盤。Props システムによる CSS クラス・スタイルの自動変換を提供。className で c-- クラスや任意クラスを指定、layout で l-- クラス、atomic で a-- クラス（divider / spacer / decorator）を指定可能。as prop で出力要素や外部コンポーネントを指定可能。レスポンシブ指定は配列またはオブジェクト形式で対応。"
+    "snippet": "全コンポーネントの基盤。Props システムによる CSS クラス・スタイルの自動変換を提供。className で b-- / c-- クラス（Block Class / Custom Class）や任意クラスを指定、layout で l-- クラス、atomic で a-- クラス（divider / spacer / decorator）を指定可能。as prop で出力要素や外部コンポーネントを指定可能。レスポンシブ指定は配列またはオブジェクト形式で対応。"
   },
   {
     "sourcePath": "core-components/lism-props.mdx",

--- a/templates/blog/astro/minimal/.lang/en/src/posts/lism-css-intro.md
+++ b/templates/blog/astro/minimal/.lang/en/src/posts/lism-css-intro.md
@@ -11,7 +11,7 @@ Here we walk through the main layers that make up Lism CSS, one at a time.
 
 ## CSS Layers
 
-Lism CSS styles are split across several `@layer`s, and the order in which the layers are declared determines their priority. They are stacked in the order `lism-base` → `lism-component` → `lism-utility`, so you can override styles with property classes without worrying about specificity.
+Lism CSS styles are split across several `@layer`s, and the order in which the layers are declared determines their priority. They are stacked in the order `lism-base` → `lism-custom` → `lism-utility`, so you can override styles with property classes without worrying about specificity.
 
 When you add custom CSS, place it in whichever layer fits its purpose.
 
@@ -24,7 +24,7 @@ When you add custom CSS, place it in whichever layer fits its purpose.
   }
 }
 
-@layer lism-component {
+@layer lism-custom {
   .c--postList > li {
     border-block-end: 1px solid var(--divider);
   }
@@ -94,16 +94,16 @@ Lism provides classes with the `is--{name}` prefix that declare a "role".
 
 Don't use them for state changes (such as active) or variations. Express state with `data-*` attributes, and variations with BEM modifiers in the form `c--{name}--{variant}`.
 
-## Component classes (c--)
+## Custom classes (c--)
 
-Define project-specific components with classes using the `c--{name}` prefix. Move any declaration you can express with a property class into the markup, and leave only CSS-only declarations — pseudo-classes, state changes, descendant selectors, and the like — in the CSS.
+Define project-specific elements and components with custom classes using the `c--{name}` prefix. Move any declaration you can express with a property class into the markup, and leave only CSS-only declarations — pseudo-classes, state changes, descendant selectors, and the like — in the CSS.
 
 ```html
 <span class="c--tag -fz:xs -px:10 -py:5 -bgc:base-2 -bdrs:10">React</span>
 ```
 
 ```css
-@layer lism-component {
+@layer lism-custom {
   .c--tag:hover {
     background-color: var(--divider);
   }

--- a/templates/blog/astro/techlog/.lang/en/src/posts/tech/lism-css-intro.mdx
+++ b/templates/blog/astro/techlog/.lang/en/src/posts/tech/lism-css-intro.mdx
@@ -15,7 +15,7 @@ Post files work with both `.md` and `.mdx`. Directive syntax like `:::note` is c
 
 ## CSS Layers
 
-Lism CSS styles are organized across several `@layer`s, and the order in which the layers are declared determines their priority. They stack in the order `lism-base` → `lism-component` → `lism-utility`, so you can override styles with Property Classes without worrying about specificity.
+Lism CSS styles are organized across several `@layer`s, and the order in which the layers are declared determines their priority. They stack in the order `lism-base` → `lism-custom` → `lism-utility`, so you can override styles with Property Classes without worrying about specificity.
 
 When you add custom CSS, place it on whichever layer fits its purpose.
 
@@ -28,7 +28,7 @@ When you add custom CSS, place it on whichever layer fits its purpose.
   }
 }
 
-@layer lism-component {
+@layer lism-custom {
   .c--postList > li {
     border-block-end: 1px solid var(--divider);
   }
@@ -98,16 +98,16 @@ Lism provides classes with the `is--{name}` prefix to declare a "role."
 
 Don't use them for state switching (such as active) or variations. Express state with `data-*` attributes, and variations with the `c--{name}--{variant}` BEM modifier.
 
-## Component Classes (c--)
+## Custom Classes (c--)
 
-Define project-specific components with classes that use the `c--{name}` prefix. Move any declarations that can be written as Property Classes into the markup, and leave in the CSS only what CSS alone can express — pseudo-classes, state switching, descendant selectors, and the like.
+Define project-specific elements and components with custom classes that use the `c--{name}` prefix. Move any declarations that can be written as Property Classes into the markup, and leave in the CSS only what CSS alone can express — pseudo-classes, state switching, descendant selectors, and the like.
 
 ```html
 <span class="c--tag -fz:xs -px:10 -py:5 -bgc:base-2 -bdrs:10">React</span>
 ```
 
 ```css
-@layer lism-component {
+@layer lism-custom {
   .c--tag:hover {
     background-color: var(--divider);
   }


### PR DESCRIPTION
## Summary

- templates/blog 英語版（minimal / techlog）の `lism-component` を `lism-custom` に揃え、見出しも日本語版の「カスタムクラス」に合わせて `Custom classes (c--)` へ更新した
- MCP `docs-index.json` の `core-components/Lism.mdx` snippet に `b--` を併記し、`lism-props` 側の表記と揃えた
- 英語版記事の構成（見出し・コードブロック・セクション順）は日本語版と一致しており、追随漏れはレイヤー名とカスタムクラス見出しのみだった

`docs-index.json` は `/mcp-update` による全体再生成ではなく、該当 snippet 1件だけを直接修正した。`Lism.mdx` 本文には className / `b--` / `c--` の記述がなく（`lism-props` への誘導のみ）、全文再生成の対象差ではないため。

Closes #558

## Test plan

- [ ] `templates/blog/astro/minimal/.lang/en/src/posts/lism-css-intro.md` に `lism-component` が残っていないこと
- [ ] `templates/blog/astro/techlog/.lang/en/src/posts/tech/lism-css-intro.mdx` に `lism-component` が残っていないこと
- [ ] 両英語記事のレイヤー順が `lism-base` → `lism-custom` → `lism-utility` になっていること
- [ ] MCP の Lism snippet が `b-- / c--` 併記になっていること

