### PR TITLE
has--transitionのデフォルト--transitionPropsをallから安全なプロパティリストに絞る

### DIFF
--- a/apps/docs/src/content/en/core-components/lism-props.mdx
+++ b/apps/docs/src/content/en/core-components/lism-props.mdx
@@ -141,7 +141,7 @@ Props corresponding to Trait Classes (`is--*` / `has--*`).
 | `isContainer` | `is--container` | Container query target |
 | `isSide` | `is--side` | Side element |
 | `isSkipFlow` | `is--skipFlow` | Skip Flow spacing |
-| `hasTransition` | `has--transition` | Sets `transition` properties via CSS variables |
+| `hasTransition(='{props}')` | `has--transition` + `--transitionProps:{props}` | Sets `transition` properties via CSS variables. Pass a string to specify which properties to transition |
 | `hasGutter` | `has--gutter` | Reserves a unified horizontal gutter (`--gutter` / `--gutter--base`) |
 | `hasSnap` | `has--snap` | Sets `scroll-snap-*` properties via CSS variables |
 | `hasMask` | `has--mask` | Sets `mask` property via CSS variables |

--- a/apps/docs/src/content/en/property-class/hov.mdx
+++ b/apps/docs/src/content/en/property-class/hov.mdx
@@ -410,6 +410,8 @@ The Lism core package provides the following classes by default:
 
 Adding the [`has--transition`](/en/docs/trait-class/#has--transition) class makes hover changes transition smoothly. Use the `--duration` variable to adjust the transition time.
 
+By default, only colors, shadows, opacity, transform-related, and filter-related properties are transitioned. We recommend explicitly listing the properties that actually change via the `--transitionProps` variable (or a string such as `hasTransition="color, opacity"` in Lism components).
+
 
 <Preview>
   <PreviewTitle>Example: combining `has--transition` to animate the bxsh intensity</PreviewTitle>

--- a/apps/docs/src/content/en/trait-class.mdx
+++ b/apps/docs/src/content/en/trait-class.mdx
@@ -34,10 +34,14 @@ Sets the `transition` property using dedicated variables.
 
 <SrcCode path="src/scss/trait/has/_transition.scss" />
 
+By default, the transitioned properties (`--transitionProps`) are limited to colors, shadows, opacity, transform-related, and filter-related properties. Using `all` tends to cause unintended animations (flickering) on page load or layout changes.
+
+We recommend explicitly listing only the properties that actually change via `--transitionProps`. In Lism components, passing a string to `hasTransition` outputs it as `--transitionProps`.
+
 <Preview>
   <PreviewTitle>Usage example</PreviewTitle>
   <PreviewArea p="30">
-    <Lism hasTransition hov={{c: 'red'}} style={{ '--transitionProps': 'color'}}>Example</Lism>
+    <Lism hasTransition="color" hov={{c: 'red'}}>Example</Lism>
   </PreviewArea>
   <PreviewCode label="HTML" slot="tab">
     ```html
@@ -46,7 +50,7 @@ Sets the `transition` property using dedicated variables.
   </PreviewCode>
   <PreviewCode label="JSX" slot="tab">
     ```jsx
-    <Lism hasTransition hov={{c: 'red'}} style={{ '--transitionProps': 'color'}}>Example</Lism>
+    <Lism hasTransition="color" hov={{c: 'red'}}>Example</Lism>
     ```
   </PreviewCode>
 </Preview>

--- a/apps/docs/src/content/ja/core-components/lism-props.mdx
+++ b/apps/docs/src/content/ja/core-components/lism-props.mdx
@@ -141,7 +141,7 @@ Trait Class (`is--*` / `has--*`) に対応する Props です。
 | `isContainer` | `is--container` | コンテナクエリ対象 |
 | `isSide` | `is--side` | サイド要素 |
 | `isSkipFlow` | `is--skipFlow` | Flow 余白をスキップ |
-| `hasTransition` | `has--transition` | `transition` プロパティを CSS 変数でセット |
+| `hasTransition(='{props}')` | `has--transition` + `--transitionProps:{props}` | `transition` プロパティを CSS 変数でセット。文字列を渡すとトランジション対象のプロパティを指定できる |
 | `hasGutter` | `has--gutter` | 左右に統一ガター（`--gutter` / `--gutter--base`）を確保 |
 | `hasSnap` | `has--snap` | `scroll-snap-*` プロパティを CSS 変数でセット |
 | `hasMask` | `has--mask` | `mask` プロパティを CSS 変数でセット |

--- a/apps/docs/src/content/ja/property-class/hov.mdx
+++ b/apps/docs/src/content/ja/property-class/hov.mdx
@@ -412,6 +412,8 @@ Lismのコアパッケージでは、以下のクラスを標準で用意して�
 
 [`has--transition`](/docs/trait-class/#has--transition)クラスを付与すると、hover時の変化になめらかなトランジションがかかります。`--duration`変数で所要時間を調整できます。
 
+初期状態でトランジションの対象になるのは、色・影・透明度・transform系・filter系のプロパティだけです。`--transitionProps`変数（Lismコンポーネントでは`hasTransition="color, opacity"`のような文字列指定）で、実際に変化させるプロパティを明示することを推奨します。
+
 
 <Preview>
   <PreviewTitle>`has--transition`と組み合わせてbxshの強さを変化させる例</PreviewTitle>

--- a/apps/docs/src/content/ja/trait-class.mdx
+++ b/apps/docs/src/content/ja/trait-class.mdx
@@ -34,10 +34,14 @@ import getSvgUrl from '@/utils/getSvgUrl';
 
 <SrcCode path="src/scss/trait/has/_transition.scss" />
 
+トランジションの対象プロパティ（`--transitionProps`）の初期値は、色・影・透明度・transform系・filter系に限定しています。`all`にすると、ページ読み込み時やレイアウト変化時に意図しないアニメーション（表示のちらつき）が入りやすいためです。
+
+実際に変化させるプロパティだけを`--transitionProps`で明示指定することを推奨します。Lismコンポーネントでは、`hasTransition`に文字列を渡すと`--transitionProps`として出力されます。
+
 <Preview>
   <PreviewTitle>使用例</PreviewTitle>
   <PreviewArea p="30">
-    <Lism hasTransition hov={{c: 'red'}} style={{ '--transitionProps': 'color'}}>Example</Lism>
+    <Lism hasTransition="color" hov={{c: 'red'}}>Example</Lism>
   </PreviewArea>
   <PreviewCode label="HTML" slot="tab">
     ```html
@@ -46,7 +50,7 @@ import getSvgUrl from '@/utils/getSvgUrl';
   </PreviewCode>
   <PreviewCode label="JSX" slot="tab">
     ```jsx
-    <Lism hasTransition hov={{c: 'red'}} style={{ '--transitionProps': 'color'}}>Example</Lism>
+    <Lism hasTransition="color" hov={{c: 'red'}}>Example</Lism>
     ```
   </PreviewCode>
 </Preview>

--- a/packages/lism-css/src/components/Lism/Lism.test.tsx
+++ b/packages/lism-css/src/components/Lism/Lism.test.tsx
@@ -1369,6 +1369,17 @@ describe('Lism', () => {
         expect(element).toHaveClass('has--transition');
       });
 
+      test('hasTransition に文字列を渡すと --transitionProps 変数も出力される', () => {
+        render(
+          <Lism hasTransition="color, opacity" data-testid="lism">
+            test
+          </Lism>
+        );
+        const element = screen.getByTestId('lism');
+        expect(element).toHaveClass('has--transition');
+        expect(element.style.getPropertyValue('--transitionProps')).toBe('color, opacity');
+      });
+
       test('hasGutter で has--gutter クラスが出力される', () => {
         render(
           <Lism hasGutter data-testid="lism">

--- a/packages/lism-css/src/lib/getLismProps.test.ts
+++ b/packages/lism-css/src/lib/getLismProps.test.ts
@@ -407,6 +407,28 @@ describe('getLismProps', () => {
       expect(result.className).not.toContain('-contentSize:s');
     });
 
+    test('hasTransition: true の場合クラスのみが追加される', () => {
+      const result = getLismProps({ hasTransition: true });
+      expect(result.className).toContain('has--transition');
+      expect(result.style).toBeUndefined();
+    });
+
+    test('hasTransition: 文字列の場合、クラスと --transitionProps 変数が出力される', () => {
+      const result = getLismProps({ hasTransition: 'scale, opacity' });
+      expect(result.className).toContain('has--transition');
+      expect(result.style?.['--transitionProps']).toBe('scale, opacity');
+    });
+
+    test('hasTransition: 前後の空白は除去される', () => {
+      const result = getLismProps({ hasTransition: '  color ' });
+      expect(result.style?.['--transitionProps']).toBe('color');
+    });
+
+    test('hasTransition: 空文字の場合は何も出力されない', () => {
+      const result = getLismProps({ hasTransition: '' });
+      expect(result).toEqual({});
+    });
+
     test('contentSize: 単独でプリセット値を指定すると、クラスのみが出力される', () => {
       const result = getLismProps({ contentSize: 'l' });
       expect(result.className).toContain('-contentSize:l');

--- a/packages/lism-css/src/lib/getLismProps.ts
+++ b/packages/lism-css/src/lib/getLismProps.ts
@@ -141,6 +141,7 @@ export class LismPropsData {
   // prop解析
   analyzeProps(): void {
     this.normalizeIsWrapper();
+    this.normalizeHasTransition();
 
     // set / util は attrs ループの前に取り出して各バケットへ振り分ける
     const rawSet = this.extractProp('set');
@@ -183,6 +184,16 @@ export class LismPropsData {
       }
       this.attrs.isWrapper = true;
     }
+  }
+
+  // hasTransition="color, opacity" 形式の文字列は --transitionProps 変数として出力し、クラス付与は boolean に寄せる。
+  normalizeHasTransition(): void {
+    const hasTransition = this.attrs.hasTransition;
+    if (typeof hasTransition !== 'string') return;
+    const transitionProps = hasTransition.trim();
+    if (transitionProps === '') return;
+    this.addStyle('--transitionProps', transitionProps);
+    this.attrs.hasTransition = true;
   }
 
   // Lism Prop 解析

--- a/packages/lism-css/src/lib/types/TraitProps.spec-d.ts
+++ b/packages/lism-css/src/lib/types/TraitProps.spec-d.ts
@@ -51,6 +51,23 @@ describe('TraitProps', () => {
     });
   });
 
+  describe('hasTransition は --transitionProps 用の文字列・boolean を受け入れる', () => {
+    it('hasTransition - string を受け入れる', () => {
+      assertType<TraitProps>({ hasTransition: 'color' });
+      assertType<TraitProps>({ hasTransition: 'scale, opacity' });
+    });
+
+    it('hasTransition - boolean を受け入れる', () => {
+      assertType<TraitProps>({ hasTransition: true });
+      assertType<TraitProps>({ hasTransition: false });
+    });
+
+    it('hasTransition - number は受け入れない', () => {
+      // @ts-expect-error - number は受け入れない
+      assertType<TraitProps>({ hasTransition: 100 });
+    });
+  });
+
   describe('isWrapper は contentSize 互換の文字列値・boolean を受け入れる', () => {
     it('isWrapper - プリセット値を受け入れる', () => {
       assertType<TraitProps>({ isWrapper: 's' });

--- a/packages/lism-css/src/lib/types/TraitProps.ts
+++ b/packages/lism-css/src/lib/types/TraitProps.ts
@@ -17,6 +17,7 @@ type TraitsConfig = typeof TRAITS;
 // → boolean のみ受け付ける（true/false でクラスの付与を制御）
 //
 // isWrapper は現行仕様として、boolean に加えて contentSize 相当の文字列値も受け付ける。
+// hasTransition は boolean に加えて、--transitionProps に出力する文字列（例: 'color, opacity'）も受け付ける。
 //
 // ============================================================
 
@@ -35,8 +36,9 @@ type ContentSizeStringValue = Extract<NonNullable<PropValueTypes['contentSize']>
  * config/index.ts の TRAITS から自動生成される Trait Props の型
  * config/index.ts の TRAITS に新しいトレイトを追加すると自動的に反映される
  */
-export type TraitProps = Omit<GeneratedTraitProps, 'isWrapper'> & {
+export type TraitProps = Omit<GeneratedTraitProps, 'isWrapper' | 'hasTransition'> & {
   isWrapper?: boolean | ContentSizeStringValue;
+  hasTransition?: boolean | string;
 };
 
 /** set prop で使われるプリセット値（エディタ補完用） */

--- a/packages/lism-css/src/scss/trait/has/_transition.scss
+++ b/packages/lism-css/src/scss/trait/has/_transition.scss
@@ -2,7 +2,8 @@
   --duration: var(--transition-duration, 0.25s);
   --ease: ease;
   --delay: 0s;
-  --transitionProps: all;
+  // `all` は読み込み時やレイアウト変化時に意図しないアニメーションを起こすため、対象を見た目系プロパティに限定する。
+  --transitionProps: color, background-color, border-color, box-shadow, scale, rotate, translate, transform, opacity, filter, backdrop-filter;
   transition: var(--duration) var(--ease) var(--delay);
   transition-property: var(--transitionProps);
 }

--- a/packages/mcp/src/data/docs-index.json
+++ b/packages/mcp/src/data/docs-index.json
@@ -1786,8 +1786,8 @@
     "description": "CSS変数を用いてtransitionプロパティをセットする Trait クラス。",
     "category": "guide",
     "headings": ["has--transition"],
-    "keywords": ["has--transition", "トランジション", "アニメーション", "transition"],
-    "snippet": "専用のCSS変数を用いてtransitionプロパティをセットするクラス。set--hov と組み合わせてスムーズなホバーアニメーションを実現。"
+    "keywords": ["has--transition", "hasTransition", "--transitionProps", "トランジション", "アニメーション", "transition"],
+    "snippet": "専用のCSS変数を用いてtransitionプロパティをセットするクラス。--transitionProps の初期値は all ではなく color, background-color, border-color, box-shadow, scale, rotate, translate, transform, opacity, filter, backdrop-filter に限定。実際に変化させるプロパティを --transitionProps で明示指定することを推奨。Lismコンポーネントでは hasTransition=\"color, opacity\" のように文字列を渡すと --transitionProps として出力。set--hov と組み合わせてスムーズなホバーアニメーションを実現。"
   },
   {
     "sourcePath": "set-class.mdx",

--- a/packages/mockup/viewer/src/components/TokenOutline.tsx
+++ b/packages/mockup/viewer/src/components/TokenOutline.tsx
@@ -61,7 +61,7 @@ export default function TokenOutline({ items, activeId }: TokenOutlineProps) {
       bdrs="20"
       bxsh={isOpen ? '20' : undefined}
       hasTransition
-      // `all` (has--transition default) would also tween border-width when `bd`
+      // The has--transition default list would also tween border-color when `bd`
       // appears, which makes the whole outline flash. Only the properties that
       // actually ease in and out are listed here.
       style={{ translate: '0 -50%', '--transitionProps': 'background-color, box-shadow' }}
@@ -96,7 +96,16 @@ export default function TokenOutline({ items, activeId }: TokenOutlineProps) {
             <Inline className={isOpen ? undefined : 'u--srOnly'} fz="2xs" ff="mono" fw={isCurrent ? 'bold' : undefined} whs="nowrap">
               {item.label}
             </Inline>
-            <Box fxsh="0" w={isCurrent ? '1.25rem' : '0.75rem'} h="2px" bdrs="99" bgc={isCurrent ? 'text' : 'divider'} hasTransition />
+            <Box
+              fxsh="0"
+              w={isCurrent ? '1.25rem' : '0.75rem'}
+              h="2px"
+              bdrs="99"
+              bgc={isCurrent ? 'text' : 'divider'}
+              hasTransition
+              // `width` is outside the has--transition default list, so it is listed explicitly.
+              style={{ '--transitionProps': 'width, background-color' }}
+            />
           </Flex>
         );
       })}

--- a/skills/lism-css-guide/components-core.md
+++ b/skills/lism-css-guide/components-core.md
@@ -190,6 +190,7 @@ Trait クラス（`is--*` / `has--*`）を出力するためのプロパティ�
 | `isSide` | `is--side` |
 | `isSkipFlow` | `is--skipFlow` |
 | `hasTransition` | `has--transition` |
+| `hasTransition="{props}"` | `has--transition` + `--transitionProps:{props}` |
 | `hasGutter` | `has--gutter` |
 | `hasSnap` | `has--snap` |
 | `hasMask` | `has--mask` |

--- a/skills/lism-css-guide/trait-class.md
+++ b/skills/lism-css-guide/trait-class.md
@@ -52,12 +52,12 @@ Lism コンポーネントでは `isContainer`, `isLayer` 等の Props として
 
 | クラス | 用途 | 主な CSS 変数 |
 | --- | --- | --- |
-| `has--transition` | transition プロパティをまとめてセット。主に hoverクラス（`-hov:*`）と組み合わせて使用 | `--transitionProps`, `--duration`, `--ease`, `--delay`（グローバル上書きは `--transition-duration`） |
+| `has--transition` | transition プロパティをまとめてセット。主に hoverクラス（`-hov:*`）と組み合わせて使用。対象プロパティは `--transitionProps` で明示指定する（初期値は `all` ではなく色・影・透明度・transform 系・filter 系に限定） | `--transitionProps`, `--duration`, `--ease`, `--delay`（グローバル上書きは `--transition-duration`） |
 | `has--gutter` | コンテンツの左右に統一した余白（gutter）を設定する | `--gutter`（基準値: `--gutter--base`、初期値 `var(--s30)`） |
 | `has--snap` | `scroll-snap-` 系プロパティを CSS 変数経由でセットできるようにする | `--snapType`, `--snapAlign` 等 |
 | `has--mask` | `--maskImg` 変数と組み合わせて、要素自身にマスクを適用する | `--maskImg`, `--maskPos`（`50%`）, `--maskSize`（`contain`）, `--maskRepeat`（`no-repeat`） |
 
-Lism コンポーネントでは `hasTransition`, `hasGutter`, `hasSnap`, `hasMask` という Props として利用できます（例: `<Lism hasTransition>`）。
+Lism コンポーネントでは `hasTransition`, `hasGutter`, `hasSnap`, `hasMask` という Props として利用できます（例: `<Lism hasTransition>`）。`hasTransition` は文字列も受け付け、`--transitionProps` として出力されます（例: `<Lism hasTransition="color, opacity">`）。
 
 詳細は以下の個別ドキュメントを参照してください:
 - [has--transition](./trait-class/has--transition.md)

--- a/skills/lism-css-guide/trait-class/has--transition.md
+++ b/skills/lism-css-guide/trait-class/has--transition.md
@@ -3,8 +3,23 @@
 `transition` 系のプロパティを CSS 変数経由でセットする Trait クラス。主に `-hov:*` クラスと組み合わせて、ホバー時のスムーズな変化に使う。
 
 - Lism props: `hasTransition`（`<Lism hasTransition>` / `<Box hasTransition>` 等）
+- 文字列を渡すと `--transitionProps` として出力される: `<Box hasTransition="color, opacity">` → `class="has--transition" style="--transitionProps: color, opacity"`
 
 公式ドキュメント（使い方・コード例）: https://lism-css.com/docs/trait-class.md#has--transition
+
+## 対象プロパティは明示指定する
+
+`--transitionProps` の初期値は `all` ではなく、色・影・透明度・transform 系・filter 系に限定したリスト。`all` はページ読み込み時やレイアウト変化時に意図しないアニメーション（ちらつき）を起こすため使わない。
+
+実際に変化させるプロパティだけを `--transitionProps`（Lism props では `hasTransition="..."`）で明示指定する。初期値のリストに無いプロパティ（`padding`, `width`, `border-width` 等）を変化させる場合は必ず指定が要る。
+
+```html
+<a class="is--boxLink has--transition -hov:-bxsh" style="--transitionProps: box-shadow; --hov-bxsh: var(--bxsh--40)">...</a>
+```
+
+```jsx
+<BoxLink hasTransition="box-shadow" hov={{ bxsh: '40' }}>...</BoxLink>
+```
 
 ## SCSS 定義
 
@@ -13,7 +28,7 @@
   --duration: var(--transition-duration, 0.25s);
   --ease: ease;
   --delay: 0s;
-  --transitionProps: all;
+  --transitionProps: color, background-color, border-color, box-shadow, scale, rotate, translate, transform, opacity, filter, backdrop-filter;
   transition: var(--duration) var(--ease) var(--delay);
   transition-property: var(--transitionProps);
 }
@@ -23,7 +38,7 @@
 
 | 変数 | 役割 | デフォルト |
 | --- | --- | --- |
-| `--transitionProps` | transition 対象プロパティ | `all` |
+| `--transitionProps` | transition 対象プロパティ | `color, background-color, border-color, box-shadow, scale, rotate, translate, transform, opacity, filter, backdrop-filter` |
 | `--duration` | トランジションの長さ | `var(--transition-duration, 0.25s)` |
 | `--ease` | イージング関数 | `ease` |
 | `--delay` | ディレイ | `0s` |


### PR DESCRIPTION
## 概要

`has--transition`のデフォルト`--transitionProps: all`をやめ、見た目系のプロパティに限定したリストへ変更しました。あわせて`hasTransition`propに文字列を渡すと`--transitionProps`として出力されるようにし、skill・ドキュメント・MCPインデックスの記載を更新しました。

Closes #575

## 変更内容

### コア（`packages/lism-css`）

- `has--transition`の`--transitionProps`初期値を次のリストへ変更
  ```css
  --transitionProps: color, background-color, border-color, box-shadow, scale, rotate, translate, transform, opacity, filter, backdrop-filter;
  ```
- `hasTransition="scale, opacity"`のように文字列を渡すと、`has--transition`クラスに加えて`--transitionProps: scale, opacity`をstyleへ出力（`getLismProps`の`normalizeHasTransition`、`isWrapper`と同じ正規化パターン）
- `TraitProps`の`hasTransition`型を`boolean | string`へ拡張
- テスト追加: `getLismProps.test.ts`、`Lism.test.tsx`、`TraitProps.spec-d.ts`

### skill / docs / MCP

- `skills/lism-css-guide/trait-class/has--transition.md`: デフォルト値の更新、`--transitionProps`明示指定の推奨、`hasTransition="..."`の案内
- `skills/lism-css-guide/trait-class.md`、`components-core.md`: 同上の要約を追記
- `apps/docs`（ja/en）: `trait-class.mdx`、`property-class/hov.mdx`、`core-components/lism-props.mdx`
- `packages/mcp/src/data/docs-index.json`: `has--transition`エントリのsnippet・keywordsを更新
- `packages/mockup/viewer/.../TokenOutline.tsx`: `all`がデフォルトである前提のコメントを修正。現在位置インジケーターは`width`をトランジションさせていたため`--transitionProps: width, background-color`を明示

## 判断したこと

- Issueの確認事項「`filter`系を含めるか」は**含める**にしました。`filter`/`backdrop-filter`はレイアウトに影響しない描画系プロパティで、読み込み時に変化することが少なく事故リスクが低い一方、hover演出でよく使われるためです（Tailwindの`transition`デフォルトにも含まれています）。不要なら該当2語を削るだけで戻せます。
- `text-decoration-color`・`fill`・`stroke`・`outline-color`は最小限に留める方針で含めていません。

## 影響範囲

- 旧デフォルト`all`に依存して`padding`・`width`・`border-width`などをトランジションさせていた箇所は、`--transitionProps`の明示指定が必要になります。
- リポジトリ内の`has--transition` / `hasTransition`使用箇所（docsプレビューパターン・templates・mockup viewer・docs本文）を確認し、リスト外プロパティに依存していたのは上記`TokenOutline.tsx`の1箇所のみでした。`-hov:in:*`系は自前で`--transitionProps`を設定しているため影響ありません。

## 動作確認

- `packages/lism-css`: `pnpm test`（29ファイル732件パス、型テスト含む）、`pnpm typecheck`、`pnpm lint`
- `packages/lism-css`: `pnpm build:css:only`でdistの`.has--transition`に新しいリストが出力されることを確認
- `packages/mcp`: `pnpm test`（68件パス）
- 変更ファイルの`prettier --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaoAuJmHW7JWNQz35kzqfF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `hasTransition` に文字列を指定し、トランジション対象のプロパティを選択できるようになりました。
  * 指定内容は `--transitionProps` として適用されます。

* **変更**
  * デフォルトのトランジション対象を、色・影・不透明度・変形・フィルター関連などに限定しました。
  * 対象外のレイアウト変化が意図せずアニメーションする問題を改善しました。

* **ドキュメント**
  * 新しい指定方法と推奨設定を各言語のガイドへ追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->