### PR TITLE
feat: -hov:-transform を追加

### DIFF
--- a/apps/docs/src/content/en/property-class/hov.mdx
+++ b/apps/docs/src/content/en/property-class/hov.mdx
@@ -39,6 +39,7 @@ The Lism core package provides the following classes by default:
 | `-hov:-bdc` | `border-color` | `currentColor` |
 | `-hov:-o` | `opacity` | `var(--o--p)` |
 | `-hov:-bxsh` | `box-shadow` | `var(--bxsh--50)` |
+| `-hov:-transform` | `transform` | `translate(0, -4px)` |
 
 
 ### Using default values

--- a/apps/docs/src/content/ja/property-class/hov.mdx
+++ b/apps/docs/src/content/ja/property-class/hov.mdx
@@ -39,6 +39,7 @@ Lismのコアパッケージでは、以下のクラスを標準で用意して�
 | `-hov:-bdc` | `border-color` | `currentColor` |
 | `-hov:-o` | `opacity` | `var(--o--p)` |
 | `-hov:-bxsh` | `box-shadow` | `var(--bxsh--50)` |
+| `-hov:-transform` | `transform` | `translate(0, -4px)` |
 
 
 ### 初期値の活用

--- a/packages/lism-css/src/lib/getLismProps.test.ts
+++ b/packages/lism-css/src/lib/getLismProps.test.ts
@@ -502,6 +502,12 @@ describe('getLismProps', () => {
       expect(result.style?.['--hov-bgc']).toBe('var(--blue)');
     });
 
+    test('hov: transform はトークン変換されず値がそのまま --hov-transform に入る', () => {
+      const result = getLismProps({ hov: { transform: 'scale(1.05)' } });
+      expect(result.className).toContain('-hov:-transform');
+      expect(result.style?.['--hov-transform']).toBe('scale(1.05)');
+    });
+
     test('hov: オブジェクト形式で true の場合はクラスのみ（- は付かない）', () => {
       const result = getLismProps({
         hov: { c: true, shadowUp: true },

--- a/packages/lism-css/src/scss/props/_hover.scss
+++ b/packages/lism-css/src/scss/props/_hover.scss
@@ -21,6 +21,9 @@
   .-hov\:-bxsh:hover {
     box-shadow: var(--hov-bxsh, var(--bxsh--50)) #{mixin.$maybe_important};
   }
+  .-hov\:-transform:hover {
+    transform: var(--hov-transform, translate(0, -4px)) #{mixin.$maybe_important};
+  }
 
   /* ----------------------------------------
    * .-hov:{preset}

--- a/skills/lism-css-guide/property-class.md
+++ b/skills/lism-css-guide/property-class.md
@@ -107,7 +107,7 @@ Lism CSS のボーダーは CSS 変数（`--bds` / `--bdw` / `--bdc`）で管理
 | `-hov:{preset}` | hover 時のスタイルをプリセットで適用 | `:hover`（同上） |
 | `-hov:in:{preset}` | 親の `set--hov` を起点に子のスタイルを変化させる | 親に `set--hov` が必要 |
 
-**標準クラス:** `-hov:-c`, `-hov:-bgc`, `-hov:-bdc`, `-hov:-o`, `-hov:-bxsh`, `-hov:underline`, `-hov:in:hide`, `-hov:in:show`, `-hov:in:zoom`
+**標準クラス:** `-hov:-c`, `-hov:-bgc`, `-hov:-bdc`, `-hov:-o`, `-hov:-bxsh`, `-hov:-transform`, `-hov:underline`, `-hov:in:hide`, `-hov:in:show`, `-hov:in:zoom`
 
 **`<Lism>` の `hov` prop:** 文字列指定（`hov="-c"` → `-hov:-c`。自動変換なし、カンマ区切りで複数可）とオブジェクト指定（`hov={{ c: 'red' }}` → `-hov:-c` + `--hov-c: var(--red)`。値 `true` でクラスのみ出力）が可能。
 

--- a/skills/lism-css-guide/property-class/hov.md
+++ b/skills/lism-css-guide/property-class/hov.md
@@ -31,6 +31,7 @@ hover 時の挙動を制御する Property Class。`:hover` 擬似クラスで�
 | `-hov:-bgc` | `background-color` | `var(--hov-bgc, var(--hov-bgc--default, color-mix(in srgb, var(--bgc, var(--base)), var(--neutral) 25%)))` |
 | `-hov:-o` | `opacity` | `var(--hov-o, var(--o--p))` |
 | `-hov:-bxsh` | `box-shadow` | `var(--hov-bxsh, var(--bxsh--50))` |
+| `-hov:-transform` | `transform` | `var(--hov-transform, translate(0, -4px))` |
 
 任意の値へ変化させたい場合は、`--hov-{prop}` 変数で値を指定する。
 


### PR DESCRIPTION
## 概要

hover時に `transform` を変化させる `-hov:-transform` を追加する。

Closes #390

## 変更内容

- SCSS: `_hover.scss` の `@media (any-hover: hover)` 内に `.-hov\:-transform:hover` を追加。初期値は `translate(0, -4px)`、他の `-hov:-{prop}` と同じく `mixin.$maybe_important` 付き。
- テスト: `getLismProps.test.ts` に `hov: { transform: 'scale(1.05)' }` がトークン変換されずそのまま `--hov-transform` に入るケースを追加。
- ドキュメント: `-hov:-{prop}` 一覧表に1行追加（ja / en の `hov.mdx`、スキルの `property-class/hov.md`）。
- Issueの範囲外だが同じ理由で追従: スキル概要 `property-class.md` の「標準クラス」列挙にも `-hov:-transform` を追加。

JS側（`setHovProps()`）は既存の汎用処理で動くため変更なし。`has--transition` の `--transitionProps` 初期値には `transform` が含まれているため、トランジション側も変更なし。

## 確認

- `getLismProps.test.ts`: 84件パス
- stylelint: `_hover.scss` OK
- `build:css:only`: `main.css` に素の宣言、`main_no_layer.css` に `!important` 付きで出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pwoKzS18SKp1h2gStT3JV
