### PR TITLE
Add: plugin/mockup の CLI smoke テストと turbo build 依存

### DIFF
--- a/packages/mockup/src/cli.test.ts
+++ b/packages/mockup/src/cli.test.ts
@@ -1,0 +1,84 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { afterAll, describe, expect, test } from 'vitest';
+
+import { resolveGeneratedConfigDir, resolveViteCacheDir } from './core/runtime.js';
+import { cleanupTempDirs, createDataDir, MOCKUP_CONFIG, PLAIN_PAGE } from './test-helpers/fixtures.js';
+
+const execFileAsync = promisify(execFile);
+const cliPath = fileURLToPath(new URL('../bin/lism-mockup.mjs', import.meta.url));
+const distEntry = fileURLToPath(new URL('../dist/index.js', import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8')) as { version: string };
+const distReady = fs.existsSync(distEntry);
+
+const checkedDirs: string[] = [];
+
+type CliResult = { code: number; stdout: string; stderr: string };
+
+async function runCli(args: string[], cwd?: string): Promise<CliResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [cliPath, ...args], {
+      cwd,
+      encoding: 'utf8',
+    });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const err = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: typeof err.code === 'number' ? err.code : 1, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  }
+}
+
+const ANSI_CSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_CSI, '');
+}
+
+afterAll(() => {
+  for (const dir of checkedDirs) {
+    if (!fs.existsSync(dir)) continue;
+    const real = fs.realpathSync(dir);
+    for (const shared of [resolveViteCacheDir(real), resolveGeneratedConfigDir(real)]) {
+      fs.rmSync(shared, { recursive: true, force: true });
+    }
+  }
+  cleanupTempDirs();
+});
+
+describe.skipIf(!distReady)('bin/lism-mockup.mjs', () => {
+  test('--version は終了コード 0 でバージョンを出す', async () => {
+    const result = await runCli(['--version']);
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim()).toBe(pkg.version);
+  });
+
+  test('未知サブコマンドは終了コード 1', async () => {
+    const result = await runCli(['not-a-command']);
+    expect(result.code).toBe(1);
+    expect(stripAnsi(result.stderr)).toMatch(/unknown command/i);
+  });
+
+  test('不正なデータディレクトリへの check は終了コード 1 で at 付きエラーを出す', async () => {
+    const dir = createDataDir({});
+    const result = await runCli(['check', dir]);
+    expect(result.code).toBe(1);
+    const stderr = stripAnsi(result.stderr);
+    expect(stderr).toContain('[lism-mockup]');
+    expect(stderr).toMatch(/mockup\.config\.json not found/);
+    expect(stderr).toContain(`at ${path.join(dir, 'mockup.config.json')}`);
+  });
+
+  test('正しいデータディレクトリへの check は終了コード 0', async () => {
+    const dir = createDataDir({
+      'mockup.config.json': MOCKUP_CONFIG,
+      'pages/home.jsx': PLAIN_PAGE,
+    });
+    checkedDirs.push(dir);
+
+    const result = await runCli(['check', dir]);
+    expect(result.code).toBe(0);
+    expect(stripAnsi(result.stdout)).toContain('check passed');
+  }, 60_000);
+});

--- a/packages/plugin/src/cli.test.ts
+++ b/packages/plugin/src/cli.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { afterAll, describe, expect, test } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const cliPath = fileURLToPath(new URL('../bin/cli.mjs', import.meta.url));
+const distEntry = fileURLToPath(new URL('../dist/builder/index.js', import.meta.url));
+const distReady = fs.existsSync(distEntry);
+
+const dirs: string[] = [];
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-plugin-cli-'));
+  dirs.push(dir);
+  return dir;
+}
+afterAll(() => dirs.forEach((d) => fs.rmSync(d, { recursive: true, force: true })));
+
+type CliResult = { code: number; stdout: string; stderr: string };
+
+async function runCli(args: string[], cwd: string): Promise<CliResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [cliPath, ...args], { cwd, encoding: 'utf8' });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const err = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: typeof err.code === 'number' ? err.code : 1, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  }
+}
+
+function cssDistDir(): string {
+  return path.dirname(fileURLToPath(import.meta.resolve('lism-css/main.css')));
+}
+
+/** CLI が書き込む共有 dist/css をテスト後に戻す。 */
+function withCssDistBackup<T>(fn: (cssDir: string) => Promise<T>): Promise<T> {
+  const cssDir = cssDistDir();
+  const backup = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-css-dist-backup-'));
+  fs.cpSync(cssDir, backup, { recursive: true });
+  return fn(cssDir).finally(() => {
+    fs.rmSync(cssDir, { recursive: true, force: true });
+    fs.cpSync(backup, cssDir, { recursive: true });
+    fs.rmSync(backup, { recursive: true, force: true });
+  });
+}
+
+describe.skipIf(!distReady)('bin/cli.mjs', () => {
+  test('サブコマンド無しなら Usage を出して終了コード 0', async () => {
+    const result = await runCli([], tmpDir());
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Usage: lism-css <command> [options]');
+    expect(result.stdout).toContain('build');
+  });
+
+  test('未知サブコマンドは stderr に出して終了コード 1', async () => {
+    const result = await runCli(['not-a-command'], tmpDir());
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('Unknown command: not-a-command');
+  });
+
+  test('build は主要 CSS を minify して生成する', async () => {
+    await withCssDistBackup(async (cssDir) => {
+      const result = await runCli(['build'], tmpDir());
+      expect(result.code).toBe(0);
+      expect(result.stdout).toMatch(/compileCssTree\] \d+ entries/);
+
+      const mainCss = fs.readFileSync(path.join(cssDir, 'main.css'), 'utf8');
+      expect(mainCss.length).toBeGreaterThan(100);
+      // minify: true（cssnano）経路。expanded の 2 スペースインデントは残らない。
+      expect(mainCss).not.toContain('\n  ');
+    });
+  }, 60_000);
+
+  test('--full なら full.css / full_no_layer.css も生成する', async () => {
+    await withCssDistBackup(async (cssDir) => {
+      const withoutFull = await runCli(['build'], tmpDir());
+      expect(withoutFull.code).toBe(0);
+      const withoutCount = Number(/compileCssTree\] (\d+) entries/.exec(withoutFull.stdout)?.[1]);
+
+      const withFull = await runCli(['build', '--full'], tmpDir());
+      expect(withFull.code).toBe(0);
+      const withCount = Number(/compileCssTree\] (\d+) entries/.exec(withFull.stdout)?.[1]);
+
+      expect(withoutCount).toBeGreaterThan(0);
+      expect(withCount).toBeGreaterThan(withoutCount);
+      expect(fs.existsSync(path.join(cssDir, 'full.css'))).toBe(true);
+      expect(fs.existsSync(path.join(cssDir, 'full_no_layer.css'))).toBe(true);
+    });
+  }, 60_000);
+});

--- a/turbo.json
+++ b/turbo.json
@@ -41,6 +41,14 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
+    "@lism-css/plugin#test": {
+      "dependsOn": ["build", "^build"],
+      "outputs": []
+    },
+    "@lism-css/mockup#test": {
+      "dependsOn": ["build", "^build"],
+      "outputs": []
+    },
     "lint": {
       "outputs": []
     },


### PR DESCRIPTION
## Summary

- `@lism-css/plugin` の公開 CLI（`bin/cli.mjs`）に smoke テストを追加した（Usage / 未知コマンド / `build` / `--full`）。`build` は既定の `minify: true` 経路も通る
- `@lism-css/mockup` の公開 CLI（`bin/lism-mockup.mjs`）に smoke テストを追加した（`--version` / 未知コマンド / `check` の終了コード 0・1）
- turbo の `test` タスクに両パッケージ自身の `build` 依存を足し、`dist` 経由の CLI テストがビルド成果物を前提に走るようにした

Part of #551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - FAQとHeroの新しいパターンプレビューを追加しました。
  - パターン一覧・詳細ページにカテゴリ説明、関連リンク、アンカーを表示します。
  - ページレイアウトにも関連ページへのリンクを追加しました。

- **ドキュメント**
  - FAQとHeroの作例をパターンページへ整理しました。
  - FAQパターンに、通常表示とアコーディオン表示の例を追加しました。
  - Heroパターンに、フルスクリーン型と2カラム型の例を追加しました。

- **改善**
  - 下書き中のパターンを一覧上で識別できるようにしました。
  - 関連ページへのリダイレクト先を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->