### PR TITLE
Avatarにプレースホルダー（イニシャル表示）スタイルを追加

### DIFF
--- a/apps/docs/src/content/en/ui/Avatar.mdx
+++ b/apps/docs/src/content/en/ui/Avatar.mdx
@@ -5,7 +5,7 @@ description: 'Documentation for the Avatar component provided by @lism-css/ui.'
 import { Flex, Center, Frame } from 'lism-css/astro';
 import { Avatar } from '@lism-css/ui/astro/Avatar';
 
-A component for displaying avatar images.
+A component for displaying avatar images. When no image is available, it can show the first letter of a name as a placeholder.
 
 
 ## Overview
@@ -55,8 +55,9 @@ Provided as `Avatar` (`b--avatar`) from the `@lism-css/ui` package.
 | Prop | Description |
 |---|---|
 |`size`| Specifies the size of the avatar. Default: `"2em"` |
-|`src`| Path to the avatar image. |
-|`alt`| Alt text for the image. |
+|`src`| Path to the avatar image. When omitted, the initial of `name` is shown instead. |
+|`name`| User name. When `src` is omitted, its first character is shown as the initial. Also used as the alt text when `alt` is not specified. |
+|`alt`| Alt text. Takes precedence over `name` when specified. Use `alt=""` to treat the avatar as decorative, e.g. when the name is displayed right next to it. |
 
 
 ## Examples
@@ -86,6 +87,48 @@ Provided as `Avatar` (`b--avatar`) from the `@lism-css/ui` package.
     ```
   </PreviewCode>
 </Preview>
+
+
+### Initial fallback
+
+When `src` is omitted, the first character of `name` is rendered (`b--avatar_initial`). Uppercasing is handled by CSS (`text-transform: uppercase`), and the font size scales with the avatar size (`--w`).
+
+The background color for the initial is applied to the root element, so it can be overridden with props such as `bgc`.
+
+<Preview>
+  <PreviewTitle>Showing an initial by omitting `src`</PreviewTitle>
+  <PreviewArea p="20" bg=":stripe">
+    <Flex layout="cluster" g="20" ai="center">
+      <Avatar size="4rem" name="Yamada Taro" />
+      <Avatar size="4rem" name="鈴木" bgc="brand" c="base" />
+      <Avatar size="4rem" name="Yamada Taro" alt="" />
+    </Flex>
+  </PreviewArea>
+  <PreviewCode slot="tab" label="JSX">
+    ```jsx
+    <Avatar size="4rem" name="Yamada Taro" />
+    <Avatar size="4rem" name="鈴木" bgc="brand" c="base" />
+    <Avatar size="4rem" name="Yamada Taro" alt="" />
+    ```
+  </PreviewCode>
+  <PreviewCode slot="tab" label="HTML">
+    ```html
+    <div class="b--avatar l--frame -w" style="--w: 4rem">
+      <span class="b--avatar_initial" role="img" aria-label="Yamada Taro">Y</span>
+    </div>
+    <div class="b--avatar l--frame -w -bgc:brand -c:base" style="--w: 4rem">
+      <span class="b--avatar_initial" role="img" aria-label="鈴木">鈴</span>
+    </div>
+    <div class="b--avatar l--frame -w" style="--w: 4rem">
+      <span class="b--avatar_initial" aria-hidden="true">Y</span>
+    </div>
+    ```
+  </PreviewCode>
+</Preview>
+
+:::note
+There is no automatic switch to the initial when the image fails to load. Since the Astro version renders static HTML, client-side load-state tracking is intentionally not included.
+:::
 
 
 ## Without @lism-css/ui

--- a/apps/docs/src/content/en/ui/Avatar.mdx
+++ b/apps/docs/src/content/en/ui/Avatar.mdx
@@ -91,9 +91,9 @@ Provided as `Avatar` (`b--avatar`) from the `@lism-css/ui` package.
 
 ### Initial fallback
 
-When `src` is omitted, the root gets `b--avatar--initial` and the first character of `name` is rendered (`b--avatar_initial`). Uppercasing is handled by CSS (`text-transform: uppercase`), and the font size scales with the avatar size (`--w`).
+When `src` is omitted, the root gets `b--avatar--initial` and the first character of `name` is rendered in the center. Uppercasing is handled by CSS (`text-transform: uppercase`), and the font size scales with the avatar size (`--w`).
 
-The background color is applied to `b--avatar--initial` (the root element), so it can be overridden with props such as `bgc`.
+The styles are applied to `b--avatar--initial` on the root element, so the background color can be overridden with props such as `bgc`.
 
 <Preview>
   <PreviewTitle>Showing an initial by omitting `src`</PreviewTitle>
@@ -114,13 +114,13 @@ The background color is applied to `b--avatar--initial` (the root element), so i
   <PreviewCode slot="tab" label="HTML">
     ```html
     <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
-      <span class="b--avatar_initial" role="img" aria-label="Yamada Taro">Y</span>
+      <span role="img" aria-label="Yamada Taro">Y</span>
     </div>
     <div class="b--avatar b--avatar--initial l--frame -w -bgc:brand -c:base" style="--w: 4rem">
-      <span class="b--avatar_initial" role="img" aria-label="鈴木">鈴</span>
+      <span role="img" aria-label="鈴木">鈴</span>
     </div>
     <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
-      <span class="b--avatar_initial" aria-hidden="true">Y</span>
+      <span aria-hidden="true">Y</span>
     </div>
     ```
   </PreviewCode>

--- a/apps/docs/src/content/en/ui/Avatar.mdx
+++ b/apps/docs/src/content/en/ui/Avatar.mdx
@@ -99,19 +99,19 @@ The styles are applied to `b--avatar--initial` on the root element, so the backg
   <PreviewTitle>Showing an initial by omitting `src`</PreviewTitle>
   <PreviewArea p="20" bg=":stripe">
     <Flex layout="cluster" g="15">
-      <Avatar size="2.5rem" name="Yamada Taro" />
+      <Avatar size="2rem" name="Yamada Taro" />
       <Avatar size="3rem" name="鈴木" bgc="brand" c="base" />
     </Flex>
   </PreviewArea>
   <PreviewCode slot="tab" label="JSX">
     ```jsx
-    <Avatar size="2.5rem" name="Yamada Taro" />
+    <Avatar size="2rem" name="Yamada Taro" />
     <Avatar size="3rem" name="鈴木" bgc="brand" c="base" />
     ```
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html
-    <div class="b--avatar b--avatar--initial l--center -w" style="--w: 2.5rem">
+    <div class="b--avatar b--avatar--initial l--center -w" style="--w: 2rem">
       <span role="img" aria-label="Yamada Taro">Y</span>
     </div>
     <div class="b--avatar b--avatar--initial l--center -w -bgc:brand -c:base" style="--w: 3rem">

--- a/apps/docs/src/content/en/ui/Avatar.mdx
+++ b/apps/docs/src/content/en/ui/Avatar.mdx
@@ -91,9 +91,9 @@ Provided as `Avatar` (`b--avatar`) from the `@lism-css/ui` package.
 
 ### Initial fallback
 
-When `src` is omitted, the first character of `name` is rendered (`b--avatar_initial`). Uppercasing is handled by CSS (`text-transform: uppercase`), and the font size scales with the avatar size (`--w`).
+When `src` is omitted, the root gets `b--avatar--initial` and the first character of `name` is rendered (`b--avatar_initial`). Uppercasing is handled by CSS (`text-transform: uppercase`), and the font size scales with the avatar size (`--w`).
 
-The background color for the initial is applied to the root element, so it can be overridden with props such as `bgc`.
+The background color is applied to `b--avatar--initial` (the root element), so it can be overridden with props such as `bgc`.
 
 <Preview>
   <PreviewTitle>Showing an initial by omitting `src`</PreviewTitle>
@@ -113,13 +113,13 @@ The background color for the initial is applied to the root element, so it can b
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html
-    <div class="b--avatar l--frame -w" style="--w: 4rem">
+    <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
       <span class="b--avatar_initial" role="img" aria-label="Yamada Taro">Y</span>
     </div>
-    <div class="b--avatar l--frame -w -bgc:brand -c:base" style="--w: 4rem">
+    <div class="b--avatar b--avatar--initial l--frame -w -bgc:brand -c:base" style="--w: 4rem">
       <span class="b--avatar_initial" role="img" aria-label="鈴木">鈴</span>
     </div>
-    <div class="b--avatar l--frame -w" style="--w: 4rem">
+    <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
       <span class="b--avatar_initial" aria-hidden="true">Y</span>
     </div>
     ```

--- a/apps/docs/src/content/en/ui/Avatar.mdx
+++ b/apps/docs/src/content/en/ui/Avatar.mdx
@@ -91,36 +91,31 @@ Provided as `Avatar` (`b--avatar`) from the `@lism-css/ui` package.
 
 ### Initial fallback
 
-When `src` is omitted, the root gets `b--avatar--initial` and the first character of `name` is rendered in the center. Uppercasing is handled by CSS (`text-transform: uppercase`), and the font size scales with the avatar size (`--w`).
+When `src` is omitted, the root switches from `l--frame` to `l--center`, gets `b--avatar--initial`, and renders the first character of `name` in the center. Uppercasing is handled by CSS (`text-transform: uppercase`), and the font size scales with the avatar size (`--w`).
 
 The styles are applied to `b--avatar--initial` on the root element, so the background color can be overridden with props such as `bgc`.
 
 <Preview>
   <PreviewTitle>Showing an initial by omitting `src`</PreviewTitle>
   <PreviewArea p="20" bg=":stripe">
-    <Flex layout="cluster" g="20" ai="center">
-      <Avatar size="4rem" name="Yamada Taro" />
-      <Avatar size="4rem" name="鈴木" bgc="brand" c="base" />
-      <Avatar size="4rem" name="Yamada Taro" alt="" />
+    <Flex layout="cluster" g="15">
+      <Avatar size="2.5rem" name="Yamada Taro" />
+      <Avatar size="3rem" name="鈴木" bgc="brand" c="base" />
     </Flex>
   </PreviewArea>
   <PreviewCode slot="tab" label="JSX">
     ```jsx
-    <Avatar size="4rem" name="Yamada Taro" />
-    <Avatar size="4rem" name="鈴木" bgc="brand" c="base" />
-    <Avatar size="4rem" name="Yamada Taro" alt="" />
+    <Avatar size="2.5rem" name="Yamada Taro" />
+    <Avatar size="3rem" name="鈴木" bgc="brand" c="base" />
     ```
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html
-    <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
+    <div class="b--avatar b--avatar--initial l--center -w" style="--w: 2.5rem">
       <span role="img" aria-label="Yamada Taro">Y</span>
     </div>
-    <div class="b--avatar b--avatar--initial l--frame -w -bgc:brand -c:base" style="--w: 4rem">
+    <div class="b--avatar b--avatar--initial l--center -w -bgc:brand -c:base" style="--w: 3rem">
       <span role="img" aria-label="鈴木">鈴</span>
-    </div>
-    <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
-      <span aria-hidden="true">Y</span>
     </div>
     ```
   </PreviewCode>

--- a/apps/docs/src/content/ja/ui/Avatar.mdx
+++ b/apps/docs/src/content/ja/ui/Avatar.mdx
@@ -100,19 +100,19 @@ Avatar のベーススタイルは、以下のCSSで定義されています。
   <PreviewTitle>`src`を省略してイニシャルを表示する</PreviewTitle>
     <PreviewArea p="20" bg=":stripe">
     <Flex layout="cluster" g="15">
-      <Avatar size="2.5rem" name="Yamada Taro" />
+      <Avatar size="2rem" name="Yamada Taro" />
       <Avatar size="3rem" name="鈴木" bgc="brand" c="base" />
     </Flex>
   </PreviewArea>
   <PreviewCode slot="tab" label="JSX">
     ```jsx
-    <Avatar size="2.5rem" name="Yamada Taro" />
+    <Avatar size="2rem" name="Yamada Taro" />
     <Avatar size="3rem" name="鈴木" bgc="brand" c="base" />
     ```
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html
-    <div class="b--avatar b--avatar--initial l--center -w" style="--w: 2.5rem">
+    <div class="b--avatar b--avatar--initial l--center -w" style="--w: 2rem">
       <span role="img" aria-label="Yamada Taro">Y</span>
     </div>
     <div class="b--avatar b--avatar--initial l--center -w -bgc:brand -c:base" style="--w: 3rem">

--- a/apps/docs/src/content/ja/ui/Avatar.mdx
+++ b/apps/docs/src/content/ja/ui/Avatar.mdx
@@ -92,36 +92,31 @@ Avatar のベーススタイルは、以下のCSSで定義されています。
 
 ### イニシャル表示
 
-`src`を省略すると、ルートに`b--avatar--initial`が付き、`name`の先頭1文字を中央に表示します。大文字化はCSSの`text-transform: uppercase`で行い、文字サイズはアバターのサイズ（`--w`）に比例します。
+`src`を省略すると、ルートが`l--frame`から`l--center`に切り替わり、`b--avatar--initial`が付いて`name`の先頭1文字を中央に表示します。大文字化はCSSの`text-transform: uppercase`で行い、文字サイズはアバターのサイズ（`--w`）に比例します。
 
 スタイルはルートの`b--avatar--initial`に当てているため、背景色は`bgc`などのPropで上書きできます。
 
 <Preview>
   <PreviewTitle>`src`を省略してイニシャルを表示する</PreviewTitle>
-  <PreviewArea p="20" bg=":stripe">
-    <Flex layout="cluster" g="20" ai="center">
-      <Avatar size="4rem" name="Yamada Taro" />
-      <Avatar size="4rem" name="鈴木" bgc="brand" c="base" />
-      <Avatar size="4rem" name="Yamada Taro" alt="" />
+    <PreviewArea p="20" bg=":stripe">
+    <Flex layout="cluster" g="15">
+      <Avatar size="2.5rem" name="Yamada Taro" />
+      <Avatar size="3rem" name="鈴木" bgc="brand" c="base" />
     </Flex>
   </PreviewArea>
   <PreviewCode slot="tab" label="JSX">
     ```jsx
-    <Avatar size="4rem" name="Yamada Taro" />
-    <Avatar size="4rem" name="鈴木" bgc="brand" c="base" />
-    <Avatar size="4rem" name="Yamada Taro" alt="" />
+    <Avatar size="2.5rem" name="Yamada Taro" />
+    <Avatar size="3rem" name="鈴木" bgc="brand" c="base" />
     ```
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html
-    <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
+    <div class="b--avatar b--avatar--initial l--center -w" style="--w: 2.5rem">
       <span role="img" aria-label="Yamada Taro">Y</span>
     </div>
-    <div class="b--avatar b--avatar--initial l--frame -w -bgc:brand -c:base" style="--w: 4rem">
+    <div class="b--avatar b--avatar--initial l--center -w -bgc:brand -c:base" style="--w: 3rem">
       <span role="img" aria-label="鈴木">鈴</span>
-    </div>
-    <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
-      <span aria-hidden="true">Y</span>
     </div>
     ```
   </PreviewCode>

--- a/apps/docs/src/content/ja/ui/Avatar.mdx
+++ b/apps/docs/src/content/ja/ui/Avatar.mdx
@@ -92,9 +92,9 @@ Avatar のベーススタイルは、以下のCSSで定義されています。
 
 ### イニシャル表示
 
-`src`を省略すると、`name`の先頭1文字（`b--avatar_initial`）を表示します。大文字化はCSSの`text-transform: uppercase`で行い、文字サイズはアバターのサイズ（`--w`）に比例します。
+`src`を省略すると、ルートに`b--avatar--initial`が付き、`name`の先頭1文字（`b--avatar_initial`）を表示します。大文字化はCSSの`text-transform: uppercase`で行い、文字サイズはアバターのサイズ（`--w`）に比例します。
 
-イニシャル表示時の背景色はルート要素側に当てているため、`bgc`などのPropで上書きできます。
+背景色は`b--avatar--initial`（ルート要素）側に当てているため、`bgc`などのPropで上書きできます。
 
 <Preview>
   <PreviewTitle>`src`を省略してイニシャルを表示する</PreviewTitle>
@@ -114,13 +114,13 @@ Avatar のベーススタイルは、以下のCSSで定義されています。
   </PreviewCode>
   <PreviewCode slot="tab" label="HTML">
     ```html
-    <div class="b--avatar l--frame -w" style="--w: 4rem">
+    <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
       <span class="b--avatar_initial" role="img" aria-label="Yamada Taro">Y</span>
     </div>
-    <div class="b--avatar l--frame -w -bgc:brand -c:base" style="--w: 4rem">
+    <div class="b--avatar b--avatar--initial l--frame -w -bgc:brand -c:base" style="--w: 4rem">
       <span class="b--avatar_initial" role="img" aria-label="鈴木">鈴</span>
     </div>
-    <div class="b--avatar l--frame -w" style="--w: 4rem">
+    <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
       <span class="b--avatar_initial" aria-hidden="true">Y</span>
     </div>
     ```

--- a/apps/docs/src/content/ja/ui/Avatar.mdx
+++ b/apps/docs/src/content/ja/ui/Avatar.mdx
@@ -5,7 +5,7 @@ description: '@lism-css/ui で提供する Avatar コンポーネントについ
 import { Flex, Center, Frame } from 'lism-css/astro';
 import { Avatar } from '@lism-css/ui/astro/Avatar';
 
-アバター画像用のコンポーネントです。
+アバター画像用のコンポーネントです。画像がない場合は、名前のイニシャル1文字をプレースホルダーとして表示できます。
 
 
 ## Overview
@@ -55,8 +55,9 @@ Avatar のベーススタイルは、以下のCSSで定義されています。
 | プロパティ | 説明 |
 |---|---|
 |`size`| アバターのサイズを指定します。初期値:`"2em"`|
-|`src`| アバター画像のパス |
-|`alt`| altテキスト |
+|`src`| アバター画像のパス。未指定の場合は`name`のイニシャルを表示します。 |
+|`name`| ユーザー名。`src`未指定時に先頭1文字をイニシャルとして表示します。`alt`未指定時は代替テキストとしても使われます。 |
+|`alt`| 代替テキスト。指定時は`name`より優先されます。隣に名前テキストが並ぶなど読み上げが二重になる場合は`alt=""`で装飾扱いにできます。 |
 {/* |`mediaProps`| 上記以外にメディア側に対してプロパティを指定したい場合はこのプロパティにオブジェクト形式で指定できます。| */}
 
 
@@ -87,6 +88,48 @@ Avatar のベーススタイルは、以下のCSSで定義されています。
     ```
   </PreviewCode>
 </Preview>
+
+
+### イニシャル表示
+
+`src`を省略すると、`name`の先頭1文字（`b--avatar_initial`）を表示します。大文字化はCSSの`text-transform: uppercase`で行い、文字サイズはアバターのサイズ（`--w`）に比例します。
+
+イニシャル表示時の背景色はルート要素側に当てているため、`bgc`などのPropで上書きできます。
+
+<Preview>
+  <PreviewTitle>`src`を省略してイニシャルを表示する</PreviewTitle>
+  <PreviewArea p="20" bg=":stripe">
+    <Flex layout="cluster" g="20" ai="center">
+      <Avatar size="4rem" name="Yamada Taro" />
+      <Avatar size="4rem" name="鈴木" bgc="brand" c="base" />
+      <Avatar size="4rem" name="Yamada Taro" alt="" />
+    </Flex>
+  </PreviewArea>
+  <PreviewCode slot="tab" label="JSX">
+    ```jsx
+    <Avatar size="4rem" name="Yamada Taro" />
+    <Avatar size="4rem" name="鈴木" bgc="brand" c="base" />
+    <Avatar size="4rem" name="Yamada Taro" alt="" />
+    ```
+  </PreviewCode>
+  <PreviewCode slot="tab" label="HTML">
+    ```html
+    <div class="b--avatar l--frame -w" style="--w: 4rem">
+      <span class="b--avatar_initial" role="img" aria-label="Yamada Taro">Y</span>
+    </div>
+    <div class="b--avatar l--frame -w -bgc:brand -c:base" style="--w: 4rem">
+      <span class="b--avatar_initial" role="img" aria-label="鈴木">鈴</span>
+    </div>
+    <div class="b--avatar l--frame -w" style="--w: 4rem">
+      <span class="b--avatar_initial" aria-hidden="true">Y</span>
+    </div>
+    ```
+  </PreviewCode>
+</Preview>
+
+:::note
+画像の読み込み失敗時にイニシャルへ切り替える機能はありません。Astro版が静的HTMLのため、クライアントJSでのロード状態監視は持ち込まない方針です。
+:::
 
 
 ## Without @lism-css/ui

--- a/apps/docs/src/content/ja/ui/Avatar.mdx
+++ b/apps/docs/src/content/ja/ui/Avatar.mdx
@@ -92,9 +92,9 @@ Avatar のベーススタイルは、以下のCSSで定義されています。
 
 ### イニシャル表示
 
-`src`を省略すると、ルートに`b--avatar--initial`が付き、`name`の先頭1文字（`b--avatar_initial`）を表示します。大文字化はCSSの`text-transform: uppercase`で行い、文字サイズはアバターのサイズ（`--w`）に比例します。
+`src`を省略すると、ルートに`b--avatar--initial`が付き、`name`の先頭1文字を中央に表示します。大文字化はCSSの`text-transform: uppercase`で行い、文字サイズはアバターのサイズ（`--w`）に比例します。
 
-背景色は`b--avatar--initial`（ルート要素）側に当てているため、`bgc`などのPropで上書きできます。
+スタイルはルートの`b--avatar--initial`に当てているため、背景色は`bgc`などのPropで上書きできます。
 
 <Preview>
   <PreviewTitle>`src`を省略してイニシャルを表示する</PreviewTitle>
@@ -115,13 +115,13 @@ Avatar のベーススタイルは、以下のCSSで定義されています。
   <PreviewCode slot="tab" label="HTML">
     ```html
     <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
-      <span class="b--avatar_initial" role="img" aria-label="Yamada Taro">Y</span>
+      <span role="img" aria-label="Yamada Taro">Y</span>
     </div>
     <div class="b--avatar b--avatar--initial l--frame -w -bgc:brand -c:base" style="--w: 4rem">
-      <span class="b--avatar_initial" role="img" aria-label="鈴木">鈴</span>
+      <span role="img" aria-label="鈴木">鈴</span>
     </div>
     <div class="b--avatar b--avatar--initial l--frame -w" style="--w: 4rem">
-      <span class="b--avatar_initial" aria-hidden="true">Y</span>
+      <span aria-hidden="true">Y</span>
     </div>
     ```
   </PreviewCode>

--- a/packages/lism-ui/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/lism-ui/src/components/Avatar/Avatar.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof Avatar> = {
   tags: ['autodocs'],
   argTypes: {
     src: { control: 'text' },
+    name: { control: 'text' },
     alt: { control: 'text' },
     size: { control: 'text' },
   },
@@ -38,5 +39,22 @@ export const Large: Story = {
     src: 'https://cdn.lism-css.com/dummy-image.jpg',
     alt: '',
     size: '8rem',
+  },
+};
+
+export const Initial: Story = {
+  name: 'イニシャル表示（src なし）',
+  args: {
+    name: 'Yamada Taro',
+    size: '4rem',
+  },
+};
+
+export const InitialDecorative: Story = {
+  name: 'イニシャル表示（装飾扱い）',
+  args: {
+    name: 'Yamada Taro',
+    alt: '',
+    size: '4rem',
   },
 };

--- a/packages/lism-ui/src/components/Avatar/_style.css
+++ b/packages/lism-ui/src/components/Avatar/_style.css
@@ -5,14 +5,14 @@
     width: var(--w);
     aspect-ratio: 1/1;
     border-radius: var(--bdrs--99);
-
-    /* イニシャル表示時の背景。ルート側に置くことで bgc 等の Property Class で上書きできる */
-    &:has(> .b--avatar_initial) {
-      background-color: var(--base-2);
-    }
   }
 
-  /* src 未指定時のイニシャル表示 */
+  /* src 未指定時（イニシャル表示）の背景。ルート側に置くことで bgc 等の Property Class で上書きできる */
+  .b--avatar--initial {
+    background-color: var(--base-2);
+  }
+
+  /* src 未指定時のイニシャル文字 */
   .b--avatar_initial {
     display: grid;
     place-items: center;

--- a/packages/lism-ui/src/components/Avatar/_style.css
+++ b/packages/lism-ui/src/components/Avatar/_style.css
@@ -1,5 +1,5 @@
 @layer lism-block {
-  /* Note: src ありは l--frame、イニシャル表示は l--center との併用を前提としています. */
+  /* src ありの通常時: l--frame との併用が前提 */
   .b--avatar {
     --w: 2em; /* size prop未指定時のデフォルトサイズ */
     width: var(--w);
@@ -7,16 +7,16 @@
     border-radius: var(--bdrs--99);
   }
 
-  /* src 未指定時: name のイニシャル1文字を表示する。ルートに当てることで bgc 等の Property Class で上書きできる */
+  /* src 未指定時: name のイニシャル1文字を表示する。l--center との併用が前提 */
   .b--avatar--initial {
+    --lh: 1;
     background-color: var(--base-2);
-    line-height: 1;
     text-transform: uppercase;
     user-select: none;
 
-    /* ルートに font-size を置くと --w: 2em の em が自身の font-size を参照して縮むため、子要素側に置く */
+    /* --w が em単位の時を考慮し、子要素側で計算する */
     > * {
-      font-size: calc(var(--w) / 2.5);
+      font-size: calc(var(--w) / 2);
     }
   }
 }

--- a/packages/lism-ui/src/components/Avatar/_style.css
+++ b/packages/lism-ui/src/components/Avatar/_style.css
@@ -1,5 +1,5 @@
 @layer lism-block {
-  /* Note: l--frame との併用を前提としています. */
+  /* Note: src ありは l--frame、イニシャル表示は l--center との併用を前提としています. */
   .b--avatar {
     --w: 2em; /* size prop未指定時のデフォルトサイズ */
     width: var(--w);
@@ -7,10 +7,8 @@
     border-radius: var(--bdrs--99);
   }
 
-  /* src 未指定時: name のイニシャル1文字を中央に表示する。ルートに当てることで bgc 等の Property Class で上書きできる */
+  /* src 未指定時: name のイニシャル1文字を表示する。ルートに当てることで bgc 等の Property Class で上書きできる */
   .b--avatar--initial {
-    display: grid;
-    place-items: center;
     background-color: var(--base-2);
     line-height: 1;
     text-transform: uppercase;

--- a/packages/lism-ui/src/components/Avatar/_style.css
+++ b/packages/lism-ui/src/components/Avatar/_style.css
@@ -5,5 +5,24 @@
     width: var(--w);
     aspect-ratio: 1/1;
     border-radius: var(--bdrs--99);
+
+    /* イニシャル表示時の背景。ルート側に置くことで bgc 等の Property Class で上書きできる */
+    &:has(> .b--avatar_initial) {
+      background-color: var(--base-2);
+    }
+  }
+
+  /* src 未指定時のイニシャル表示 */
+  .b--avatar_initial {
+    display: grid;
+    place-items: center;
+
+    /* l--frame の子要素ルールは img/video/iframe 限定のため自前で広げる */
+    width: 100%;
+    height: 100%;
+    font-size: calc(var(--w) / 2.5);
+    line-height: 1;
+    text-transform: uppercase;
+    user-select: none;
   }
 }

--- a/packages/lism-ui/src/components/Avatar/_style.css
+++ b/packages/lism-ui/src/components/Avatar/_style.css
@@ -7,22 +7,18 @@
     border-radius: var(--bdrs--99);
   }
 
-  /* src 未指定時（イニシャル表示）の背景。ルート側に置くことで bgc 等の Property Class で上書きできる */
+  /* src 未指定時: name のイニシャル1文字を中央に表示する。ルートに当てることで bgc 等の Property Class で上書きできる */
   .b--avatar--initial {
-    background-color: var(--base-2);
-  }
-
-  /* src 未指定時のイニシャル文字 */
-  .b--avatar_initial {
     display: grid;
     place-items: center;
-
-    /* l--frame の子要素ルールは img/video/iframe 限定のため自前で広げる */
-    width: 100%;
-    height: 100%;
-    font-size: calc(var(--w) / 2.5);
+    background-color: var(--base-2);
     line-height: 1;
     text-transform: uppercase;
     user-select: none;
+
+    /* ルートに font-size を置くと --w: 2em の em が自身の font-size を参照して縮むため、子要素側に置く */
+    > * {
+      font-size: calc(var(--w) / 2.5);
+    }
   }
 }

--- a/packages/lism-ui/src/components/Avatar/astro/Avatar.astro
+++ b/packages/lism-ui/src/components/Avatar/astro/Avatar.astro
@@ -1,7 +1,7 @@
 ---
 import type { HTMLTag, Polymorphic } from 'astro/types';
 import type { AstroLismBaseProps } from 'lism-css/astro';
-import { Frame } from 'lism-css/astro';
+import { Lism } from 'lism-css/astro';
 import atts from 'lism-css/lib/helper/atts';
 import getAvatarProps, { type AvatarProps } from '../getProps';
 import '../_style.css';
@@ -12,6 +12,6 @@ const { size, src, name, alt, class: className, ...props } = Astro.props;
 const { label, initial, initialAtts } = getAvatarProps({ name, alt });
 ---
 
-<Frame class={atts(className, 'b--avatar', !src && 'b--avatar--initial')} w={size} {...props}>
+<Lism layout={src ? 'frame' : 'center'} class={atts(className, 'b--avatar', !src && 'b--avatar--initial')} w={size} {...props}>
   {src ? <img src={src} alt={label} width="100%" height="100%" decoding="async" /> : <span {...initialAtts}>{initial}</span>}
-</Frame>
+</Lism>

--- a/packages/lism-ui/src/components/Avatar/astro/Avatar.astro
+++ b/packages/lism-ui/src/components/Avatar/astro/Avatar.astro
@@ -12,7 +12,7 @@ const { size, src, name, alt, class: className, ...props } = Astro.props;
 const { label, initial, initialAtts } = getAvatarProps({ name, alt });
 ---
 
-<Frame class={atts(className, 'b--avatar')} w={size} {...props}>
+<Frame class={atts(className, 'b--avatar', !src && 'b--avatar--initial')} w={size} {...props}>
   {
     src ? (
       <img src={src} alt={label} width="100%" height="100%" decoding="async" />

--- a/packages/lism-ui/src/components/Avatar/astro/Avatar.astro
+++ b/packages/lism-ui/src/components/Avatar/astro/Avatar.astro
@@ -13,13 +13,5 @@ const { label, initial, initialAtts } = getAvatarProps({ name, alt });
 ---
 
 <Frame class={atts(className, 'b--avatar', !src && 'b--avatar--initial')} w={size} {...props}>
-  {
-    src ? (
-      <img src={src} alt={label} width="100%" height="100%" decoding="async" />
-    ) : (
-      <span class="b--avatar_initial" {...initialAtts}>
-        {initial}
-      </span>
-    )
-  }
+  {src ? <img src={src} alt={label} width="100%" height="100%" decoding="async" /> : <span {...initialAtts}>{initial}</span>}
 </Frame>

--- a/packages/lism-ui/src/components/Avatar/astro/Avatar.astro
+++ b/packages/lism-ui/src/components/Avatar/astro/Avatar.astro
@@ -3,18 +3,23 @@ import type { HTMLTag, Polymorphic } from 'astro/types';
 import type { AstroLismBaseProps } from 'lism-css/astro';
 import { Frame } from 'lism-css/astro';
 import atts from 'lism-css/lib/helper/atts';
+import getAvatarProps, { type AvatarProps } from '../getProps';
 import '../_style.css';
 
-type Props<Tag extends HTMLTag = 'div'> = Polymorphic<{ as: Tag }> &
-  AstroLismBaseProps & {
-    size?: string;
-    src?: string;
-    alt?: string;
-  };
+type Props<Tag extends HTMLTag = 'div'> = Polymorphic<{ as: Tag }> & AstroLismBaseProps & AvatarProps;
 
-const { size, src = '', alt = '', class: className, ...props } = Astro.props;
+const { size, src, name, alt, class: className, ...props } = Astro.props;
+const { label, initial, initialAtts } = getAvatarProps({ name, alt });
 ---
 
 <Frame class={atts(className, 'b--avatar')} w={size} {...props}>
-  <img src={src} alt={alt} width="100%" height="100%" decoding="async" />
+  {
+    src ? (
+      <img src={src} alt={label} width="100%" height="100%" decoding="async" />
+    ) : (
+      <span class="b--avatar_initial" {...initialAtts}>
+        {initial}
+      </span>
+    )
+  }
 </Frame>

--- a/packages/lism-ui/src/components/Avatar/getProps.test.ts
+++ b/packages/lism-ui/src/components/Avatar/getProps.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import getAvatarProps from './getProps';
+
+describe('getAvatarProps', () => {
+  it('name の先頭1文字をイニシャルにし、alt 未指定なら name を label にする', () => {
+    expect(getAvatarProps({ name: 'Yamada Taro' })).toEqual({
+      label: 'Yamada Taro',
+      initial: 'Y',
+      initialAtts: { role: 'img', 'aria-label': 'Yamada Taro' },
+    });
+  });
+
+  it('サロゲートペア（絵文字）を壊さずに1文字取る', () => {
+    expect(getAvatarProps({ name: '😀 Smile' }).initial).toBe('😀');
+  });
+
+  it('alt を明示すると name より優先される', () => {
+    const result = getAvatarProps({ name: 'Yamada Taro', alt: '山田太郎のアバター' });
+    expect(result.label).toBe('山田太郎のアバター');
+    expect(result.initial).toBe('Y');
+    expect(result.initialAtts).toEqual({ role: 'img', 'aria-label': '山田太郎のアバター' });
+  });
+
+  it('alt が空文字なら装飾扱い（aria-hidden）になる', () => {
+    const result = getAvatarProps({ name: 'Yamada Taro', alt: '' });
+    expect(result.label).toBe('');
+    expect(result.initialAtts).toEqual({ 'aria-hidden': 'true' });
+  });
+
+  it('name も alt も無ければイニシャル無し・装飾扱いになる', () => {
+    expect(getAvatarProps({})).toEqual({
+      label: '',
+      initial: '',
+      initialAtts: { 'aria-hidden': 'true' },
+    });
+  });
+});

--- a/packages/lism-ui/src/components/Avatar/getProps.test.ts
+++ b/packages/lism-ui/src/components/Avatar/getProps.test.ts
@@ -34,4 +34,12 @@ describe('getAvatarProps', () => {
       initialAtts: { 'aria-hidden': 'true' },
     });
   });
+
+  it('name なし・alt のみなら空のイニシャル要素は装飾扱い（aria-hidden）になる', () => {
+    expect(getAvatarProps({ alt: '説明' })).toEqual({
+      label: '説明',
+      initial: '',
+      initialAtts: { 'aria-hidden': 'true' },
+    });
+  });
 });

--- a/packages/lism-ui/src/components/Avatar/getProps.ts
+++ b/packages/lism-ui/src/components/Avatar/getProps.ts
@@ -10,11 +10,12 @@ export type AvatarProps = {
 /** name / alt から、img の alt と src 未指定時のイニシャル表示に必要な値を求める */
 export default function getAvatarProps({ name, alt }: Pick<AvatarProps, 'name' | 'alt'>) {
   const label = alt ?? name ?? '';
+  // charAt(0) はサロゲートペア（絵文字等）を壊すためコードポイント単位で取る
+  const initial = name ? ([...name][0] ?? '') : '';
   return {
     label,
-    // charAt(0) はサロゲートペア（絵文字等）を壊すためコードポイント単位で取る
-    initial: name ? ([...name][0] ?? '') : '',
-    // img の alt と同じ読み上げになるよう role="img"。label が空なら装飾扱い
-    initialAtts: label ? { role: 'img' as const, 'aria-label': label } : { 'aria-hidden': 'true' as const },
+    initial,
+    // 表示する initial と label の両方があるときだけ画像として公開。空の span に aria-label だけ付けない
+    initialAtts: initial && label ? { role: 'img' as const, 'aria-label': label } : { 'aria-hidden': 'true' as const },
   };
 }

--- a/packages/lism-ui/src/components/Avatar/getProps.ts
+++ b/packages/lism-ui/src/components/Avatar/getProps.ts
@@ -1,0 +1,20 @@
+export type AvatarProps = {
+  size?: string;
+  src?: string;
+  /** イニシャルの生成元。alt 未指定時は代替テキストにも使う */
+  name?: string;
+  /** 代替テキスト。指定時は name より優先。'' で装飾扱い */
+  alt?: string;
+};
+
+/** name / alt から、img の alt と src 未指定時のイニシャル表示に必要な値を求める */
+export default function getAvatarProps({ name, alt }: Pick<AvatarProps, 'name' | 'alt'>) {
+  const label = alt ?? name ?? '';
+  return {
+    label,
+    // charAt(0) はサロゲートペア（絵文字等）を壊すためコードポイント単位で取る
+    initial: name ? ([...name][0] ?? '') : '',
+    // img の alt と同じ読み上げになるよう role="img"。label が空なら装飾扱い
+    initialAtts: label ? { role: 'img' as const, 'aria-label': label } : { 'aria-hidden': 'true' as const },
+  };
+}

--- a/packages/lism-ui/src/components/Avatar/react/Avatar.tsx
+++ b/packages/lism-ui/src/components/Avatar/react/Avatar.tsx
@@ -2,18 +2,28 @@ import type { ElementType } from 'react';
 import { Frame, type LayoutComponentProps } from 'lism-css/react';
 import type { FrameProps } from 'lism-css/lib/types/LayoutProps';
 import atts from 'lism-css/lib/helper/atts';
+import getAvatarProps, { type AvatarProps } from '../getProps';
 import '../_style.css';
 
-type AvatarProps<T extends ElementType = 'div'> = LayoutComponentProps<T, FrameProps> & {
-  size?: string;
-  src?: string;
-  alt?: string;
-};
+export function Avatar<T extends ElementType = 'div'>({
+  size,
+  src,
+  name,
+  alt,
+  className,
+  ...props
+}: LayoutComponentProps<T, FrameProps> & AvatarProps) {
+  const { label, initial, initialAtts } = getAvatarProps({ name, alt });
 
-export function Avatar<T extends ElementType = 'div'>({ size, src = '', alt = '', className, ...props }: AvatarProps<T>) {
   return (
     <Frame className={atts(className, 'b--avatar')} w={size} {...(props as LayoutComponentProps<T, FrameProps>)}>
-      <img src={src} alt={alt} width="100%" height="100%" decoding="async" />
+      {src ? (
+        <img src={src} alt={label} width="100%" height="100%" decoding="async" />
+      ) : (
+        <span className="b--avatar_initial" {...initialAtts}>
+          {initial}
+        </span>
+      )}
     </Frame>
   );
 }

--- a/packages/lism-ui/src/components/Avatar/react/Avatar.tsx
+++ b/packages/lism-ui/src/components/Avatar/react/Avatar.tsx
@@ -16,7 +16,7 @@ export function Avatar<T extends ElementType = 'div'>({
   const { label, initial, initialAtts } = getAvatarProps({ name, alt });
 
   return (
-    <Frame className={atts(className, 'b--avatar')} w={size} {...(props as LayoutComponentProps<T, FrameProps>)}>
+    <Frame className={atts(className, 'b--avatar', !src && 'b--avatar--initial')} w={size} {...(props as LayoutComponentProps<T, FrameProps>)}>
       {src ? (
         <img src={src} alt={label} width="100%" height="100%" decoding="async" />
       ) : (

--- a/packages/lism-ui/src/components/Avatar/react/Avatar.tsx
+++ b/packages/lism-ui/src/components/Avatar/react/Avatar.tsx
@@ -1,23 +1,20 @@
 import type { ElementType } from 'react';
-import { Frame, type LayoutComponentProps } from 'lism-css/react';
-import type { FrameProps } from 'lism-css/lib/types/LayoutProps';
+import { Lism, type LayoutComponentProps, type LismComponentProps } from 'lism-css/react';
 import atts from 'lism-css/lib/helper/atts';
 import getAvatarProps, { type AvatarProps } from '../getProps';
 import '../_style.css';
 
-export function Avatar<T extends ElementType = 'div'>({
-  size,
-  src,
-  name,
-  alt,
-  className,
-  ...props
-}: LayoutComponentProps<T, FrameProps> & AvatarProps) {
+export function Avatar<T extends ElementType = 'div'>({ size, src, name, alt, className, ...props }: LayoutComponentProps<T> & AvatarProps) {
   const { label, initial, initialAtts } = getAvatarProps({ name, alt });
 
   return (
-    <Frame className={atts(className, 'b--avatar', !src && 'b--avatar--initial')} w={size} {...(props as LayoutComponentProps<T, FrameProps>)}>
+    <Lism
+      layout={src ? 'frame' : 'center'}
+      className={atts(className, 'b--avatar', !src && 'b--avatar--initial')}
+      w={size}
+      {...(props as LismComponentProps<T>)}
+    >
       {src ? <img src={src} alt={label} width="100%" height="100%" decoding="async" /> : <span {...initialAtts}>{initial}</span>}
-    </Frame>
+    </Lism>
   );
 }

--- a/packages/lism-ui/src/components/Avatar/react/Avatar.tsx
+++ b/packages/lism-ui/src/components/Avatar/react/Avatar.tsx
@@ -17,13 +17,7 @@ export function Avatar<T extends ElementType = 'div'>({
 
   return (
     <Frame className={atts(className, 'b--avatar', !src && 'b--avatar--initial')} w={size} {...(props as LayoutComponentProps<T, FrameProps>)}>
-      {src ? (
-        <img src={src} alt={label} width="100%" height="100%" decoding="async" />
-      ) : (
-        <span className="b--avatar_initial" {...initialAtts}>
-          {initial}
-        </span>
-      )}
+      {src ? <img src={src} alt={label} width="100%" height="100%" decoding="async" /> : <span {...initialAtts}>{initial}</span>}
     </Frame>
   );
 }

--- a/packages/mcp/src/data/docs-index.json
+++ b/packages/mcp/src/data/docs-index.json
@@ -1473,9 +1473,23 @@
     "title": "Avatar",
     "description": "@lism-css/ui で提供する Avatar コンポーネントについて解説します。",
     "category": "ui",
-    "headings": ["Overview", "Styles", "How to use", "Import", "Props", "Examples", "Without @lism-css/ui"],
-    "keywords": ["Avatar", "アバター", "プロフィール", "画像", "丸", "user icon", "ユーザーアイコン"],
-    "snippet": "アバター画像用のコンポーネント。円形の画像表示に使用。@lism-css/uiパッケージで提供。"
+    "headings": ["Overview", "Styles", "How to use", "Import", "Props", "Examples", "イニシャル表示", "Without @lism-css/ui"],
+    "keywords": [
+      "Avatar",
+      "アバター",
+      "プロフィール",
+      "画像",
+      "丸",
+      "user icon",
+      "ユーザーアイコン",
+      "イニシャル",
+      "initial",
+      "プレースホルダー",
+      "placeholder",
+      "name",
+      "b--avatar_initial"
+    ],
+    "snippet": "アバター画像用のコンポーネント。円形の画像表示に使用。src 未指定時は name の先頭1文字をイニシャル（b--avatar_initial）として表示し、alt は name より優先される代替テキスト（alt=\"\" で装飾扱い）。@lism-css/uiパッケージで提供。"
   },
   {
     "sourcePath": "ui/block-examples/Chat.mdx",

--- a/packages/mcp/src/data/docs-index.json
+++ b/packages/mcp/src/data/docs-index.json
@@ -1487,9 +1487,10 @@
       "プレースホルダー",
       "placeholder",
       "name",
+      "b--avatar--initial",
       "b--avatar_initial"
     ],
-    "snippet": "アバター画像用のコンポーネント。円形の画像表示に使用。src 未指定時は name の先頭1文字をイニシャル（b--avatar_initial）として表示し、alt は name より優先される代替テキスト（alt=\"\" で装飾扱い）。@lism-css/uiパッケージで提供。"
+    "snippet": "アバター画像用のコンポーネント。円形の画像表示に使用。src 未指定時はルートに b--avatar--initial が付き、name の先頭1文字をイニシャル（b--avatar_initial）として表示し、alt は name より優先される代替テキスト（alt=\"\" で装飾扱い）。@lism-css/uiパッケージで提供。"
   },
   {
     "sourcePath": "ui/block-examples/Chat.mdx",

--- a/packages/mcp/src/data/docs-index.json
+++ b/packages/mcp/src/data/docs-index.json
@@ -1487,10 +1487,9 @@
       "プレースホルダー",
       "placeholder",
       "name",
-      "b--avatar--initial",
-      "b--avatar_initial"
+      "b--avatar--initial"
     ],
-    "snippet": "アバター画像用のコンポーネント。円形の画像表示に使用。src 未指定時はルートに b--avatar--initial が付き、name の先頭1文字をイニシャル（b--avatar_initial）として表示し、alt は name より優先される代替テキスト（alt=\"\" で装飾扱い）。@lism-css/uiパッケージで提供。"
+    "snippet": "アバター画像用のコンポーネント。円形の画像表示に使用。src 未指定時はルートに b--avatar--initial が付き、name の先頭1文字をイニシャルとして中央に表示し、alt は name より優先される代替テキスト（alt=\"\" で装飾扱い）。@lism-css/uiパッケージで提供。"
   },
   {
     "sourcePath": "ui/block-examples/Chat.mdx",

--- a/skills/lism-css-guide/components-ui.md
+++ b/skills/lism-css-guide/components-ui.md
@@ -89,16 +89,19 @@ import { Button } from '@lism-css/ui/astro/Button';
 
 ソース: [Avatar/](https://github.com/lism-css/lism-css/tree/main/packages/lism-ui/src/components/Avatar)
 
-アバター（プロフィール画像）コンポーネント。Frame ベースの円形画像表示。`b--avatar` クラスが付与される。
+アバター（プロフィール画像）コンポーネント。Frame ベースの円形画像表示。`b--avatar` クラスが付与される。`src` 未指定時は `name` の先頭1文字をイニシャル（`span.b--avatar_initial`）として表示する（画像ロード失敗時の自動切替は無い）。
 
 | Prop | 型 | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `src` | `string` | — | 画像URL |
-| `alt` | `string` | — | 代替テキスト |
+| `src` | `string` | — | 画像URL。未指定なら `name` のイニシャルを表示 |
+| `name` | `string` | — | ユーザー名。イニシャルの生成元。`alt` 未指定時は代替テキストにも使う |
+| `alt` | `string` | — | 代替テキスト。指定時は `name` より優先。`alt=''` で装飾扱い（イニシャル表示時は `aria-hidden`） |
 | `size` | `string` | `'2em'` | アバターのサイズ |
 
 ```jsx
 <Avatar src='/avatar.jpg' alt='User' size='48px' />
+<Avatar name='Yamada Taro' size='48px' /> {/* イニシャル "Y" を表示 */}
+<Avatar name='Yamada Taro' bgc='brand' c='base' /> {/* 背景色はルートの Prop で上書き可 */}
 ```
 
 

--- a/skills/lism-css-guide/components-ui.md
+++ b/skills/lism-css-guide/components-ui.md
@@ -89,7 +89,7 @@ import { Button } from '@lism-css/ui/astro/Button';
 
 ソース: [Avatar/](https://github.com/lism-css/lism-css/tree/main/packages/lism-ui/src/components/Avatar)
 
-アバター（プロフィール画像）コンポーネント。Frame ベースの円形画像表示。`b--avatar` クラスが付与される。`src` 未指定時はルートに `b--avatar--initial`（背景色 `--base-2`・中央寄せ）が付き、`name` の先頭1文字をイニシャルとして `span` で表示する（画像ロード失敗時の自動切替は無い）。
+アバター（プロフィール画像）コンポーネント。円形の画像表示で、`b--avatar` クラスが付与される。`src` ありは `l--frame`、`src` 未指定時は `l--center` に切り替わり、ルートに `b--avatar--initial`（背景色 `--base-2`）が付いて `name` の先頭1文字をイニシャルとして `span` で表示する（画像ロード失敗時の自動切替は無い）。
 
 | Prop | 型 | デフォルト | 説明 |
 | --- | --- | --- | --- |

--- a/skills/lism-css-guide/components-ui.md
+++ b/skills/lism-css-guide/components-ui.md
@@ -89,7 +89,7 @@ import { Button } from '@lism-css/ui/astro/Button';
 
 ソース: [Avatar/](https://github.com/lism-css/lism-css/tree/main/packages/lism-ui/src/components/Avatar)
 
-アバター（プロフィール画像）コンポーネント。Frame ベースの円形画像表示。`b--avatar` クラスが付与される。`src` 未指定時はルートに `b--avatar--initial`（背景色 `--base-2`）が付き、`name` の先頭1文字をイニシャル（`span.b--avatar_initial`）として表示する（画像ロード失敗時の自動切替は無い）。
+アバター（プロフィール画像）コンポーネント。Frame ベースの円形画像表示。`b--avatar` クラスが付与される。`src` 未指定時はルートに `b--avatar--initial`（背景色 `--base-2`・中央寄せ）が付き、`name` の先頭1文字をイニシャルとして `span` で表示する（画像ロード失敗時の自動切替は無い）。
 
 | Prop | 型 | デフォルト | 説明 |
 | --- | --- | --- | --- |

--- a/skills/lism-css-guide/components-ui.md
+++ b/skills/lism-css-guide/components-ui.md
@@ -89,7 +89,7 @@ import { Button } from '@lism-css/ui/astro/Button';
 
 ソース: [Avatar/](https://github.com/lism-css/lism-css/tree/main/packages/lism-ui/src/components/Avatar)
 
-アバター（プロフィール画像）コンポーネント。Frame ベースの円形画像表示。`b--avatar` クラスが付与される。`src` 未指定時は `name` の先頭1文字をイニシャル（`span.b--avatar_initial`）として表示する（画像ロード失敗時の自動切替は無い）。
+アバター（プロフィール画像）コンポーネント。Frame ベースの円形画像表示。`b--avatar` クラスが付与される。`src` 未指定時はルートに `b--avatar--initial`（背景色 `--base-2`）が付き、`name` の先頭1文字をイニシャル（`span.b--avatar_initial`）として表示する（画像ロード失敗時の自動切替は無い）。
 
 | Prop | 型 | デフォルト | 説明 |
 | --- | --- | --- | --- |


### PR DESCRIPTION
Closes #554

## 変更内容

- `Avatar`に`name` propを追加。`src`未指定時はルートを`l--frame`から`l--center`に切り替えて`b--avatar--initial`モディファイアを付け、`name`の先頭1文字を`span`（`role="img"` + `aria-label`）として中央に表示する
- `alt`は残し、未指定時は`name`にフォールバック。`alt=""`で装飾扱い（img版は`alt=""`、イニシャル版は`aria-hidden="true"`）
- `src = ''` / `alt = ''`のデフォルト引数を削除
- イニシャル抽出はコードポイント単位（`[...name][0]`）。React / Astroで共有するため`getProps.ts`に切り出し、vitestを追加
- CSS: `.b--avatar--initial`に背景`--base-2`・`--lh: 1`・`text-transform: uppercase`・`user-select: none`。中央寄せは`l--center`に任せる。文字サイズは`> * { font-size: calc(var(--w) / 2) }`で子要素側に置く（ルートに置くと`--w: 2em`のようなem指定時に自身のfont-sizeを参照して縮むため）
- docs（ja / en）に`name`/`alt`の説明と「イニシャル表示」の例を追加。`skills/lism-css-guide/components-ui.md`・MCP `docs-index.json`を追随
- Storybookにイニシャル表示のstoryを追加

## Issueからの調整点

- **子要素のクラスを持たない**: Issue案の`span.b--avatar_initial`は設けず、ルートの`b--avatar--initial`モディファイアだけでスタイルを当てます（既存の`b--badge--outline`等と同じBEM規約）。背景をルート側に置くことで、Issueの「利用者側がFrameのpropsで上書き可能」も成立します（子要素に背景を置くと全面を覆うため`bgc` propで上書きできません）。
- **`l--frame` / `l--center`の切り替え**: `Frame`固定ではなく`Lism layout={src ? 'frame' : 'center'}`にし、イニシャル表示の中央寄せをprimitiveに任せてCSSを減らしました。
- **文字サイズ**: Issue案の`--w / 2.5`から目視調整で`--w / 2`にしました。
- **`alt`とイニシャル版の`aria-label`**: `alt`を明示した場合はイニシャル版の`aria-label`にも`alt`を使い、img版と読み上げを揃えています（未指定時はIssueどおり`name`）。

## やらないこと（Issueどおり）

- 画像ロード失敗時のJSによるフォールバック切替（docsにnoteとして明記）
- 2文字イニシャルの自動生成

## 確認

- `packages/lism-ui`で`pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm build`: 成功
- `dist/style.css`に`.b--avatar--initial`のスタイルが出力されることを確認
- `registry-index.json` / `package.json`（exports）に差分なし
- docsのdevサーバーでイニシャル表示が円形で描画されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKRNAaE1Z6qXCyNzG4rv2i
