### PR TITLE
fix(docs): ランドマーク構造を見直し、サイドバーのasideを外してfooterをmainの外に出す

### DIFF
--- a/apps/docs/src/components/Sidebar.astro
+++ b/apps/docs/src/components/Sidebar.astro
@@ -5,7 +5,8 @@ import SiteNav from './SiteNav.astro';
 // import LanguageSelect from './LanguageSelect.astro';
 ---
 
-<Stack as="aside" class="c--siteSidebar" isContainer g="10" {...Astro.props}>
+{/* 中身はサイトナビだけなので aside（補足ランドマーク）にはしない。nav は SiteNav 側 */}
+<Stack class="c--siteSidebar" isContainer g="10" {...Astro.props}>
   <Stack class="c--siteSidebar_nav" fx="1" min-h="0">
     <SiteNav />
   </Stack>

--- a/apps/docs/src/components/SiteNav.astro
+++ b/apps/docs/src/components/SiteNav.astro
@@ -10,10 +10,12 @@ import NavLink from '@parts/NavLink.astro';
 import sidebarConfig, { getTranslatedLabel, isSeparator, getSiteSection, extractSlugFromUrl } from '../config/sidebar';
 import { groupPostsBySidebarDirs, hasDirProperty, getPostUrl } from '@/lib/sidebarPosts';
 import { getPostsByLang, type PostEntry } from '@/lib/content';
-import { getLangFromUrl, getLocalizedUrl, getPathWithoutLang } from '@/lib/i18n';
+import { getLangFromUrl, getLocalizedUrl, getPathWithoutLang, t } from '@/lib/i18n';
 
 // 現在の言語を取得
 const currentLang = getLangFromUrl(Astro.url);
+// nav ランドマークのラベル（目次・記事ナビと区別するため）
+const navText = t(currentLang, 'siteNav');
 
 // 現在のページパス（言語プレフィックスなし）を取得してアクティブ判定に使用
 const currentPathWithoutLang = getPathWithoutLang(Astro.url);
@@ -74,7 +76,7 @@ function getDirNestedDepth(postId: string, dir: string): number {
 }
 ---
 
-<Stack as="nav" class="c--siteNav set--cqUnit set--s" g="10" fx="1" min-h="0">
+<Stack as="nav" class="c--siteNav set--cqUnit set--s" g="10" fx="1" min-h="0" aria-label={navText.ariaLabel}>
   {/* トップレベルリンク */}
   {
     topLevelLinks.length > 0 && (

--- a/apps/docs/src/components/TableOfContents.astro
+++ b/apps/docs/src/components/TableOfContents.astro
@@ -16,7 +16,7 @@ const lang = getLangFromUrl(Astro.url);
 const tocText = t(lang, 'toc');
 ---
 
-<Stack class="c--toc set--cqUnit set--s" g="15" px={px} py={py}>
+<Stack as="nav" class="c--toc set--cqUnit set--s" g="15" px={px} py={py} aria-label={tocText.ariaLabel}>
   <Heading level="3" class="b--eyebrow" tt="upper">{tocText.title}</Heading>
   <Stack as="ul" class="c--toc_list" g="0" bd-s>
     {toc.map((item) => <TocItemComponent item={item} />)}

--- a/apps/docs/src/config/translations.ts
+++ b/apps/docs/src/config/translations.ts
@@ -9,9 +9,10 @@ import type { LangCode } from './site';
  * キー構造のみを定義し、値は string 型
  */
 type TranslationKeys = {
-  toc: 'title' | 'open';
+  toc: 'title' | 'open' | 'ariaLabel';
   search: 'title' | 'devMessage';
   header: 'openMenu';
+  siteNav: 'ariaLabel';
   main: 'ariaLabel';
   themeSwitch: 'ariaLabel' | 'system' | 'light' | 'dark';
   langSelect: 'ariaLabel' | 'menuAriaLabel';
@@ -39,6 +40,7 @@ export const translations: Record<LangCode, UITranslations> = {
     toc: {
       title: '目次',
       open: '目次を開く',
+      ariaLabel: '目次',
     },
     search: {
       title: '検索',
@@ -46,6 +48,9 @@ export const translations: Record<LangCode, UITranslations> = {
     },
     header: {
       openMenu: 'メニューを開く',
+    },
+    siteNav: {
+      ariaLabel: 'サイトナビゲーション',
     },
     main: {
       ariaLabel: 'メインコンテンツ',
@@ -95,6 +100,7 @@ export const translations: Record<LangCode, UITranslations> = {
     toc: {
       title: 'TOC',
       open: 'Open contents',
+      ariaLabel: 'Table of contents',
     },
     search: {
       title: 'Search',
@@ -102,6 +108,9 @@ export const translations: Record<LangCode, UITranslations> = {
     },
     header: {
       openMenu: 'Open menu',
+    },
+    siteNav: {
+      ariaLabel: 'Site navigation',
     },
     main: {
       ariaLabel: 'Main content',

--- a/apps/docs/src/layouts/BaseLayout.astro
+++ b/apps/docs/src/layouts/BaseLayout.astro
@@ -73,19 +73,22 @@ const canonicalUrl = isDev ? Astro.url.toString() : Astro.site ? new URL(Astro.u
           mt="20"
         >
           <Sidebar d={['none', null, 'flex']} layout="stack" />
-          <Container as="main" class="c--siteMain b--shadowBox is--scrollPanel" tabindex={-1} aria-label={t(lang, 'main').ariaLabel}>
+          <Container class="c--siteMain b--shadowBox is--scrollPanel">
             <Box class="c--siteMain_inner" tabindex={0}>
               <Container isWrapper={toc ? true : 'l'} hasGutter py="40">
-                {/* 目次「Top」の着地用。u--srOnly(absolute)だとリロード時のハッシュスクロールがずれる */}
-                <span id={PAGE_TITLE_ID} class="c--scrollTarget" aria-hidden="true"></span>
-                <slot />
+                {/* main は Footer を含めない（footer が main 内だと contentinfo ランドマークにならない）。スクロール領域の構造は維持する */}
+                <Box as="main" tabindex={-1} aria-label={t(lang, 'main').ariaLabel}>
+                  {/* 目次「Top」の着地用。u--srOnly(absolute)だとリロード時のハッシュスクロールがずれる */}
+                  <span id={PAGE_TITLE_ID} class="c--scrollTarget" aria-hidden="true"></span>
+                  <slot />
+                </Box>
                 <Footer />
               </Container>
             </Box>
           </Container>
           {
             toc && (
-              <Stack as="aside" class="c--siteToc b--shadowBox is--scrollPanel" isContainer g="15" d={['none', null, null, 'flex']} min-h="0">
+              <Stack class="c--siteToc b--shadowBox is--scrollPanel" isContainer g="15" d={['none', null, null, 'flex']} min-h="0">
                 <TableOfContents toc={toc} px="20" py="30" />
               </Stack>
             )

--- a/apps/docs/src/styles/_custom.scss
+++ b/apps/docs/src/styles/_custom.scss
@@ -129,7 +129,7 @@
     }
   }
   .c--siteFooter {
-    /* Main内に配置されるためgrid-areaは不要 */
+    /* 本文カラム（.c--siteMain）内に配置されるためgrid-areaは不要 */
 
     .c--themeModeSwitch {
       margin-inline: auto;


### PR DESCRIPTION
## 概要

apps/docs のランドマーク構造を見直し、スクリーンリーダーで意味のない「補足」が読まれる問題と、サイトフッターが `contentinfo` にならない問題を修正しました。見た目は変えていません。

Closes #576

## 変更内容

- `Sidebar.astro`: `aside` を外して `div` にした。中の `nav`（`SiteNav`）はそのまま
- `BaseLayout.astro`: `main` を本文カラムの外側パネルからラッパー内側へ移し、`Footer` を `main` の外に出した。スクロール領域（`.c--siteMain` / `.c--siteMain_inner`）の構造は変えていない
- `BaseLayout.astro`: 目次の `aside` を `div` にした
- `TableOfContents.astro`: ルートを `nav aria-label="目次"` にした（デスクトップの目次とモバイルのモーダル目次の両方に適用）
- `SiteNav.astro`: `nav` に `aria-label="サイトナビゲーション"` を付けた（サイドバーとモバイルメニューの両方に適用）
- `translations.ts`: `siteNav.ariaLabel` と `toc.ariaLabel` を追加（ja / en）
- `_custom.scss`: `.c--siteFooter` のコメントを実態に合わせて修正

## 判断したこと

- 目次は Issue の確認事項にあった `nav aria-label="目次"` 案を採用した。ナビゲーションが複数になるため、それぞれ区別できるラベルを付けている
- `main` の `tabindex="-1"` と `aria-label` は、移動先の `main` にそのまま引き継いだ
- `main` は `Box` で出力しているため `l--box` クラスが付くが、lism-css 側にスタイル定義はないため見た目への影響はない

## 確認したこと

- dev サーバーで `/docs/overview/`・`/en/docs/overview/`・`/ui/`・`/` の HTML を取得し、ランドマークの入れ子を確認
  - `footer` が `main` の外にあり、`aside` が 0 件になっている
  - `nav` のラベルが「サイトナビゲーション」「目次」「記事ナビゲーション」で区別できている
- `pnpm typecheck`（apps/docs）、ESLint、Prettier を変更ファイルに対して実行

## 未確認

- ブラウザでの見た目の実機確認はしていません。`main` は幅・余白に影響しないブロック要素として `Footer` と同じラッパー内に置いているため、レイアウトは変わらない想定です

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mum7GSDwXSpya73ZKemeka


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **アクセシビリティ**
  - サイトナビゲーションと目次に、言語に応じた読み上げ用ラベルを追加しました。
  - ページのメインコンテンツ、フッター、ナビゲーションのランドマーク構造を改善し、支援技術でより適切に認識できるようにしました。
- **改善**
  - ドキュメントサイトのページ構造を整理し、ナビゲーション領域とコンテンツ領域の区別を明確にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->