### PR TITLE
fix(core): -bdのborder-width/colorをunlayeredに出し、上位レイヤーのborderショートハンドに負けないようにする

### DIFF
--- a/apps/docs/src/content/en/property-class/bd.mdx
+++ b/apps/docs/src/content/en/property-class/bd.mdx
@@ -15,7 +15,7 @@ Border-related properties in Lism follow a slightly different convention.
 
 <PreviewTitle>css</PreviewTitle>
 ```scss
-/* Only the variable defaults live in the weak position (@layer lism-base) */
+/* Only the variable defaults live in the weak position (@layer lism-base in the layered build, :where() in the no_layer build) */
 :where(.-bd, [class*=' -bd-'], [class^='-bd-']) {
   --bds: solid;
   --bdw: 1px;

--- a/apps/docs/src/content/en/property-class/bd.mdx
+++ b/apps/docs/src/content/en/property-class/bd.mdx
@@ -15,10 +15,13 @@ Border-related properties in Lism follow a slightly different convention.
 
 <PreviewTitle>css</PreviewTitle>
 ```scss
+/* Only the variable defaults live in the weak position (@layer lism-base) */
 :where(.-bd, [class*=' -bd-'], [class^='-bd-']) {
   --bds: solid;
   --bdw: 1px;
   --bdc: var(--divider);
+}
+.-bd, [class*=' -bd-'], [class^='-bd-'] {
   border-width: var(--bdw);
   border-color: var(--bdc);
 }

--- a/apps/docs/src/content/ja/property-class/bd.mdx
+++ b/apps/docs/src/content/ja/property-class/bd.mdx
@@ -15,7 +15,7 @@ Lismでは、border系の指定が少し特殊になっています。
 
 <PreviewTitle>css</PreviewTitle>
 ```scss
-/* 変数の初期値だけ弱い位置（@layer lism-base）に置く */
+/* 変数の初期値だけ弱い位置に置く（@layer ビルドでは @layer lism-base、no_layer ビルドでは :where()） */
 :where(.-bd, [class*=' -bd-'], [class^='-bd-']) {
   --bds: solid;
   --bdw: 1px;

--- a/apps/docs/src/content/ja/property-class/bd.mdx
+++ b/apps/docs/src/content/ja/property-class/bd.mdx
@@ -15,10 +15,13 @@ Lismでは、border系の指定が少し特殊になっています。
 
 <PreviewTitle>css</PreviewTitle>
 ```scss
+/* 変数の初期値だけ弱い位置（@layer lism-base）に置く */
 :where(.-bd, [class*=' -bd-'], [class^='-bd-']) {
   --bds: solid;
   --bdw: 1px;
   --bdc: var(--divider);
+}
+.-bd, [class*=' -bd-'], [class^='-bd-'] {
   border-width: var(--bdw);
   border-color: var(--bdc);
 }

--- a/packages/lism-css/src/scss/layer_mode.test.ts
+++ b/packages/lism-css/src/scss/layer_mode.test.ts
@@ -152,6 +152,16 @@ describe('no_layer エントリ', () => {
     expect(css).toMatch(/@layer lism-base \{\s*\.-bd, \[class\*=" -bd-"\], \[class\^=-bd-\] \{/);
   });
 
+  test('-bd は変数の初期値だけを lism-base に置き、border-width / border-color は unlayered に出す', () => {
+    const css = compileEntry('main.scss');
+
+    // lism-base 側は変数3つだけで閉じる（border-* を含めると上位レイヤーの border ショートハンドに負ける）
+    expect(css).toMatch(
+      /@layer lism-base \{\s*\.-bd, \[class\*=" -bd-"\], \[class\^=-bd-\] \{\s*--bds: solid;\s*--bdw: 1px;\s*--bdc: var\(--divider\);\s*\}\s*\}/
+    );
+    expect(css).toMatch(/\n\.-bd,\s*\[class\*=" -bd-"\],\s*\[class\^=-bd-\] \{\s*border-width: var\(--bdw\);\s*border-color: var\(--bdc\);\s*\}/);
+  });
+
   test('単体エントリ utility/index.scss は $layer_mode 既定のため二重化しない', () => {
     const css = compileEntry('utility/index.scss');
 

--- a/packages/lism-css/src/scss/props/_border.scss
+++ b/packages/lism-css/src/scss/props/_border.scss
@@ -10,19 +10,21 @@
 	--bdw を変化させることで方向を変化させたりできるようになっている。
 */
 
-// Memo: base レイヤーで初期値セット済み
-// bdc, bdw などでカラーや太さを上書きできるように border 自体を変数管理
-// @layer ありビルドでは lism-base へ退避する（unlayered 位置だと :where() で詳細度 0 でも
-// 「unlayered > 全レイヤー」のルールで b-- 等の border 指定に勝ってしまうため）。
-// no_layer ビルドでは :where() で詳細度 0 にする。
+// 変数の初期値だけ弱い位置（lism-base / :where()）に置き、b-- 側の変数上書きを効かせる。
+// border-* まで弱い位置に置くと、上位レイヤーの `border: none` に太さ・色が負けて 3px の文字色ボーダーになる。
 @include mixin.in_base_layer {
   #{mixin.maybe_where('.-bd,[class*=" -bd-"],[class^="-bd-"]')} {
     --bds: solid;
     --bdw: 1px;
     --bdc: var(--divider);
-    border-width: var(--bdw) #{mixin.$maybe_important};
-    border-color: var(--bdc) #{mixin.$maybe_important};
   }
+}
+
+.-bd,
+[class*=' -bd-'],
+[class^='-bd-'] {
+  border-width: var(--bdw) #{mixin.$maybe_important};
+  border-color: var(--bdc) #{mixin.$maybe_important};
 }
 
 .-bd {

--- a/skills/lism-css-guide/property-class/bd.md
+++ b/skills/lism-css-guide/property-class/bd.md
@@ -12,10 +12,13 @@ Lism CSS のボーダーは、CSS 変数（`--bds` / `--bdw` / `--bdc`）で管�
 `-bd` または `-bd-{side}` クラスが付くと、以下の初期値がセットされる。
 
 ```scss
+/* 変数の初期値だけ弱い位置（@layer lism-base）に置く */
 :where(.-bd, [class*=" -bd-"], [class^="-bd-"]) {
   --bds: solid;
   --bdw: 1px;
   --bdc: var(--divider);
+}
+.-bd, [class*=" -bd-"], [class^="-bd-"] {
   border-width: var(--bdw);
   border-color: var(--bdc);
 }

--- a/skills/lism-css-guide/property-class/bd.md
+++ b/skills/lism-css-guide/property-class/bd.md
@@ -12,7 +12,7 @@ Lism CSS のボーダーは、CSS 変数（`--bds` / `--bdw` / `--bdc`）で管�
 `-bd` または `-bd-{side}` クラスが付くと、以下の初期値がセットされる。
 
 ```scss
-/* 変数の初期値だけ弱い位置（@layer lism-base）に置く */
+/* 変数の初期値だけ弱い位置に置く（@layer ビルドでは @layer lism-base、no_layer ビルドでは :where()） */
 :where(.-bd, [class*=" -bd-"], [class^="-bd-"]) {
   --bds: solid;
   --bdw: 1px;


### PR DESCRIPTION
## 概要

`-bd` / `-bd-{side}` の `border-width` / `border-color` を `lism-base` レイヤーから unlayered に移動し、上位レイヤーの `border` ショートハンドに負けないようにします。

## 背景

`-bd` は `border-style` だけ unlayered で、太さと色は `lism-base` に置いていました。そのため `b--` などの上位レイヤーで `border: none` のようなショートハンドを書くと、太さが `medium`、色が `currentcolor` にリセットされて `lism-base` の 1px / divider に勝ちます。そこへ `-bd` の `border-style: solid` だけが乗り、3px の文字色ボーダーになっていました。

#588 の Popover で顕在化しました。UA の `[popover] { border: solid }` を消すために `border: none` を書いており、`-bd` を付けると太いボーダーが出ます。

他の Property Class は「unlayered が層付きクラスに勝つ」のに、`-bd` の太さと色だけ層付きクラスに負けるのは Lism の中で例外になっていました。

## 変更内容

- `_border.scss`: 変数の初期値（`--bds` / `--bdw` / `--bdc`）だけを `lism-base`（no_layer では `:where()`）に残し、`border-width` / `border-color` は unlayered の `.-bd, [class*=" -bd-"], [class^="-bd-"]` に出す。
- `layer_mode.test.ts`: 「base 層は変数3つだけ」「太さと色は層の外」を確認するテストを追加。
- `bd.mdx`（ja / en）と `skills/lism-css-guide/property-class/bd.md` の CSS スニペットを更新。

## 影響

- Button / Badge / Alert / `u--cbox` / `u--divide` は変数経由なので挙動は変わりません。
- no_layer ビルドでは太さと色はもともと `!important` 付きなので、実質変わりません。
- 変わるのは、層付きクラスで `border: 2px solid red` のように直書きして `-bd` で style だけ点けていたケースです。その場合は `--bdw` / `--bdc` で指定する形に移行してください。

## 関連

- #588（このPRのマージ後は、Popover 側は `border: none` のままで動きます）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXGPvqmfgS3uiqfax9vNS8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - ボーダー指定が他のスタイルによって意図せず上書きされる問題を修正しました。
  - ボーダーの太さと色が、指定どおり正しく適用されるようになりました。

- **ドキュメント**
  - ボーダープロパティクラスの仕組みとCSS例を更新しました。
  - 英語・日本語のドキュメントで、初期値と適用ルールの説明を整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->