### PR TITLE
Modalのアクセシビリティ改善（アクセシブルネーム案内・type="button"付与・reduced-motion対応など）

### DIFF
--- a/apps/docs/src/content/en/ui/Modal.mdx
+++ b/apps/docs/src/content/en/ui/Modal.mdx
@@ -21,11 +21,11 @@ A component for displaying modals using the `dialog` element.
       <Fragment>Open Modal 01</Fragment>
     </Modal.OpenBtn>
 
-    <Modal.Root id="modal-01" p="30">
+    <Modal.Root id="modal-01" aria-labelledby="modal-01-title" p="30">
       <Modal.Inner layout="stack" pos="relative" max-sz="m" mx="auto" p="35" bdrs="30" bxsh="30">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="10" />
         <Modal.Body layout="stack" g="30" util="trimAll">
-          <div className="-fz:l -fw:bold">Modal Title</div>
+          <h2 className="-fz:l -fw:bold" id="modal-01-title">Modal Title</h2>
           <p>Lorem ipsum dolor sit amet. Consectetur adipiscing elit, sed do eiusmod tempor Incididunt ut. Labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
         </Modal.Body>
       </Modal.Inner>
@@ -35,11 +35,11 @@ A component for displaying modals using the `dialog` element.
     ```jsx '"modal-01"'
     <Modal.OpenBtn modalId="modal-01" className="-bd -px:15 -py:5 -bdrs:10">Open Modal 01</Modal.OpenBtn>
 
-    <Modal.Root id="modal-01" p="30">
+    <Modal.Root id="modal-01" aria-labelledby="modal-01-title" p="30">
       <Modal.Inner layout="stack" pos="relative" max-sz="m" mx="auto" p="35" bdrs="30" bxsh="30">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="10" />
         <Modal.Body layout="stack" g="30" util="trimAll">
-          <div className="-fz:l -fw:bold">Modal Title</div>
+          <h2 className="-fz:l -fw:bold" id="modal-01-title">Modal Title</h2>
           <p>Lorem ipsum dolor sit amet. Consectetur adipiscing elit, sed do eiusmod tempor Incididunt ut. Labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
         </Modal.Body>
       </Modal.Inner>
@@ -48,16 +48,16 @@ A component for displaying modals using the `dialog` element.
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html '"modal-01"'
-    <button class="-bd -px:15 -py:5 -bdrs:10 b--modal_openBtn set--plain -hov:-o" data-modal-open="modal-01">Open Modal 01</button>
+    <button class="-bd -px:15 -py:5 -bdrs:10 b--modal_openBtn set--plain -hov:-o" type="button" aria-haspopup="dialog" data-modal-open="modal-01">Open Modal 01</button>
 
-    <dialog class="b--modal set--plain -p:30" id="modal-01">
+    <dialog class="b--modal set--plain -p:30" id="modal-01" aria-labelledby="modal-01-title">
       <div class="b--modal_inner l--stack -pos:relative -max-sz:m -mx:auto -p:35 -bdrs:30 -bxsh:30">
-        <button class="b--modal_closeBtn set--plain -hov:-o -pos:absolute -t:0 -r:0 -z:1 -fz:xl -p:10 -m:10" data-modal-close="modal-01" autofocus>
+        <button class="b--modal_closeBtn set--plain -hov:-o -pos:absolute -t:0 -r:0 -z:1 -fz:xl -p:10 -m:10" type="button" data-modal-close="modal-01" autofocus>
           <svg class="a--icon" aria-hidden="true">...</svg>
           <span class="u--srOnly">Close</span>
         </button>
         <div class="b--modal_body l--stack u--trimAll -g:30">
-          <div class="-fz:l -fw:bold">Modal Title</div>
+          <h2 class="-fz:l -fw:bold" id="modal-01-title">Modal Title</h2>
           <p>Lorem ipsum dolor sit amet. Consectetur adipiscing elit, sed do eiusmod tempor Incididunt ut. Labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
         </div>
       </div>
@@ -71,6 +71,7 @@ Add an `id` to `<Modal.Root>`, and pass the same `modalId` to `<Modal.OpenBtn>` 
 
 - Do not change the `display` value of the `dialog` element.
 - Due to animation issues with `::backdrop`, this component assumes the dialog covers the full viewport width with a background color.
+- To announce the modal's name to screen readers, specify `aria-labelledby` on `<Modal.Root>` pointing to the title element (e.g. `h2`). For modals without a visible title, use `aria-label` instead.
 :::
 
 
@@ -107,6 +108,8 @@ Provided as `Modal` from the `@lism-css/ui` package.
 |<PropBadge>`<Modal.Inner>`</PropBadge><br/> `offset`| Offset value to shift the position of `__inner` when hidden. |
 |<PropBadge>`<Modal.OpenBtn>`</PropBadge><br/> `modalId`| Output as `data-modal-open`. Specifies the modal `id` on the trigger element that opens the modal. |
 |<PropBadge>`<Modal.CloseBtn>`</PropBadge><br/> `modalId`| Output as `data-modal-close`. Specifies the modal `id` on the trigger element that closes the modal. |
+|<PropBadge>`<Modal.CloseBtn>`</PropBadge><br/> `icon`| Specifies the icon displayed when no children are passed. (Default: `x`) |
+|<PropBadge>`<Modal.CloseBtn>`</PropBadge><br/> `srText`| Specifies the text output for screen readers when the icon is displayed. (Default: `Close`) |
 
 
 ## Examples
@@ -125,10 +128,10 @@ To make `<Modal.Body>` scrollable, specify `ov-y="auto"`. Place any content that
       <Fragment>Open Modal 02</Fragment>
     </Modal.OpenBtn>
 
-    <Modal.Root id="modal-02" isContainer px="30" py="50">
+    <Modal.Root id="modal-02" aria-labelledby="modal-02-title" isContainer px="30" py="50">
       <Modal.Inner layout="stack" max-sz="s" mx="auto" bdrs="20" bxsh="40">
         <Flex ai="center" jc="between" py="15" bd-b>
-          <Inline fz="l" fw="bold" hl="s" ms="30">
+          <Inline as="h2" id="modal-02-title" fz="l" fw="bold" hl="s" ms="30">
             <Fragment>Modal Header</Fragment>
           </Inline>
           <Modal.CloseBtn modalId="modal-02" autofocus fz="xl" p="10" mx="15" />
@@ -154,10 +157,10 @@ To make `<Modal.Body>` scrollable, specify `ov-y="auto"`. Place any content that
     ```jsx '"modal-02"'
     <Modal.OpenBtn modalId="modal-02" className="-bd -px:15 -py:5 -bdrs:10">Open Modal 02</Modal.OpenBtn>
 
-    <Modal.Root id="modal-02" isContainer px="30" py="50">
+    <Modal.Root id="modal-02" aria-labelledby="modal-02-title" isContainer px="30" py="50">
       <Modal.Inner layout="stack" max-sz="s" mx="auto" bdrs="20" bxsh="40">
         <Flex ai="center" jc="between" py="15" bd-b>
-          <Inline fz="l" fw="bold" hl="s" ms="30">
+          <Inline as="h2" id="modal-02-title" fz="l" fw="bold" hl="s" ms="30">
             <Fragment>Modal Header</Fragment>
           </Inline>
           <Modal.CloseBtn modalId="modal-02" autofocus fz="xl" p="10" mx="15" />
@@ -182,13 +185,13 @@ To make `<Modal.Body>` scrollable, specify `ov-y="auto"`. Place any content that
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html '"modal-02"'
-    <button class="-bd -px:15 -py:5 -bdrs:10 b--modal_openBtn set--plain -hov:-o" data-modal-open="modal-02">Open Modal 02</button>
+    <button class="-bd -px:15 -py:5 -bdrs:10 b--modal_openBtn set--plain -hov:-o" type="button" aria-haspopup="dialog" data-modal-open="modal-02">Open Modal 02</button>
 
-    <dialog class="b--modal set--plain is--container -px:30 -py:50" id="modal-02">
+    <dialog class="b--modal set--plain is--container -px:30 -py:50" id="modal-02" aria-labelledby="modal-02-title">
       <div class="b--modal_inner l--stack -max-sz:s -mx:auto -bdrs:20 -bxsh:40">
         <div class="l--flex -ai:center -jc:between -py:15 -bd-b">
-          <span class="-fz:l -fw:bold -hl:s -ms:30">Modal Header</span>
-          <button class="b--modal_closeBtn set--plain -hov:-o -fz:xl -p:10 -mx:15" data-modal-close="modal-02" autofocus>
+          <h2 class="-fz:l -fw:bold -hl:s -ms:30" id="modal-02-title">Modal Header</h2>
+          <button class="b--modal_closeBtn set--plain -hov:-o -fz:xl -p:10 -mx:15" type="button" data-modal-close="modal-02" autofocus>
             <svg class="a--icon" aria-hidden="true">...</svg>
             <span class="u--srOnly">Close</span>
           </button>
@@ -203,7 +206,7 @@ To make `<Modal.Body>` scrollable, specify `ov-y="auto"`. Place any content that
           <p>...Contents...</p>
         </div>
         <div class="l--flex -jc:end -px:30 -py:15 -bd-t">
-          <button class="b--modal_closeBtn set--plain -hov:-o -bgc:text -c:base -hl:s -px:15 -py:10 -bd:none -bdrs:10" data-modal-close="modal-02">Cancel</button>
+          <button class="b--modal_closeBtn set--plain -hov:-o -bgc:text -c:base -hl:s -px:15 -py:10 -bd:none -bdrs:10" type="button" data-modal-close="modal-02">Cancel</button>
         </div>
       </div>
     </dialog>
@@ -223,7 +226,7 @@ To make `<Modal.Body>` scrollable, specify `ov-y="auto"`. Place any content that
       <span>MENU</span>
     </Modal.OpenBtn>
 
-    <Modal.Root id="modal-03">
+    <Modal.Root id="modal-03" aria-label="Menu">
       <Modal.Inner layout="stack" max-w="24rem" h="100%" bxsh="40" offset="-100px 0">
         <Flex bd-b ai="center" jc="between" p="20">
           <Inline fw="bold">MENU</Inline>
@@ -256,7 +259,7 @@ To make `<Modal.Body>` scrollable, specify `ov-y="auto"`. Place any content that
       <Icon icon="menu" fz="l" /><span>MENU</span>
     </Modal.OpenBtn>
 
-    <Modal.Root id="modal-03">
+    <Modal.Root id="modal-03" aria-label="Menu">
       <Modal.Inner layout="stack" max-w="24rem" h="100%" bxsh="40" offset="-100px 0">
         <Flex bd-b ai="center" jc="between" p="20">
           <Inline fw="bold">MENU</Inline>
@@ -286,16 +289,16 @@ To make `<Modal.Body>` scrollable, specify `ov-y="auto"`. Place any content that
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html '"modal-03"'
-    <button class="b--modal_openBtn set--plain -hov:-o -g:5 -fz:s" data-modal-open="modal-03">
+    <button class="b--modal_openBtn set--plain -hov:-o -g:5 -fz:s" type="button" aria-haspopup="dialog" data-modal-open="modal-03">
       <svg class="a--icon -fz:l" aria-hidden="true">...</svg>
       <span>MENU</span>
     </button>
 
-    <dialog class="b--modal set--plain" id="modal-03">
+    <dialog class="b--modal set--plain" id="modal-03" aria-label="Menu">
       <div class="b--modal_inner l--stack -max-w -h:100% -bxsh:40" style="--offset:-100px 0;--max-w:24rem">
         <div class="l--flex -bd-b -ai:center -jc:between -p:20">
           <span class="-fw:bold">MENU</span>
-          <button class="b--modal_closeBtn set--plain -hov:-o -fz:xl -p:5" data-modal-close="modal-03" autofocus>
+          <button class="b--modal_closeBtn set--plain -hov:-o -fz:xl -p:5" type="button" data-modal-close="modal-03" autofocus>
             <svg class="a--icon" aria-hidden="true">...</svg>
             <span class="u--srOnly">Close</span>
           </button>

--- a/apps/docs/src/content/ja/ui/Modal.mdx
+++ b/apps/docs/src/content/ja/ui/Modal.mdx
@@ -21,11 +21,11 @@ import { DummyText } from '@lism-css/ui/astro/DummyText';
       <Fragment>Open Modal 01</Fragment>
     </Modal.OpenBtn>
 
-    <Modal.Root id="modal-01" p="30">
+    <Modal.Root id="modal-01" aria-labelledby="modal-01-title" p="30">
       <Modal.Inner layout="stack" pos="relative" max-sz="m" mx="auto" p="35" bdrs="30" bxsh="30">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="10" />
         <Modal.Body layout="stack" g="30" util="trimAll">
-          <div className="-fz:l -fw:bold">Modal Title</div>
+          <h2 className="-fz:l -fw:bold" id="modal-01-title">Modal Title</h2>
           <p>Lorem ipsum dolor sit amet. Consectetur adipiscing elit, sed do eiusmod tempor Incididunt ut. Labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
         </Modal.Body>
       </Modal.Inner>
@@ -35,11 +35,11 @@ import { DummyText } from '@lism-css/ui/astro/DummyText';
     ```jsx '"modal-01"'
     <Modal.OpenBtn modalId="modal-01" className="-bd -px:15 -py:5 -bdrs:10">Open Modal 01</Modal.OpenBtn>
 
-    <Modal.Root id="modal-01" p="30">
+    <Modal.Root id="modal-01" aria-labelledby="modal-01-title" p="30">
       <Modal.Inner layout="stack" pos="relative" max-sz="m" mx="auto" p="35" bdrs="30" bxsh="30">
         <Modal.CloseBtn modalId="modal-01" autofocus pos="absolute" t="0" r="0" z="1" fz="xl" p="10" m="10" />
         <Modal.Body layout="stack" g="30" util="trimAll">
-          <div className="-fz:l -fw:bold">Modal Title</div>
+          <h2 className="-fz:l -fw:bold" id="modal-01-title">Modal Title</h2>
           <p>Lorem ipsum dolor sit amet. Consectetur adipiscing elit, sed do eiusmod tempor Incididunt ut. Labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
         </Modal.Body>
       </Modal.Inner>
@@ -48,16 +48,16 @@ import { DummyText } from '@lism-css/ui/astro/DummyText';
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html '"modal-01"'
-    <button class="-bd -px:15 -py:5 -bdrs:10 b--modal_openBtn set--plain -hov:-o" data-modal-open="modal-01">Open Modal 01</button>
+    <button class="-bd -px:15 -py:5 -bdrs:10 b--modal_openBtn set--plain -hov:-o" type="button" aria-haspopup="dialog" data-modal-open="modal-01">Open Modal 01</button>
 
-    <dialog class="b--modal set--plain -p:30" id="modal-01">
+    <dialog class="b--modal set--plain -p:30" id="modal-01" aria-labelledby="modal-01-title">
       <div class="b--modal_inner l--stack -pos:relative -max-sz:m -mx:auto -p:35 -bdrs:30 -bxsh:30">
-        <button class="b--modal_closeBtn set--plain -hov:-o -pos:absolute -t:0 -r:0 -z:1 -fz:xl -p:10 -m:10" data-modal-close="modal-01" autofocus>
+        <button class="b--modal_closeBtn set--plain -hov:-o -pos:absolute -t:0 -r:0 -z:1 -fz:xl -p:10 -m:10" type="button" data-modal-close="modal-01" autofocus>
           <svg class="a--icon" aria-hidden="true">...</svg>
           <span class="u--srOnly">Close</span>
         </button>
         <div class="b--modal_body l--stack u--trimAll -g:30">
-          <div class="-fz:l -fw:bold">Modal Title</div>
+          <h2 class="-fz:l -fw:bold" id="modal-01-title">Modal Title</h2>
           <p>Lorem ipsum dolor sit amet. Consectetur adipiscing elit, sed do eiusmod tempor Incididunt ut. Labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
         </div>
       </div>
@@ -71,6 +71,7 @@ import { DummyText } from '@lism-css/ui/astro/DummyText';
 
 - Modalは`dialog`を使用しています。display値を変更しないように注意してください。
 - `::backdrop` はアニメーションに問題があるため、dialogをスクリーン幅いっぱいにして背景色をつけて運用する前提で設計しています。
+- スクリーンリーダーにモーダルの名前が伝わるよう、`<Modal.Root>`にはタイトル要素（`h2`など）を指す`aria-labelledby`を指定してください。視覚的なタイトルを持たないモーダルでは、代わりに`aria-label`を指定します。
 :::
 
 
@@ -107,6 +108,8 @@ Modal のベーススタイルは、以下のCSSで定義されています。
 |<PropBadge>`<Modal.Inner>`</PropBadge><br/> `offset`| `__inner`の非表示時の位置をずらすためのオフセット値|
 |<PropBadge>`<Modal.OpenBtn>`</PropBadge><br/> `modalId`| `data-modal-open`として出力されます。モーダルを開くトリガー要素にて、モーダルの`id`を指定します。|
 |<PropBadge>`<Modal.CloseBtn>`</PropBadge><br/> `modalId`| `data-modal-close`として出力されます。モーダルを閉じるトリガー要素にて、モーダルの`id`を指定します。|
+|<PropBadge>`<Modal.CloseBtn>`</PropBadge><br/> `icon`| 子要素を渡さない場合に表示されるアイコンを指定します。（デフォルト: `x`）|
+|<PropBadge>`<Modal.CloseBtn>`</PropBadge><br/> `srText`| アイコン表示時にスクリーンリーダー向けに出力されるテキストを指定します。デフォルトは`Close`のため、日本語サイトでは`srText="閉じる"`の指定を推奨します。|
 
 
 ## Examples
@@ -125,10 +128,10 @@ Modal のベーススタイルは、以下のCSSで定義されています。
       <Fragment>Open Modal 02</Fragment>
     </Modal.OpenBtn>
 
-    <Modal.Root id="modal-02" isContainer px="30" py="50">
+    <Modal.Root id="modal-02" aria-labelledby="modal-02-title" isContainer px="30" py="50">
       <Modal.Inner layout="stack" max-sz="s" mx="auto" bdrs="20" bxsh="40">
         <Flex ai="center" jc="between" py="15" bd-b>
-          <Inline fz="l" fw="bold" hl="s" ms="30">
+          <Inline as="h2" id="modal-02-title" fz="l" fw="bold" hl="s" ms="30">
             <Fragment>Modal Header</Fragment>
           </Inline>
           <Modal.CloseBtn modalId="modal-02" autofocus fz="xl" p="10" mx="15" />
@@ -154,10 +157,10 @@ Modal のベーススタイルは、以下のCSSで定義されています。
     ```jsx '"modal-02"'
     <Modal.OpenBtn modalId="modal-02" className="-bd -px:15 -py:5 -bdrs:10">Open Modal 02</Modal.OpenBtn>
 
-    <Modal.Root id="modal-02" isContainer px="30" py="50">
+    <Modal.Root id="modal-02" aria-labelledby="modal-02-title" isContainer px="30" py="50">
       <Modal.Inner layout="stack" max-sz="s" mx="auto" bdrs="20" bxsh="40">
         <Flex ai="center" jc="between" py="15" bd-b>
-          <Inline fz="l" fw="bold" hl="s" ms="30">
+          <Inline as="h2" id="modal-02-title" fz="l" fw="bold" hl="s" ms="30">
             <Fragment>Modal Header</Fragment>
           </Inline>
           <Modal.CloseBtn modalId="modal-02" autofocus fz="xl" p="10" mx="15" />
@@ -182,13 +185,13 @@ Modal のベーススタイルは、以下のCSSで定義されています。
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html '"modal-02"'
-    <button class="-bd -px:15 -py:5 -bdrs:10 b--modal_openBtn set--plain -hov:-o" data-modal-open="modal-02">Open Modal 02</button>
+    <button class="-bd -px:15 -py:5 -bdrs:10 b--modal_openBtn set--plain -hov:-o" type="button" aria-haspopup="dialog" data-modal-open="modal-02">Open Modal 02</button>
 
-    <dialog class="b--modal set--plain is--container -px:30 -py:50" id="modal-02">
+    <dialog class="b--modal set--plain is--container -px:30 -py:50" id="modal-02" aria-labelledby="modal-02-title">
       <div class="b--modal_inner l--stack -max-sz:s -mx:auto -bdrs:20 -bxsh:40">
         <div class="l--flex -ai:center -jc:between -py:15 -bd-b">
-          <span class="-fz:l -fw:bold -hl:s -ms:30">Modal Header</span>
-          <button class="b--modal_closeBtn set--plain -hov:-o -fz:xl -p:10 -mx:15" data-modal-close="modal-02" autofocus>
+          <h2 class="-fz:l -fw:bold -hl:s -ms:30" id="modal-02-title">Modal Header</h2>
+          <button class="b--modal_closeBtn set--plain -hov:-o -fz:xl -p:10 -mx:15" type="button" data-modal-close="modal-02" autofocus>
             <svg class="a--icon" aria-hidden="true">...</svg>
             <span class="u--srOnly">Close</span>
           </button>
@@ -203,7 +206,7 @@ Modal のベーススタイルは、以下のCSSで定義されています。
           <p>...Contents...</p>
         </div>
         <div class="l--flex -jc:end -px:30 -py:15 -bd-t">
-          <button class="b--modal_closeBtn set--plain -hov:-o -bgc:text -c:base -hl:s -px:15 -py:10 -bd:none -bdrs:10" data-modal-close="modal-02">Cancel</button>
+          <button class="b--modal_closeBtn set--plain -hov:-o -bgc:text -c:base -hl:s -px:15 -py:10 -bd:none -bdrs:10" type="button" data-modal-close="modal-02">Cancel</button>
         </div>
       </div>
     </dialog>
@@ -222,7 +225,7 @@ Modal のベーススタイルは、以下のCSSで定義されています。
       <span>MENU</span>
     </Modal.OpenBtn>
 
-    <Modal.Root id="modal-03">
+    <Modal.Root id="modal-03" aria-label="メニュー">
       <Modal.Inner layout="stack" max-w="24rem" h="100%" bxsh="40" offset="-100px 0">
         <Flex bd-b ai="center" jc="between" p="20">
           <Inline fw="bold">MENU</Inline>
@@ -255,7 +258,7 @@ Modal のベーススタイルは、以下のCSSで定義されています。
       <Icon icon="menu" fz="l" /><span>MENU</span>
     </Modal.OpenBtn>
 
-    <Modal.Root id="modal-03">
+    <Modal.Root id="modal-03" aria-label="メニュー">
       <Modal.Inner layout="stack" max-w="24rem" h="100%" bxsh="40" offset="-100px 0">
         <Flex bd-b ai="center" jc="between" p="20">
           <Inline fw="bold">MENU</Inline>
@@ -285,16 +288,16 @@ Modal のベーススタイルは、以下のCSSで定義されています。
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html '"modal-03"'
-    <button class="b--modal_openBtn set--plain -hov:-o -g:5 -fz:s" data-modal-open="modal-03">
+    <button class="b--modal_openBtn set--plain -hov:-o -g:5 -fz:s" type="button" aria-haspopup="dialog" data-modal-open="modal-03">
       <svg class="a--icon -fz:l" aria-hidden="true">...</svg>
       <span>MENU</span>
     </button>
 
-    <dialog class="b--modal set--plain" id="modal-03">
+    <dialog class="b--modal set--plain" id="modal-03" aria-label="メニュー">
       <div class="b--modal_inner l--stack -max-w -h:100% -bxsh:40" style="--offset:-100px 0;--max-w:24rem">
         <div class="l--flex -bd-b -ai:center -jc:between -p:20">
           <span class="-fw:bold">MENU</span>
-          <button class="b--modal_closeBtn set--plain -hov:-o -fz:xl -p:5" data-modal-close="modal-03" autofocus>
+          <button class="b--modal_closeBtn set--plain -hov:-o -fz:xl -p:5" type="button" data-modal-close="modal-03" autofocus>
             <svg class="a--icon" aria-hidden="true">...</svg>
             <span class="u--srOnly">Close</span>
           </button>

--- a/packages/lism-ui/src/components/Modal/_style.css
+++ b/packages/lism-ui/src/components/Modal/_style.css
@@ -48,4 +48,11 @@
   .b--modal:not([data-is-open]) > .b--modal_inner {
     translate: var(--offset);
   }
+
+  /* 減速設定時はアニメーションを無効化（duration プロップ由来の inline style よりも優先させるため !important） */
+  @media (prefers-reduced-motion: reduce) {
+    .b--modal {
+      --duration: 0s !important;
+    }
+  }
 }

--- a/packages/lism-ui/src/components/Modal/astro/CloseBtn.astro
+++ b/packages/lism-ui/src/components/Modal/astro/CloseBtn.astro
@@ -17,11 +17,11 @@ const { class: className, modalId = '', icon, srText = 'Close', ...props } = Ast
 
 {
   Astro.slots.has('default') ? (
-    <Lism as="button" class={atts(className, 'b--modal_closeBtn')} set="plain" hov="-o" data-modal-close={modalId} {...props}>
+    <Lism as="button" type="button" class={atts(className, 'b--modal_closeBtn')} set="plain" hov="-o" data-modal-close={modalId} {...props}>
       <slot />
     </Lism>
   ) : (
-    <Lism as="button" class={atts(className, 'b--modal_closeBtn')} set="plain" hov="-o" data-modal-close={modalId} {...props}>
+    <Lism as="button" type="button" class={atts(className, 'b--modal_closeBtn')} set="plain" hov="-o" data-modal-close={modalId} {...props}>
       <Icon icon={icon || 'x'} />
       <span class="u--srOnly">{srText || 'Close'}</span>
     </Lism>

--- a/packages/lism-ui/src/components/Modal/astro/OpenBtn.astro
+++ b/packages/lism-ui/src/components/Modal/astro/OpenBtn.astro
@@ -12,6 +12,15 @@ type Props<Tag extends HTMLTag = 'button'> = Polymorphic<{ as: Tag }> &
 const { class: className, modalId = '', ...props } = Astro.props;
 ---
 
-<Lism as="button" class={atts(className, 'b--modal_openBtn')} set="plain" hov="-o" data-modal-open={modalId} {...props}>
+<Lism
+  as="button"
+  type="button"
+  aria-haspopup="dialog"
+  class={atts(className, 'b--modal_openBtn')}
+  set="plain"
+  hov="-o"
+  data-modal-open={modalId}
+  {...props}
+>
   <slot />
 </Lism>

--- a/packages/lism-ui/src/components/Modal/react/CloseBtn.tsx
+++ b/packages/lism-ui/src/components/Modal/react/CloseBtn.tsx
@@ -17,7 +17,15 @@ export default function CloseBtn<T extends ElementType = 'button'>({
   ...props
 }: CloseBtnProps<T>) {
   return (
-    <Lism as="button" className={atts(className, 'b--modal_closeBtn')} set="plain" hov="-o" data-modal-close={modalId} {...(props as object)}>
+    <Lism
+      as="button"
+      type="button"
+      className={atts(className, 'b--modal_closeBtn')}
+      set="plain"
+      hov="-o"
+      data-modal-close={modalId}
+      {...(props as object)}
+    >
       {children ? (
         children
       ) : (

--- a/packages/lism-ui/src/components/Modal/react/OpenBtn.tsx
+++ b/packages/lism-ui/src/components/Modal/react/OpenBtn.tsx
@@ -8,7 +8,16 @@ type OpenBtnProps<T extends ElementType = 'button'> = LismComponentProps<T> & {
 
 export default function OpenBtn<T extends ElementType = 'button'>({ children, className, modalId = '', ...props }: OpenBtnProps<T>) {
   return (
-    <Lism as="button" className={atts(className, 'b--modal_openBtn')} set="plain" hov="-o" data-modal-open={modalId} {...(props as object)}>
+    <Lism
+      as="button"
+      type="button"
+      aria-haspopup="dialog"
+      className={atts(className, 'b--modal_openBtn')}
+      set="plain"
+      hov="-o"
+      data-modal-open={modalId}
+      {...(props as object)}
+    >
       {children}
     </Lism>
   );

--- a/packages/lism-ui/src/components/Modal/setModal.test.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.test.ts
@@ -52,7 +52,7 @@ describe('setEvent (dialog 要素)', () => {
     });
   });
 
-  it('余白クリック（e.target === modal）で閉じる', async () => {
+  it('余白クリック（pointerdown / click ともにターゲットが modal）で閉じる', async () => {
     const modal = document.querySelector<HTMLDialogElement>('#m1')!;
     const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;
     setEvent(modal);
@@ -62,10 +62,51 @@ describe('setEvent (dialog 要素)', () => {
       expect(modal.dataset.isOpen).toBe('1');
     });
 
+    modal.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
     modal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await vi.waitFor(() => {
       expect(modal).not.toHaveAttribute('data-is-open');
       expect(modal).not.toHaveAttribute('open');
+    });
+  });
+
+  it('モーダル内で pointerdown した後の余白 click では閉じない（ドラッグ誤爆防止）', async () => {
+    const modal = document.querySelector<HTMLDialogElement>('#m1')!;
+    const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;
+    const innerBtn = document.querySelector<HTMLElement>('[data-modal-close="m1"]')!;
+    setEvent(modal);
+
+    trigger.click();
+    await vi.waitFor(() => {
+      expect(modal.dataset.isOpen).toBe('1');
+    });
+
+    // モーダル内でドラッグ（テキスト選択等）を開始し、余白で離して click のターゲットが modal になったケース
+    innerBtn.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    modal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+
+    expect(modal.dataset.isOpen).toBe('1');
+    expect(modal).toHaveAttribute('open');
+  });
+
+  it('closeDialog を経由せず閉じられた場合（form method="dialog" 等）も後始末される', async () => {
+    const modal = document.querySelector<HTMLDialogElement>('#m1')!;
+    const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;
+    setEvent(modal);
+
+    trigger.click();
+    await vi.waitFor(() => {
+      expect(modal.dataset.isOpen).toBe('1');
+    });
+
+    // closeDialog() を経由しないネイティブの close()（form method="dialog" の送信相当）
+    modal.close();
+
+    await vi.waitFor(() => {
+      expect(modal).not.toHaveAttribute('data-is-open');
+      expect(modal).not.toHaveAttribute('open');
+      expect(trigger.dataset.targetOpened).toBeUndefined();
     });
   });
 
@@ -122,8 +163,16 @@ describe('setEvent (dialog 要素)', () => {
   });
 });
 
-describe('setEvent (非 dialog 要素)', () => {
-  it('open/close が open 属性ベースで動作する', async () => {
+describe('setEvent (早期 return ケース)', () => {
+  it('id が無い modal は何もしない', () => {
+    document.body.innerHTML = `<dialog class="b--modal"></dialog>`;
+    const modal = document.querySelector<HTMLDialogElement>('dialog')!;
+
+    setEvent(modal);
+    expect(modal).not.toHaveAttribute('open');
+  });
+
+  it('dialog 以外の要素はサポートせず、イベントを登録しない', async () => {
     document.body.innerHTML = `
       <div id="m2" class="b--modal">
         <button data-modal-close="m2"></button>
@@ -135,27 +184,10 @@ describe('setEvent (非 dialog 要素)', () => {
     setEvent(modal);
 
     trigger.click();
-    // open 属性は同期で付くが、closeDialog は data-is-open を見て早期 return するため、
-    // rAF での data-is-open 付与まで待ってから閉じる
-    await vi.waitFor(() => {
-      expect(modal).toHaveAttribute('open');
-      expect(modal.dataset.isOpen).toBe('1');
-    });
+    await Promise.resolve();
 
-    document.querySelector<HTMLElement>('[data-modal-close="m2"]')!.click();
-    await vi.waitFor(() => {
-      expect(modal).not.toHaveAttribute('open');
-    });
-  });
-});
-
-describe('setEvent (早期 return ケース)', () => {
-  it('id が無い modal は何もしない', () => {
-    document.body.innerHTML = `<dialog class="b--modal"></dialog>`;
-    const modal = document.querySelector<HTMLDialogElement>('dialog')!;
-
-    setEvent(modal);
     expect(modal).not.toHaveAttribute('open');
+    expect(modal.dataset.isOpen).toBeUndefined();
   });
 });
 

--- a/packages/lism-ui/src/components/Modal/setModal.test.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.test.ts
@@ -110,6 +110,25 @@ describe('setEvent (dialog 要素)', () => {
     });
   });
 
+  it('開いた直後（data-is-open 付与前）に閉じられた場合、次フレーム以降も data-is-open は付かない', async () => {
+    const modal = document.querySelector<HTMLDialogElement>('#m1')!;
+    const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;
+    setEvent(modal);
+
+    // open の rAF が実行される前に、closeDialog() を経由しない close() が走るケース
+    trigger.click();
+    modal.close();
+
+    // rAF を2フレーム分待って、保留中の rAF が属性を戻していないことを確認する
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+
+    expect(modal).not.toHaveAttribute('data-is-open');
+    expect(modal).not.toHaveAttribute('open');
+    expect(trigger.dataset.targetOpened).toBeUndefined();
+  });
+
   it('cancel イベントで preventDefault され、closeDialog が走る', async () => {
     const modal = document.querySelector<HTMLDialogElement>('#m1')!;
     const trigger = document.querySelector<HTMLElement>('[data-modal-open="m1"]')!;

--- a/packages/lism-ui/src/components/Modal/setModal.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.ts
@@ -67,7 +67,11 @@ export function setEvent(target: HTMLElement): void {
     modal.showModal();
 
     // 次フレームで data-is-open を付与（CSS側でフェードインアニメーション開始）
+    //   Point: rAF が実行されるまでの間に閉じられている場合があるため、開いていることを確認してから付与する。
+    //          close イベントは task としてキューされるので、開いた直後の close() では
+    //          後始末（close ハンドラでの data-is-open 削除）が先に走り、この rAF が属性を戻してしまう
     requestAnimationFrame(() => {
+      if (!modal.open) return;
       modal.dataset.isOpen = '1';
     });
   };

--- a/packages/lism-ui/src/components/Modal/setModal.ts
+++ b/packages/lism-ui/src/components/Modal/setModal.ts
@@ -37,11 +37,14 @@ const unlockScrollbarGutter = (): void => {
 /**
  * モーダルの開閉イベントを設定する
  */
-export function setEvent(modal: HTMLElement): void {
-  // modalがない、またはidがない場合は処理を終了
-  if (!modal || !modal.id) return;
+export function setEvent(target: HTMLElement): void {
+  // 対象がない、またはidがない場合は処理を終了
+  if (!target || !target.id) return;
 
-  const isDialog = modal instanceof HTMLDialogElement;
+  // フォーカストラップ・背景のinert化・Escクローズ等をネイティブ dialog に依存しているため、dialog 要素のみサポートする
+  if (!(target instanceof HTMLDialogElement)) return;
+
+  const modal = target;
 
   // オープンした時のトリガー要素を記憶する（data属性を戻すため）
   let theTrigger: HTMLElement | null = null;
@@ -60,13 +63,8 @@ export function setEvent(modal: HTMLElement): void {
     // その間の連打で showModal() が二重に呼ばれてしまう（dialog では InvalidStateError になる）
     if (modal.hasAttribute('open')) return;
 
-    // dialog 要素なら showModal()、それ以外は open 属性を付与
-    if (isDialog) {
-      lockScrollbarGutter(); // showModal() でスクロールバーが消える前にスクロールバー幅を予約する
-      modal.showModal();
-    } else {
-      modal.setAttribute('open', '');
-    }
+    lockScrollbarGutter(); // showModal() でスクロールバーが消える前にスクロールバー幅を予約する
+    modal.showModal();
 
     // 次フレームで data-is-open を付与（CSS側でフェードインアニメーション開始）
     requestAnimationFrame(() => {
@@ -90,13 +88,9 @@ export function setEvent(modal: HTMLElement): void {
     // アニメーション完了を待機
     await waitAnimation(modal);
 
-    // アニメーション終了後、dialog を閉じる（open属性の削除）
-    if (isDialog) {
-      modal.close();
-      unlockScrollbarGutter(); // close() の後に scrollbar-gutter を復元する
-    } else {
-      modal.removeAttribute('open');
-    }
+    // アニメーション終了後、dialog を閉じる
+    modal.close();
+    unlockScrollbarGutter(); // close() の後に scrollbar-gutter を復元する
   };
 
   // openボタンにイベント登録
@@ -119,27 +113,36 @@ export function setEvent(modal: HTMLElement): void {
   });
 
   // 余白クリックで閉じる
+  //   Point: click だけで判定すると、モーダル内で開始したドラッグ（テキスト選択等）を余白で離した場合にも
+  //          click のターゲットが共通祖先の modal になって閉じてしまうため、pointerdown の発生位置も併せて見る
+  let isPointerDownOnBackdrop = false;
+  modal.addEventListener('pointerdown', (e) => {
+    isPointerDownOnBackdrop = e.target === modal;
+  });
   modal.addEventListener('click', (e) => {
-    if (e.target === modal) {
+    if (isPointerDownOnBackdrop && e.target === modal) {
       void closeDialog();
+    }
+    isPointerDownOnBackdrop = false;
+  });
+
+  // close 完了時の後処理。dialog はどの経路で閉じても close イベントが発火するため、
+  // <form method="dialog"> の送信など closeDialog() を経由しないクローズでも
+  // data-is-open の削除と scrollbar-gutter の復元が漏れないようにする（いずれも冪等）
+  modal.addEventListener('close', () => {
+    modal.removeAttribute('data-is-open');
+    unlockScrollbarGutter();
+    if (theTrigger) {
+      theTrigger.removeAttribute('data-target-opened');
+      theTrigger = null;
     }
   });
 
-  if (isDialog) {
-    // close() 完了時にトリガーのdata属性をリセット（dialog専用イベント）
-    modal.addEventListener('close', () => {
-      if (theTrigger) {
-        theTrigger.removeAttribute('data-target-opened');
-        theTrigger = null;
-      }
-    });
-
-    // ESCキーで閉じた時もアニメーションを実行する処理（dialog専用イベント）
-    modal.addEventListener('cancel', (e) => {
-      e.preventDefault(); // デフォルトの即時 close() を防ぐ
-      void closeDialog(); // 自分で用意したクローズ処理
-    });
-  }
+  // ESCキーで閉じた時もアニメーションを実行する処理
+  modal.addEventListener('cancel', (e) => {
+    e.preventDefault(); // デフォルトの即時 close() を防ぐ
+    void closeDialog(); // 自分で用意したクローズ処理
+  });
 }
 
 const setModal = () => {


### PR DESCRIPTION
## 概要

Modalコンポーネントのアクセシビリティ改善をまとめて対応します。対応方針はIssueの本文・コメントで確定済みの内容に従っています。

Closes #555

## 変更内容

### コンポーネント（@lism-css/ui）

- `Modal.OpenBtn` / `Modal.CloseBtn`（React / Astro）に`type="button"`をデフォルト付与。`<form>`内に配置した場合の意図しないsubmitを防ぎます（propsで上書き可能）
- `Modal.OpenBtn`に`aria-haspopup="dialog"`をデフォルト付与
- `setEvent`の非dialog要素サポートを廃止し、`dialog`以外の要素は早期returnに変更。フォーカストラップ・背景のinert化・Escクローズ等をネイティブ`dialog`に依存しているため（リポジトリ内に非dialog使用例なし。CSSも`::backdrop`等dialog前提）
- 余白クリックで閉じる判定に`pointerdown`の発生位置を追加。モーダル内でテキスト選択などのドラッグを開始して余白で離した場合に、意図せず閉じてしまう問題を修正
- `close`イベントリスナーで`data-is-open`の削除と`scrollbar-gutter`の復元を実行。`<form method="dialog">`の送信など`closeDialog()`を経由しないクローズでも後始末が漏れないようにしました（いずれも冪等）

### CSS

- `prefers-reduced-motion: reduce`時は`--duration: 0s !important`で開閉アニメーションを無効化（`duration`プロップ由来のinline styleより優先させるため`!important`を使用）

### docs（ja / en）

- 全サンプルにアクセシブルネームを追加
  - modal-01 / modal-02: タイトルを`h2`化し、`aria-labelledby`で紐付け
  - modal-03（ドロワー）: `aria-label`を指定（視覚的タイトルを持たない場合の例）
- Overviewのnoteにアクセシブルネーム指定の案内を追記
- Propsテーブルに`Modal.CloseBtn`の`icon` / `srText`を追記（日本語版では`srText="閉じる"`の指定を推奨）
- HTMLサンプルにも`type="button"` / `aria-haspopup="dialog"`を反映

### テスト

- 非dialog要素のテストを「イベントを登録しない」ことの確認に変更
- ドラッグ誤爆防止・`closeDialog()`を経由しないクローズ時の後始末のテストを追加

## 動作確認

- `nr lint` / `nr test`（11件を含む全テスト） / `nr build:ui` / `nr build:docs` すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBQpTn3RBoNGKDE3oz3gMn
