### PR TITLE
fix(ui): Buttonのfillの--bdc初期値をtransparentに変更

### DIFF
--- a/apps/docs/src/content/en/changelog.mdx
+++ b/apps/docs/src/content/en/changelog.mdx
@@ -14,6 +14,10 @@ Significant changes may continue until v1.0 is released, so all notable changes 
 
 - Moved `lism-css` from `dependencies` to `peerDependencies` (`*`) so CSS is generated from the `lism-css` installed in your project. The plugin no longer bundles its own copy of `lism-css`, so install `lism-css` alongside it (#609).
 
+**`@lism-css/ui`**
+
+- Changed the border color (`--bdc`) of the default `fill` `Button` from `var(--bgc)` to `transparent`, so changing only the background (e.g. `hov="-bgc"`) no longer leaves a border in the original color. Set `--bdc: var(--bgc)` if you want a visible border on hover (see the `hov="reverse"` example).
+
 <Divider bds="dashed" my="40" />
 
 ## lism-css v0.28.2 (2026.09.10)

--- a/apps/docs/src/content/en/ui/Button.mdx
+++ b/apps/docs/src/content/en/ui/Button.mdx
@@ -397,6 +397,7 @@ An example of adding a [`-hov` class](/en/docs/property-class/hov) that swaps th
   --hov-bgc: var(--c);
 }
 .-hov\\:reverse:where(.b--button--fill) {
+  --bdc: var(--bgc);
   --hov-bgc: transparent;
 }
 .-hov\\:reverse:where(.b--button--outline) {
@@ -426,6 +427,7 @@ An example of adding a [`-hov` class](/en/docs/property-class/hov) that swaps th
     --hov-c: var(--bgc);
     --hov-bgc: var(--c);
     &:where(.b--button--fill) {
+      --bdc: var(--bgc);
       --hov-bgc: transparent;
     }
     &:where(.b--button--outline) {

--- a/apps/docs/src/content/ja/changelog.mdx
+++ b/apps/docs/src/content/ja/changelog.mdx
@@ -14,6 +14,10 @@ v1.0のリリースまでは大きな変更が続く可能性があるため、�
 
 - `lism-css`を`dependencies`から`peerDependencies`（`*`）へ移し、利用側にインストールされている`lism-css`からCSSを生成するようにしました。pluginが`lism-css`を同梱しなくなるため、`lism-css`は利用側で導入してください（#609）。
 
+**`@lism-css/ui`**
+
+- `Button`の`fill`（既定）のボーダー色`--bdc`を`var(--bgc)`から`transparent`へ変更しました。`hov="-bgc"`などで背景色だけを変えたときに、ボーダーが元の色で縁として残らなくなります。ホバー時に枠線を残したい場合は`--bdc: var(--bgc)`を指定してください（`hov="reverse"`の例を参照）。
+
 <Divider bds="dashed" my="40" />
 
 ## lism-css v0.28.2 (2026.09.10)

--- a/apps/docs/src/content/ja/ui/Button.mdx
+++ b/apps/docs/src/content/ja/ui/Button.mdx
@@ -398,6 +398,7 @@ Button のベーススタイルは、以下のCSSで定義されています。
   --hov-bgc: var(--c);
 }
 .-hov\\:reverse:where(.b--button--fill) {
+  --bdc: var(--bgc);
   --hov-bgc: transparent;
 }
 .-hov\\:reverse:where(.b--button--outline) {
@@ -427,6 +428,7 @@ Button のベーススタイルは、以下のCSSで定義されています。
     --hov-c: var(--bgc);
     --hov-bgc: var(--c);
     &:where(.b--button--fill) {
+      --bdc: var(--bgc);
       --hov-bgc: transparent;
     }
     &:where(.b--button--outline) {

--- a/packages/lism-ui/src/components/Button/_style.css
+++ b/packages/lism-ui/src/components/Button/_style.css
@@ -2,7 +2,8 @@
   .b--button {
     --c: var(--base);
     --bgc: var(--text);
-    --bdc: var(--bgc);
+    /* var(--bgc) にすると -hov:-bgc 等で背景だけ変えた時にボーダーが元の色で縁として残る */
+    --bdc: transparent;
     --bdw: 1px;
     --hl: var(--hl--s);
 


### PR DESCRIPTION
## 概要

`@lism-css/ui`の`Button`で、`fill`（既定）のボーダー色`--bdc`の初期値を`var(--bgc)`から`transparent`へ変更します。

## 背景

- `hov="-bgc"`などで背景色だけを変えると、ボーダーが元の`--bgc`の色のまま残り、ホバー時に1pxの縁が見えていました。回避するには`bdc`も一緒に変える必要がありました。
- `--bdc: var(--bgc)`にしていたのは、docsの`hov="reverse"`（Opt-in例）でホバー時に枠線を残すためでしたが、それはreverse側のCSSで指定すれば足ります。
- `Badge`はすでに`--bdc: transparent`（outlineは`currentColor`）なので、設計が揃います。

## 変更点

- `packages/lism-ui/src/components/Button/_style.css`: `.b--button`の`--bdc`を`transparent`に変更
- `apps/docs`の`ui/Button.mdx`（ja/en）: `hov="reverse"`例の`fill`側に`--bdc: var(--bgc)`を追加し、これまでの見た目を維持
- `apps/docs`の`changelog.mdx`（ja/en）: 未リリース欄に`@lism-css/ui`の項目を追加

## 見た目への影響

- 静的な見た目は変わりません（`background-clip`の既定は`border-box`で、透明ボーダーの下にも背景が塗られるため）。
- `fill`に`hov="-bgc"`を付けた場合、ホバー時の縁が消えます（docsの「`Grid`でアイコンを端に寄せる」例が該当）。
- docsの`hov="reverse"`例をコピーして使っている場合は、`fill`側に`--bdc: var(--bgc)`の追加が必要です。changelogに記載しています。
- リポジトリ内で`fill`に`hov="-bgc"`を付けている箇所はdocsの上記例のみでした。テンプレートの`hov="-bgc"`は`outline`なので影響しません。

## 確認

- `stylelint`（`_style.css`）: OK
- ブラウザでの実機確認は未実施です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fqhuSkYzqk8eR7YrGvX4U


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * `fill` ボタンのデフォルトボーダーを透明に変更し、背景色のみ変更した際に元のボーダー色が残らないようにしました。
  * `hov="reverse"` 使用時は、ボーダー色が背景色に追従するようになりました。
* **ドキュメント**
  * ボーダーを表示したい場合の設定方法を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->