### PR TITLE
fix: l--flow直下の見出し上余白を微調整し、先頭と is--skipFlow 直後で余白が残る問題を修正

### DIFF
--- a/packages/lism-css/src/scss/primitives/layout/_flow.scss
+++ b/packages/lism-css/src/scss/primitives/layout/_flow.scss
@@ -19,9 +19,11 @@
   --flow: inherit;
 }
 
-// 見出しの上部の余白は広くする.
-.l--flow > :where(h1, h2, h3, h4, h5, h6) {
-  margin-block-start: calc(var(--flow) * 2 + 0.5em);
+// 見出し上部の余白は広くする.
+// em だけの加算だと --flow が小さい時に余白が過大になるため、--flow にも比例させる.
+// h5, h6 はレイアウト上の区切りとして弱いので対象外.
+.l--flow > :where(h1, h2, h3, h4) {
+  margin-block-start: calc(var(--flow) * 1.5 + 0.5em);
 }
 
 // 打ち消し

--- a/packages/lism-css/src/scss/primitives/layout/_flow.scss
+++ b/packages/lism-css/src/scss/primitives/layout/_flow.scss
@@ -3,7 +3,8 @@
 
   > * + * {
     --flow: var(--flow--base);
-    margin-block-start: var(--flow);
+    --mbs: var(--flow);
+    margin-block-start: var(--mbs);
   }
 
   // flow 直下のメディア要素は block に初期リセット
@@ -23,11 +24,12 @@
 // em だけの加算だと --flow が小さい時に余白が過大になるため、--flow にも比例させる.
 // h5, h6 はレイアウト上の区切りとして弱いので対象外.
 .l--flow > :where(h1, h2, h3, h4) {
-  margin-block-start: calc(var(--flow) * 1.5 + 0.5em);
+  --mbs: calc(var(--flow) * 1.5 + 0.5em);
+  margin-block-start: var(--mbs);
 }
 
-// 打ち消し
+// 打ち消し. 見出しは em の定数加算があるため、--flow ではなく --mbs を 0 にする.
 .is--skipFlow + *,
 .l--flow > :first-child {
-  --flow: 0px;
+  --mbs: 0px;
 }

--- a/skills/lism-css-guide/primitives/l--flow.md
+++ b/skills/lism-css-guide/primitives/l--flow.md
@@ -6,7 +6,7 @@
 
 ## 余白の仕組み
 
-`l--flow` 直下の子要素は、`--flow` 変数と `margin-block-start` で間隔が管理されます。見出しタグ（`h1`〜`h6`）のみ余白が大きくなり、`calc(var(--flow) * 2 + 0.5em)` で計算されます。
+`l--flow`直下の子要素は、`--flow`をもとに`--mbs`で上余白を決め、`margin-block-start`に適用します。見出しタグの`h1`〜`h4`は`calc(var(--flow) * 1.5 + 0.5em)`で余白を大きくします。
 
 | クラス | 余白量 |
 | --- | --- |
@@ -19,8 +19,8 @@
 ## 既定の挙動
 
 - `display:flow-root`。
-- 直下の`* + *`へ`margin-block-start:var(--flow)`を付与し、`--flow`は`--flow--base`を初期値にします。
-- 直下の見出しは上余白を広めにし、先頭要素と`is--skipFlow + *`は余白を打ち消します。
+- 直下の`* + *`へ`--flow:var(--flow--base)`、`--mbs:var(--flow)`、`margin-block-start:var(--mbs)`を付与します。
+- 先頭要素と`is--skipFlow + *`は`--mbs:0px`で上余白を打ち消します。
 - 直下の`img`/`video`/`iframe`は`display:block`へ初期化します。
 
 ## 専用Props


### PR DESCRIPTION
## 概要

`l--flow` 直下の見出し上部の余白を微調整する。

- 加算の倍率を `--flow * 2` から `--flow * 1.5` に下げる
- `h5` / `h6` はレイアウト上の区切りとして弱いため、余白の加算対象から外す
- コード内コメントを要点だけに整理

## あわせて修正した不具合

先頭要素や `is--skipFlow` 直後の見出しに、`+ 0.5em` の分だけ上余白が残っていた。見出しの計算式に em の定数加算を入れた時（`4ce5c52b`）からの問題。

`margin-block-start` を `--mbs` 変数経由にし、打ち消しを `--flow: 0px` から `--mbs: 0px` に変更して修正。稀なケースだが、先頭や `is--skipFlow` 直後に置いた入れ子の `l--flow` が親の `--flow` を引き継ぐ時に間隔が 0 になっていた問題も、これで合わせて解消されている。

## ドキュメント追従

- [x] `skills/lism-css-guide/primitives/l--flow.md`（計算式・対象見出し・`--mbs` 経由の打ち消し）
- [ ] `apps/docs` の `l--flow` ページ（ja / en）と MCP の `docs-index.json` は「見出しタグのみ余白が大きくなる」という表現のみ。厳密に書くなら要修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1wL6ca3jKCTxVr752ZvUc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - フローによる要素間の余白計算を調整しました。
  - 見出しの余白拡大対象を h1〜h4 に限定し、余白量を見直しました。
  - 先頭要素やフローをスキップする要素では、余白が適切に打ち消されるようになりました。

- **ドキュメント**
  - フローの余白計算と例外ルールに関する説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->