### PR TITLE
fix(ui): lism-css本体をexternal化し、distへのコア同梱をやめる

### DIFF
--- a/packages/lism-ui/vite.config.js
+++ b/packages/lism-ui/vite.config.js
@@ -79,7 +79,10 @@ export default defineConfig({
     },
     rollupOptions: {
       plugins: [preserveDirectives()],
-      external: ['react', 'react-dom', 'react/jsx-runtime', 'lism-css/config.js'],
+      // lism-css 本体は dependencies として利用側で解決させる（バンドルするとトークン・CONFIG の
+      // スナップショットが焼き込まれ、lism-css/react と併用時にランタイムが2重になる）。
+      // lism-css/config.js は @lism-css/plugin が利用者の lism.config へ alias する差し替え点なので単独でも external に残す。
+      external: ['react', 'react-dom', 'react/jsx-runtime', 'lism-css/config.js', /^lism-css(\/|$)/],
       output: {
         dir: 'dist',
         // exports: 'named',


### PR DESCRIPTION
Closes #578

## 変更内容

`packages/lism-ui/vite.config.js` の `rollupOptions.external` に `/^lism-css(\/|$)/` を追加し、`lism-css` 本体をバンドル対象から外した。`lism-css/config.js` の external は従来通り維持している。

これにより `@lism-css/ui` の dist は次のように変わる。

- `dist/lism-css/` へのコア一式のコピー出力（37ファイル）が無くなる
- 各モジュールは `lism-css/react` / `lism-css/lib/helper/atts` 等の bare specifier で `lism-css` を import する（`dependencies` の `lism-css` を利用側で解決）
- 型定義（`.d.ts`）は元々 bare specifier で参照していたため変更なし

## 確認事項への回答

- 同梱が意図的だったかどうか: Issue の通り記録は見当たらず、`lism-css/config.js` だけ external にしていた点から本体側は単に external 漏れと判断した。
- npm 利用者側の解決経路: dist 内で使われる `lism-css/*` specifier はすべて `lism-css` の `exports` マップに存在する（`./react`、`./lib/*`）。`@lism-css/ui` は `dependencies` に `lism-css` を持つため、利用者は自動で `lism-css` がインストールされる。
- config alias: `@lism-css/plugin` が差し替える `lism-css/config.js` の import は `lism-css` 自身の `dist/config/index.js` にあり、外部化後は lism-ui 経由でもこの1箇所に集約される。

## 検証

- `build:ui` 成功。dist に `lism-css/dist` への相対参照が残っていないことを確認
- Node の `import.meta.resolve` で、dist 内の全 `lism-css/*` specifier が lism-ui 起点と docs 起点で同じ実体パスに解決されることを確認（型専用の `lib/types/LayoutProps` は `.js` が無いため除外）
- docs の Astro dev サーバーで一時ページを SSR し、`@lism-css/ui/react/DummyText` の `lts="xs"` が `-lts:xs` に、docs の `lism.config.js` で追加した `lts="2xl"` / `p="box"` が `-lts:2xl` / `-p:box` に展開されることを確認（alias が lism-ui 経由でも効いている）
- `@lism-css/ui` の vitest 120件通過
- `check:mockup`（`@lism-css/ui` を使う `__test__` ページを Vite で bundle）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178syj6XmAVdLrRNeNyywNs
