### PR TITLE
lism-cli create に --ref オプションを追加する

### DIFF
--- a/packages/create-lism/src/index.ts
+++ b/packages/create-lism/src/index.ts
@@ -38,7 +38,14 @@ async function main(): Promise<void> {
     } else if (a.startsWith('--lang=')) {
       // 先行走査で処理済み
     } else if (a === '--ref') {
-      ref = args[++i];
+      const next = args[i + 1];
+      // 次が無い、または別オプションなら値不足として終了する（`--ref --help` で --help を消費しない）
+      if (!next || next.startsWith('-')) {
+        process.stderr.write("error: option '--ref <ref>' argument missing\n");
+        process.exit(1);
+      }
+      ref = next;
+      i++;
     } else if (a.startsWith('--ref=')) {
       ref = a.slice('--ref='.length);
     } else if (a === '-h' || a === '--help') {

--- a/packages/create-lism/src/index.ts
+++ b/packages/create-lism/src/index.ts
@@ -10,6 +10,7 @@ async function main(): Promise<void> {
   let force = false;
   let showHelp = false;
   let lang: string | undefined;
+  let ref: string | undefined;
 
   // --help の description や printHelp 表示に言語選択を反映させるため、
   // まず `--lang` を先に走査してから残りの引数を処理する。
@@ -36,6 +37,10 @@ async function main(): Promise<void> {
       i++;
     } else if (a.startsWith('--lang=')) {
       // 先行走査で処理済み
+    } else if (a === '--ref') {
+      ref = args[++i];
+    } else if (a.startsWith('--ref=')) {
+      ref = a.slice('--ref='.length);
     } else if (a === '-h' || a === '--help') {
       showHelp = true;
     } else if (!a.startsWith('-')) {
@@ -48,7 +53,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  await runCreate({ template, targetDir, force, lang });
+  await runCreate({ template, targetDir, force, lang, ref });
 }
 
 function printHelp(): void {
@@ -60,6 +65,7 @@ function printHelp(): void {
       `  -t, --template <name>   ${t('cli.create.opt.template')}`,
       `  -f, --force             ${t('cli.create.opt.force')}`,
       `      --lang <code>       ${t('cli.opt.lang')}`,
+      `      --ref <ref>         ${t('cli.create.opt.ref')}`,
       `  -h, --help              ${t('common.help')}`,
       '',
     ].join('\n')

--- a/packages/lism-cli/src/commands/create.test.ts
+++ b/packages/lism-cli/src/commands/create.test.ts
@@ -151,6 +151,16 @@ describe('runCreate', () => {
     expect(pkg.dependencies['lism-css']).not.toBe('workspace:*');
   });
 
+  it('ref指定時はそのrefのテンプレートを取得する', async () => {
+    await runCreate({ template: 'minimal-astro', targetDir: 'my-app', force: true, ref: 'dev' });
+
+    expect(downloadTemplate).toHaveBeenCalledWith('github:lism-css/lism-css/templates/minimal/astro#dev', {
+      dir: path.join(tmpDir, 'my-app'),
+      force: true,
+      forceClean: true,
+    });
+  });
+
   it('workspace依存をnpmレジストリのlatestへ置換する', async () => {
     mockTemplateWithWorkspaceDeps();
     const latest: Record<string, string> = {

--- a/packages/lism-cli/src/commands/create.ts
+++ b/packages/lism-cli/src/commands/create.ts
@@ -63,6 +63,7 @@ const CATEGORIES: CategoryDef[] = [
 interface CreateOptions {
   template?: string;
   force?: boolean;
+  ref?: string;
 }
 
 /** commander の action 第3引数（グローバル --lang を読むために最小限の構造だけ受ける） */
@@ -74,6 +75,8 @@ export interface RunCreateArgs {
   template?: string;
   targetDir?: string;
   force?: boolean;
+  /** テンプレ取得元の Git ref。未指定なら `DEFAULT_TEMPLATES_REF`。 */
+  ref?: string;
   /**
    * 明示指定された言語（`--lang`）。`ja` / `en` のときその言語で CLI 表示・テンプレ生成を確定する。
    * 未指定（undefined / 不正値）の場合は、対話端末では最初に言語選択プロンプトを出し、
@@ -82,12 +85,15 @@ export interface RunCreateArgs {
   lang?: string;
 }
 
-export async function runCreate({ template, targetDir, force = false, lang }: RunCreateArgs): Promise<void> {
-  await runCreateWithTemplates({ template, targetDir, force, lang }, TEMPLATES);
+export async function runCreate({ template, targetDir, force = false, lang, ref }: RunCreateArgs): Promise<void> {
+  await runCreateWithTemplates({ template, targetDir, force, lang, ref }, TEMPLATES);
 }
 
 /** 言語とテンプレートを解決し、取得したテンプレートへ生成後の変換を適用する。 */
-export async function runCreateWithTemplates({ template, targetDir, force = false, lang }: RunCreateArgs, templates: TemplateDef[]): Promise<void> {
+export async function runCreateWithTemplates(
+  { template, targetDir, force = false, lang, ref = DEFAULT_TEMPLATES_REF }: RunCreateArgs,
+  templates: TemplateDef[]
+): Promise<void> {
   const resolvedLang = await resolveLang(lang);
   setLang(resolvedLang);
 
@@ -107,7 +113,6 @@ export async function runCreateWithTemplates({ template, targetDir, force = fals
     }
   }
 
-  const ref = DEFAULT_TEMPLATES_REF;
   logger.info(t('create.fetching', { name: tpl.slug, ref }));
   await downloadTemplateSource(tpl, outDir, ref, force);
 
@@ -125,7 +130,7 @@ export async function createCommand(targetDir: string | undefined, options: Crea
   // ルートプログラムの `--lang` はグローバルオプションなので optsWithGlobals() で取得する。
   const langOpt = command?.optsWithGlobals().lang;
   const lang = typeof langOpt === 'string' ? langOpt : undefined;
-  await runCreate({ template: options.template, targetDir, force: options.force, lang });
+  await runCreate({ template: options.template, targetDir, force: options.force, lang, ref: options.ref });
 }
 
 // 非対話端末はenへフォールバックし、言語選択は現在の言語に依存しない固定表示にする。

--- a/packages/lism-cli/src/createProgram.ts
+++ b/packages/lism-cli/src/createProgram.ts
@@ -27,6 +27,7 @@ export function createLismProgram(): Command {
     .argument('[targetDir]', t('cli.create.arg.targetDir'))
     .option('-t, --template <name>', t('cli.create.opt.template'))
     .option('-f, --force', t('cli.create.opt.force'), false)
+    .option('--ref <ref>', t('cli.create.opt.ref'))
     .action(createCommand);
 
   const init = program.command('init').description(t('cli.init.description'));

--- a/packages/lism-cli/src/messages.ts
+++ b/packages/lism-cli/src/messages.ts
@@ -49,6 +49,10 @@ export const messages = {
     ja: '既存ディレクトリを強制上書き',
     en: 'Overwrite existing directory',
   },
+  'cli.create.opt.ref': {
+    ja: 'テンプレート取得元の Git ref（ブランチ / タグ / コミット）',
+    en: 'Git ref to fetch templates from (branch / tag / commit)',
+  },
 
   // init
   'cli.init.description': {


### PR DESCRIPTION
Closes #593

## 変更内容

`lism-cli create`と`create-lism`に`--ref <ref>`を追加し、テンプレの取得元refを上書きできるようにした。`ui add` / `skill add`と同じ`options.ref ?? DEFAULT_TEMPLATES_REF`の形。

- `createProgram.ts`: `create`に`--ref <ref>`を追加
- `commands/create.ts`: `CreateOptions` / `RunCreateArgs`に`ref?: string`を追加し、`runCreateWithTemplates`の既定値を`DEFAULT_TEMPLATES_REF`にした
- `messages.ts`: `cli.create.opt.ref`のja/en文言を追加
- `create-lism/src/index.ts`: `--ref <ref>` / `--ref=<ref>`の解析と`printHelp`の行を追加
- `create.test.ts`: `ref: 'dev'`で`#dev`付きURLが`downloadTemplate`へ渡るテストを追加

## やらないこと（Issueどおり）

- 既定値は`'main'`のまま
- `packages/lism-cli/README.md`には書かない（`documents/cli-guide.md`の`--ref`節は既に`create`を含んでいる）

## 確認

- `create.test.ts` 30件パス
- `lism-cli` / `create-lism`の`tsc --noEmit`、prettier、eslint OK
- ビルド後の`lism-cli create --help`と`create-lism --help`に`--ref`が表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016odBDupvMDmH995etpy8ke


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `create` コマンドで、テンプレート取得元のGitブランチ・タグ・コミットを `--ref <ref>` または `--ref=<ref>` で指定できるようになりました。
  * 指定したrefがテンプレート取得と関連処理に適用されます。未指定時は既定のrefが使用されます。
  * CLIヘルプにオプションの説明を追加しました。

* **テスト**
  * 指定したrefがテンプレート取得先に正しく反映されることを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->