### PR TITLE
Fix: next の watch テストを決定的方式へ

### DIFF
--- a/packages/plugin/src/builder/next.test.ts
+++ b/packages/plugin/src/builder/next.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterAll, describe, expect, test } from 'vitest';
+import type { ConfigWatcher, WatchLismConfigOptions } from './config-watcher';
 import { withLism } from './next';
 
 // withLism は受け取った config 型 `T` をそのまま返すため、`{}` を渡すと turbopack/webpack が型に現れない。
@@ -96,22 +97,27 @@ describe('withLism', () => {
     const configPath = path.join(root, 'lism.config.js');
     fs.writeFileSync(configPath, 'export default { props: { myz: { prop: "zIndex", utils: { "9": "9" } } } };\n');
 
-    // dev フェーズで起動 → 初回生成 + watcher 起動（watcher は unref 済みなのでプロセスを保持しない）。
-    await withLism({}, { projectRoot: root })('phase-development-server');
+    // 実 fs.watch / debounce には頼らず、webpack.test.ts と同じくコールバックを捕捉して直接発火する。
+    let captured: WatchLismConfigOptions | undefined;
+    const watchConfig = (opts: WatchLismConfigOptions): ConfigWatcher => {
+      captured = opts;
+      return { close() {} };
+    };
+
+    await withLism({}, { projectRoot: root, watchConfig })('phase-development-server');
+    expect(captured?.configPath).toBe(configPath);
+    expect(typeof captured?.onChange).toBe('function');
+
     const dtsPath = path.join(root, 'lism-env.d.ts');
     const before = fs.readFileSync(dtsPath, 'utf8');
 
-    // config を変更（別 custom prop を追加）→ watcher が型を再生成して内容が変わるはず。
+    // config を変更（別 custom prop を追加）→ onChange が型を再生成して内容が変わる。
     fs.writeFileSync(
       configPath,
       'export default { props: { myz: { prop: "zIndex", utils: { "9": "9" } }, myw: { prop: "width", utils: { x: "10px" } } } };\n'
     );
 
-    // 各再生成は SCSS コンパイルを伴い重い。初回 + (FSEvents エコー) + 実変更の再生成が積み上がるため余裕を持たせる。
-    const start = Date.now();
-    while (Date.now() - start < 16000 && fs.readFileSync(dtsPath, 'utf8') === before) {
-      await new Promise((r) => setTimeout(r, 50));
-    }
+    await captured?.onChange();
     expect(fs.readFileSync(dtsPath, 'utf8')).not.toBe(before);
-  }, 20000);
+  }, 15000);
 });

--- a/packages/plugin/src/builder/next.ts
+++ b/packages/plugin/src/builder/next.ts
@@ -23,7 +23,7 @@ import path from 'node:path';
 import { generateCssToDir } from './generated-css';
 import { buildWebpackAlias, buildTurbopackAlias } from './webpack-alias';
 import { syncLismEnvDts } from './typegen';
-import { watchLismConfig } from './config-watcher';
+import { watchLismConfig, type ConfigWatcher, type WatchLismConfigOptions } from './config-watcher';
 
 /** Next.js の dev サーバーフェーズ識別子（`next/constants` の PHASE_DEVELOPMENT_SERVER。next 非依存にするため直書き）。 */
 const PHASE_DEVELOPMENT_SERVER = 'phase-development-server';
@@ -41,6 +41,11 @@ export interface WithLismOptions {
   typegen?: boolean;
   /** full.css / full_no_layer.css も生成するか（既定: false。purge 併用時に有効化）。 */
   full?: boolean;
+  /**
+   * lism.config 監視の実装。未指定時は `watchLismConfig`。
+   * テストから差し替えて、実 `fs.watch` を介さず `onChange` を直接発火するために使う。
+   */
+  watchConfig?: (opts: WatchLismConfigOptions) => ConfigWatcher;
 }
 
 /** Turbopack 設定の最小構造（next 非依存。実際の型は `T` 側に従う）。 */
@@ -82,7 +87,8 @@ export function withLism<T extends Record<string, any>>(nextConfig?: T, opts?: W
     if (phase === PHASE_DEVELOPMENT_SERVER && generated.userConfigPath && !watchedConfigs.has(generated.userConfigPath)) {
       const userConfigPath = generated.userConfigPath;
       watchedConfigs.add(userConfigPath);
-      watchLismConfig({
+      const watch = opts?.watchConfig ?? watchLismConfig;
+      watch({
         configPath: userConfigPath,
         onChange: async () => {
           await generateCssToDir({ projectRoot, outDir, configPath: opts?.configPath, full: opts?.full ?? false, minify: false });


### PR DESCRIPTION
## Summary

- `withLism` に `watchConfig` 差し替え経路を追加し、dev フェーズの config 監視をテストから注入できるようにした
- `next.test.ts` の watch テストを実 `fs.watch` + ポーリングから、webpack テストと同じ「コールバックを捕捉して直接発火」する決定的方式へ置き換えた
- `turbo run test` 並列時にタイムアウトしていた flaky を解消する（Phase 1）

Part of #551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - FAQとHeroの新しいパターン例を追加しました。
  - パターン・ページレイアウト一覧に説明文、関連リンク、カテゴリ別アンカーを追加しました。
  - パターン詳細ページから関連カテゴリやページへ移動できるようになりました。
- **改善**
  - FAQとHeroの作例をパターンページへ整理しました。
  - FAQ・Heroを含む旧URLから新しい掲載先へ適切に移動できるようになりました。
  - Hero002を下書きとして表示します。
- **ドキュメント**
  - Heroの説明を更新し、対応範囲を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->