### PR TITLE
lism-css build のCSS出力を一時ファイル経由の差し替えにし、pnpmストアへの書き換えを防ぐ

### DIFF
--- a/documents/lism-config.md
+++ b/documents/lism-config.md
@@ -1,4 +1,4 @@
-基準日: 2026-09-03・コミット105422df
+基準日: 2026-09-04・コミット5331445f
 
 # lism.config.js メモ（運営者向け）
 
@@ -45,6 +45,7 @@
 
 - 出力先はインストール済み`lism-css`の`dist/css`（`node_modules/lism-css/dist/css`、`builder/paths.ts`の`cssDistDir`）で、同梱CSSを直接上書きする。変更するオプションは無い。
 - 上書きするので、プラグイン無しの`import 'lism-css/main.css'`でも生成後のCSSが読まれる。これが狙い。
+- 書き込みは同じディレクトリの一時ファイルへ書いて`fs.renameSync`で差し替える（`compile.ts`の`writeCss`）。新しい実体になるので、pnpmのハードリンク配置でもストア側のファイルは変わらない。
 - `node_modules`を入れ直すと消える。インストール後に毎回実行する運用にする。
 - 処理フロー5の「`node_modules`内は書き換えない」はSCSSソースの話で、CSS出力先には当てはまらない。
 

--- a/packages/plugin/src/builder/compile.test.ts
+++ b/packages/plugin/src/builder/compile.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, describe, expect, test } from 'vitest';
+import { compileCssTree } from './compile';
+
+const dirs: string[] = [];
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lism-plugin-compile-'));
+  dirs.push(dir);
+  return dir;
+}
+afterAll(() => dirs.forEach((d) => fs.rmSync(d, { recursive: true, force: true })));
+
+describe('compileCssTree', () => {
+  test('既存の出力をその場で上書きせず新しい実体へ差し替える（ハードリンク先を汚さない・#594）', async () => {
+    const scssDir = tmpDir();
+    const distDir = tmpDir();
+    fs.writeFileSync(path.join(scssDir, 'a.scss'), '.a { color: red; }\n');
+
+    // pnpm のハードリンク配置を模す: dist の既存ファイルとストア側が同じ実体。
+    const distPath = path.join(distDir, 'a.css');
+    const storePath = path.join(tmpDir(), 'a.css');
+    fs.writeFileSync(storePath, '/* store */');
+    fs.linkSync(storePath, distPath);
+    expect(fs.statSync(distPath).ino).toBe(fs.statSync(storePath).ino);
+
+    const written = await compileCssTree({ scssDir, distDir, minify: false, log: () => {} });
+
+    expect(written).toEqual([distPath]);
+    expect(fs.readFileSync(distPath, 'utf8')).toContain('.a');
+    expect(fs.readFileSync(storePath, 'utf8')).toBe('/* store */');
+    expect(fs.statSync(distPath).ino).not.toBe(fs.statSync(storePath).ino);
+    // 一時ファイルは残らない。
+    expect(fs.readdirSync(distDir)).toEqual(['a.css']);
+  });
+
+  test('出力先ディレクトリが無ければ作成する', async () => {
+    const scssDir = tmpDir();
+    const distDir = path.join(tmpDir(), 'nested', 'css');
+    fs.writeFileSync(path.join(scssDir, 'b.scss'), '.b { margin: 0; }\n');
+
+    const written = await compileCssTree({ scssDir, distDir, minify: false, log: () => {} });
+
+    expect(written).toEqual([path.join(distDir, 'b.css')]);
+    expect(fs.readdirSync(distDir)).toEqual(['b.css']);
+  });
+});

--- a/packages/plugin/src/builder/compile.ts
+++ b/packages/plugin/src/builder/compile.ts
@@ -11,6 +11,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
+import { randomUUID } from 'node:crypto';
 import * as sass from 'sass';
 import postcss, { type AcceptedPlugin } from 'postcss';
 import autoprefixer from 'autoprefixer';
@@ -151,7 +152,8 @@ function writeCss(filePath: string, css: string): void {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  // worker_threads 間では PID が共通なので、呼び出しごとに一意な値を足して衝突を避ける。
+  const tmpPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
   try {
     fs.writeFileSync(tmpPath, css);
     fs.renameSync(tmpPath, filePath);

--- a/packages/plugin/src/builder/compile.ts
+++ b/packages/plugin/src/builder/compile.ts
@@ -141,10 +141,22 @@ export async function buildCssToDir({
   }
 }
 
+/**
+ * 同じディレクトリの一時ファイルへ書いてから rename で差し替える。
+ * 既存ファイルをその場で上書きすると、pnpm のハードリンク配置ではストア側の実体まで書き換わり、
+ * 同じバージョンをリンクする他プロジェクトへ漏れる。新しい実体に置き換えることでストアには触れない。
+ */
 function writeCss(filePath: string, css: string): void {
   const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-  fs.writeFileSync(filePath, css);
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, css);
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    fs.rmSync(tmpPath, { force: true });
+    throw error;
+  }
 }


### PR DESCRIPTION
## 概要

`lism-css build`のCSS出力を、既存ファイルのその場上書きから「同じディレクトリの一時ファイルへ書いて`fs.renameSync`で差し替える」方式に変えました。新しい実体（inode）になるため、pnpmのハードリンク配置でもストア側のファイルは変わらず、同じバージョンをリンクしている別プロジェクトに影響しません。

Closes #594

## 変更内容

- `packages/plugin/src/builder/compile.ts`の`writeCss`: 一時ファイル（`<出力先>.<pid>.tmp`）へ書いてからrenameで差し替える。rename前に失敗したら一時ファイルを削除して再throwする。
- `packages/plugin/src/builder/compile.test.ts`を追加: ハードリンクで結んだ「ストア側」ファイルが`compileCssTree`後も変わらず、出力先が別inodeになること、一時ファイルが残らないこと、出力先ディレクトリが自動作成されることを確認。
- `documents/lism-config.md`の「`lism-css build`の出力先」節に、一時ファイル経由の差し替えでストアに影響しない旨を1行追加。

## 変えていないこと

- 利用者から見た挙動（`lism-css build`後に`import 'lism-css/main.css'`で反映される、`node_modules`を入れ直すと消える）はそのまま。
- 出力先を`node_modules`の外へ移す案は対象外（Issueの「やらないこと」どおり）。

## 確認

- `packages/plugin`で`build` / `typecheck` / `lint` / `test`を実行。テストは20ファイル・220件すべて通過。lint警告2件は既存の`no-explicit-any`で今回の変更とは無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2b4PJ4TGCRiBz58dS72EZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * CSSビルド時の出力を安全に置き換える方式へ変更し、既存ファイルや共有ストレージの内容が意図せず変更される問題を防止しました。
  * 出力先ディレクトリが存在しない場合でも、自動的に作成されるようになりました。
  * 書き込みに失敗した際、一時ファイルが残らないよう改善しました。

* **ドキュメント**
  * CSSビルド時のファイル書き込み方式に関する説明を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->