### PR TITLE
Add: Vite/Astro フックと known 自動構築のテスト

### DIFF
--- a/packages/plugin/src/builder/shared.test.ts
+++ b/packages/plugin/src/builder/shared.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, describe, expect, test } from 'vitest';
+import { buildConfigAwareKnown } from './shared';
+
+const dirs: string[] = [];
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-known-'));
+  dirs.push(dir);
+  return dir;
+}
+afterAll(() => dirs.forEach((d) => fs.rmSync(d, { recursive: true, force: true })));
+
+describe('buildConfigAwareKnown', () => {
+  test('custom prop 由来のクラスを known に含める', async () => {
+    const root = tmpDir();
+    fs.writeFileSync(path.join(root, 'lism.config.js'), 'export default { props: { myz: { prop: "zIndex", utils: { "9": "9" } } } };\n');
+
+    const known = await buildConfigAwareKnown(root);
+    expect(known).toBeDefined();
+    expect([...known!.classes].some((cls) => cls.startsWith('-myz'))).toBe(true);
+  }, 15000);
+
+  test('壊れた config では例外を漏らさず undefined を返す', async () => {
+    const root = tmpDir();
+    fs.writeFileSync(path.join(root, 'lism.config.js'), 'export default { this is not valid javascript');
+
+    await expect(buildConfigAwareKnown(root)).resolves.toBeUndefined();
+  });
+});

--- a/packages/plugin/src/builder/vite.test.ts
+++ b/packages/plugin/src/builder/vite.test.ts
@@ -2,11 +2,13 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { describe, expect, test, vi } from 'vitest';
 import type { Plugin } from 'vite';
 import { lismCss } from './vite';
 import { lismCss as lismCssForAstro } from './astro';
 import { lismConfigAlias } from './vite-config-alias';
+import { lismTypegen } from './vite-typegen';
 
 type ConfigReturn = { optimizeDeps: { exclude: string[] }; resolve?: { alias: Record<string, string> } };
 
@@ -17,6 +19,19 @@ function callConfigHook(plugin: Plugin, root: string): ConfigReturn {
     e: { command: string; mode: string }
   ) => ConfigReturn;
   return fn({ root }, { command: 'serve', mode: 'development' });
+}
+
+function getHook(plugin: Plugin, name: keyof Plugin): (...args: never[]) => unknown {
+  const hook = plugin[name];
+  const fn = typeof hook === 'function' ? hook : (hook as { handler?: (...args: never[]) => unknown } | undefined)?.handler;
+  if (!fn) throw new Error(`${String(name)} hook not found`);
+  return fn as (...args: never[]) => unknown;
+}
+
+function writeUserConfig(root: string): string {
+  const configPath = path.join(root, 'lism.config.js');
+  fs.writeFileSync(configPath, 'export default { props: { myz: { prop: "zIndex", utils: { "9": "9" } } } };\n');
+  return configPath;
 }
 
 describe('lismCss (umbrella / vite)', () => {
@@ -106,5 +121,172 @@ describe('lismCss (integrated / astro)', () => {
 
   test('purge:true: lism-css + purge integration', () => {
     expect(lismCssForAstro({ purge: true }).map((i) => i.name)).toEqual(['lism-css', 'lism-css:purge']);
+  });
+
+  test('astro:config:setup は root を解決し Vite プラグイン 3 つを渡す', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-astro-'));
+    writeUserConfig(tmp);
+    const updateConfig = vi.fn();
+    try {
+      const setup = lismCssForAstro()[0];
+      await setup.hooks['astro:config:setup']?.({
+        config: { root: pathToFileURL(tmp) },
+        updateConfig,
+      } as never);
+
+      expect(updateConfig).toHaveBeenCalledTimes(1);
+      const plugins = (updateConfig.mock.calls[0][0] as { vite: { plugins: Plugin[] } }).vite.plugins;
+      expect(plugins.map((p) => p.name)).toEqual(['lism-css:config-alias', 'lism-css:typegen', 'lism-css:css']);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('astro:build:start は known を構築しても例外を投げない', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-astro-'));
+    writeUserConfig(tmp);
+    try {
+      const setup = lismCssForAstro({ purge: true })[0];
+      await setup.hooks['astro:config:setup']?.({
+        config: { root: pathToFileURL(tmp) },
+        updateConfig: vi.fn(),
+      } as never);
+      await expect(setup.hooks['astro:build:start']?.({} as never)).resolves.toBeUndefined();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 15000);
+});
+
+describe('lismTypegen hooks', () => {
+  test('buildStart は custom prop 設定で lism-env.d.ts を生成する', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-typegen-'));
+    writeUserConfig(tmp);
+    try {
+      const plugin = lismTypegen();
+      getHook(plugin, 'configResolved')({ root: tmp } as never);
+      await getHook(plugin, 'buildStart')();
+      expect(fs.existsSync(path.join(tmp, 'lism-env.d.ts'))).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('disabled のとき buildStart は .d.ts を書かない', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-typegen-'));
+    writeUserConfig(tmp);
+    try {
+      const plugin = lismTypegen({ disabled: true });
+      getHook(plugin, 'configResolved')({ root: tmp } as never);
+      await getHook(plugin, 'buildStart')();
+      expect(fs.existsSync(path.join(tmp, 'lism-env.d.ts'))).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('handleHotUpdate は lism.config 変更で型を再生成する', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-typegen-'));
+    const configPath = writeUserConfig(tmp);
+    try {
+      const plugin = lismTypegen();
+      getHook(plugin, 'configResolved')({ root: tmp } as never);
+      await getHook(plugin, 'buildStart')();
+      const dtsPath = path.join(tmp, 'lism-env.d.ts');
+      const before = fs.readFileSync(dtsPath, 'utf8');
+
+      fs.writeFileSync(
+        configPath,
+        'export default { props: { myz: { prop: "zIndex", utils: { "9": "9" } }, myw: { prop: "width", utils: { x: "10px" } } } };\n'
+      );
+      await getHook(plugin, 'handleHotUpdate')({ file: configPath } as never);
+      expect(fs.readFileSync(dtsPath, 'utf8')).not.toBe(before);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('lismConfigAlias handleHotUpdate', () => {
+  test('lism.config 変更時は full-reload を送り空配列を返す', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-alias-'));
+    const configPath = writeUserConfig(tmp);
+    try {
+      const plugin = lismConfigAlias();
+      callConfigHook(plugin, tmp);
+      const send = vi.fn();
+      const result = getHook(plugin, 'handleHotUpdate')({ file: configPath, server: { ws: { send } } } as never);
+      expect(send).toHaveBeenCalledWith({ type: 'full-reload' });
+      expect(result).toEqual([]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('無関係なファイルでは何もしない', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-alias-'));
+    writeUserConfig(tmp);
+    try {
+      const plugin = lismConfigAlias();
+      callConfigHook(plugin, tmp);
+      const send = vi.fn();
+      const result = getHook(
+        plugin,
+        'handleHotUpdate'
+      )({
+        file: path.join(tmp, 'unrelated.ts'),
+        server: { ws: { send } },
+      } as never);
+      expect(send).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('lismCss known / purge hooks', () => {
+  test('known プラグインの buildStart は custom prop を known に載せる', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-known-'));
+    writeUserConfig(tmp);
+    try {
+      const plugins = lismCss({ purge: true });
+      const knownPlugin = plugins.find((p) => p.name === 'lism-css:known');
+      if (!knownPlugin) throw new Error('lism-css:known not found');
+      getHook(knownPlugin, 'configResolved')({ root: tmp } as never);
+      await expect(getHook(knownPlugin, 'buildStart')()).resolves.toBeUndefined();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  test('knownRef 未設定時はデフォルト known へ落ち、未使用クラスを purge する', async () => {
+    const plugins = lismCss({ purge: true });
+    const purge = plugins.find((p) => p.name === 'lism-css:purge');
+    if (!purge) throw new Error('lism-css:purge not found');
+
+    const bundle: Record<string, unknown> = {
+      'assets/main.css': {
+        type: 'asset',
+        fileName: 'assets/main.css',
+        source: '.-p\\:20{padding:var(--s20)}.-m\\:10{margin:var(--s10)}',
+      },
+      'assets/app.js': {
+        type: 'chunk',
+        fileName: 'assets/app.js',
+        code: 'const cls = "-p:20";',
+      },
+    };
+    const ctx = { info: vi.fn(), warn: vi.fn() };
+    await (getHook(purge, 'generateBundle') as (this: unknown, opts: unknown, bundle: unknown, isWrite: boolean) => unknown).call(
+      ctx,
+      {},
+      bundle,
+      false
+    );
+
+    const source = (bundle['assets/main.css'] as { source: string }).source;
+    expect(source).toContain('-p\\:20');
+    expect(source).not.toContain('-m\\:10');
   });
 });

--- a/packages/plugin/src/builder/vite.test.ts
+++ b/packages/plugin/src/builder/vite.test.ts
@@ -34,6 +34,38 @@ function writeUserConfig(root: string): string {
   return configPath;
 }
 
+/** 使用中の既定クラス + 未使用の custom prop クラス。後者はデフォルト known には無い。 */
+const CUSTOM_PROP_CSS = '.-p\\:20{padding:var(--s20)}.-myz\\:9{z-index:9}';
+
+function makeCssBundle(css = CUSTOM_PROP_CSS): Record<string, unknown> {
+  return {
+    'assets/main.css': {
+      type: 'asset',
+      fileName: 'assets/main.css',
+      source: css,
+    },
+    'assets/app.js': {
+      type: 'chunk',
+      fileName: 'assets/app.js',
+      code: 'const cls = "-p:20";',
+    },
+  };
+}
+
+async function callGenerateBundle(purge: Plugin, bundle: Record<string, unknown>): Promise<void> {
+  const ctx = { info: vi.fn(), warn: vi.fn() };
+  await (getHook(purge, 'generateBundle') as (this: unknown, opts: unknown, bundle: unknown, isWrite: boolean) => unknown).call(
+    ctx,
+    {},
+    bundle,
+    false
+  );
+}
+
+function cssSource(bundle: Record<string, unknown>): string {
+  return (bundle['assets/main.css'] as { source: string }).source;
+}
+
 describe('lismCss (umbrella / vite)', () => {
   test('purge なし: config alias + typegen + CSS ビルドの3プラグイン', () => {
     expect(lismCss().map((p) => p.name)).toEqual(['lism-css:config-alias', 'lism-css:typegen', 'lism-css:css']);
@@ -141,21 +173,6 @@ describe('lismCss (integrated / astro)', () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
-
-  test('astro:build:start は known を構築しても例外を投げない', async () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-astro-'));
-    writeUserConfig(tmp);
-    try {
-      const setup = lismCssForAstro({ purge: true })[0];
-      await setup.hooks['astro:config:setup']?.({
-        config: { root: pathToFileURL(tmp) },
-        updateConfig: vi.fn(),
-      } as never);
-      await expect(setup.hooks['astro:build:start']?.({} as never)).resolves.toBeUndefined();
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
-  }, 15000);
 });
 
 describe('lismTypegen hooks', () => {
@@ -246,15 +263,28 @@ describe('lismConfigAlias handleHotUpdate', () => {
 });
 
 describe('lismCss known / purge hooks', () => {
-  test('known プラグインの buildStart は custom prop を known に載せる', async () => {
+  test('buildStart 前は custom クラスを unknown として残し、後は purge する', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-known-'));
     writeUserConfig(tmp);
     try {
       const plugins = lismCss({ purge: true });
       const knownPlugin = plugins.find((p) => p.name === 'lism-css:known');
+      const purge = plugins.find((p) => p.name === 'lism-css:purge');
       if (!knownPlugin) throw new Error('lism-css:known not found');
+      if (!purge) throw new Error('lism-css:purge not found');
+
+      const before = makeCssBundle();
+      await callGenerateBundle(purge, before);
+      expect(cssSource(before)).toContain('-p\\:20');
+      expect(cssSource(before)).toContain('-myz\\:9');
+
       getHook(knownPlugin, 'configResolved')({ root: tmp } as never);
-      await expect(getHook(knownPlugin, 'buildStart')()).resolves.toBeUndefined();
+      await getHook(knownPlugin, 'buildStart')();
+
+      const after = makeCssBundle();
+      await callGenerateBundle(purge, after);
+      expect(cssSource(after)).toContain('-p\\:20');
+      expect(cssSource(after)).not.toContain('-myz\\:9');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -265,28 +295,59 @@ describe('lismCss known / purge hooks', () => {
     const purge = plugins.find((p) => p.name === 'lism-css:purge');
     if (!purge) throw new Error('lism-css:purge not found');
 
-    const bundle: Record<string, unknown> = {
-      'assets/main.css': {
-        type: 'asset',
-        fileName: 'assets/main.css',
-        source: '.-p\\:20{padding:var(--s20)}.-m\\:10{margin:var(--s10)}',
-      },
-      'assets/app.js': {
-        type: 'chunk',
-        fileName: 'assets/app.js',
-        code: 'const cls = "-p:20";',
-      },
-    };
-    const ctx = { info: vi.fn(), warn: vi.fn() };
-    await (getHook(purge, 'generateBundle') as (this: unknown, opts: unknown, bundle: unknown, isWrite: boolean) => unknown).call(
-      ctx,
-      {},
-      bundle,
-      false
-    );
+    const bundle = makeCssBundle('.-p\\:20{padding:var(--s20)}.-m\\:10{margin:var(--s10)}');
+    await callGenerateBundle(purge, bundle);
 
-    const source = (bundle['assets/main.css'] as { source: string }).source;
-    expect(source).toContain('-p\\:20');
-    expect(source).not.toContain('-m\\:10');
+    expect(cssSource(bundle)).toContain('-p\\:20');
+    expect(cssSource(bundle)).not.toContain('-m\\:10');
   });
+
+  test('astro:build:start 前は custom クラスを unknown として残し、後は purge する', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-astro-known-'));
+    const dist = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-astro-dist-'));
+    writeUserConfig(tmp);
+    const cssPath = path.join(dist, 'styles.css');
+    const writeDist = () => {
+      fs.writeFileSync(cssPath, CUSTOM_PROP_CSS);
+      fs.writeFileSync(path.join(dist, 'index.html'), '<div class="-p:20"></div>');
+    };
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    try {
+      const integrations = lismCssForAstro({ purge: true });
+      const setup = integrations[0];
+      const purge = integrations.find((i) => i.name === 'lism-css:purge');
+      if (!purge) throw new Error('lism-css:purge not found');
+
+      await setup.hooks['astro:config:setup']?.({
+        config: { root: pathToFileURL(tmp) },
+        updateConfig: vi.fn(),
+      } as never);
+
+      writeDist();
+      await purge.hooks['astro:build:done']?.({
+        dir: pathToFileURL(`${dist}/`),
+        logger,
+        pages: [],
+        routes: [],
+      } as never);
+      expect(fs.readFileSync(cssPath, 'utf8')).toContain('-p\\:20');
+      expect(fs.readFileSync(cssPath, 'utf8')).toContain('-myz\\:9');
+
+      await setup.hooks['astro:build:start']?.({} as never);
+
+      writeDist();
+      await purge.hooks['astro:build:done']?.({
+        dir: pathToFileURL(`${dist}/`),
+        logger,
+        pages: [],
+        routes: [],
+      } as never);
+      const after = fs.readFileSync(cssPath, 'utf8');
+      expect(after).toContain('-p\\:20');
+      expect(after).not.toContain('-myz\\:9');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+      fs.rmSync(dist, { recursive: true, force: true });
+    }
+  }, 15000);
 });


### PR DESCRIPTION
## Summary

- Vite の `configResolved` / `buildStart` / `handleHotUpdate` を直接呼ぶテストを追加した（typegen・config-alias・known プラグイン）
- Astro の `astro:config:setup` / `astro:build:start` をスタブ付きで直接呼ぶテストを追加した
- `buildConfigAwareKnown` の直接テスト（custom prop が known に入ること / 壊れた config で undefined）と、`knownRef` 未設定時のデフォルト known フォールバックを追加した

Part of #551
